### PR TITLE
Superimpose marshal dir in workspace volume

### DIFF
--- a/kale/core.py
+++ b/kale/core.py
@@ -238,6 +238,7 @@ class Kale:
 
         # generate full kfp pipeline definition
         kfp_code = generate_code.gen_kfp_code(nb_graph=pipeline_graph,
+                                              nb_path=os.path.abspath(self.source_path),
                                               pipeline_parameters=pipeline_parameters,
                                               metadata=self.pipeline_metadata)
 

--- a/kale/templates/function_template.txt
+++ b/kale/templates/function_template.txt
@@ -5,7 +5,7 @@ def {{ function_name }}({{ function_args }}):
     from kale.marshal import resource_save as _kale_resource_save
     from kale.marshal import resource_load as _kale_resource_load
 
-    _kale_data_directory = "/marshal/{{ pipeline_name }}/"
+    _kale_data_directory = os.path.join("{{ marshal_path }}", "{{ pipeline_name }}")
 
 {%- if in_variables|length > 0 %}
     # -----------------------DATA LOADING START--------------------------------

--- a/kale/templates/pipeline_template.txt
+++ b/kale/templates/pipeline_template.txt
@@ -22,14 +22,18 @@ import kfp.dsl as dsl
    description='{{ pipeline_description }}'
 )
 def auto_generated_pipeline({{ pipeline_arguments }}):
+    {% if marshal_volume %}
     marshal_vop = dsl.VolumeOp(
         name="kale_marshal_volume",
         resource_name="kale-marshal-pvc",
         modes=dsl.VOLUME_MODE_RWM,
         size="1Gi"
     )
+    pvolumes_dict = {'{{ marshal_path }}': marshal_vop.volume}
+    {% else %}
+    pvolumes_dict = dict()
+    {% endif %}
 
-    pvolumes_dict = {'/marshal': marshal_vop.volume}
 
     {% for vol in volumes -%}
     {% set name= vol['name'] %}
@@ -108,19 +112,6 @@ def auto_generated_pipeline({{ pipeline_arguments }}):
     {% endif %}
     {% endfor %}
 
-{#    vol_dict = {#}
-{#        "apiVersion": "v1",#}
-{#        "kind": "PersistentVolumeClaim",#}
-{#        "metadata": {#}
-{#            "name": marshal_vop.outputs['name']#}
-{#        }#}
-{#    }#}
-{##}
-{#    delete_vol = dsl.ResourceOp(#}
-{#        name="delete_kale_marshal_volume",#}
-{#        action="delete",#}
-{#        k8s_resource=vol_dict#}
-{#    ).after({{ leaf_steps|join(', ') }})  # Depend on the last executing steps#}
 
 {# The script will deploy the pipeline if run manually #}
 if __name__ == "__main__":


### PR DESCRIPTION
Whenever a volume is detected over the working dir, use that volume to
marshal data between the steps. When there is no workspace volumes
shared between the steps, fallback to creating a ad-hoc volume for
marshal data mounted at `/marshal`.

Signed-off-by: Stefano Fioravanzo <stefano.fioravanzo@gmail.com>
Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>