### PR TITLE
RPC/nb: Remove logger manipulation

### DIFF
--- a/kale/rpc/nb.py
+++ b/kale/rpc/nb.py
@@ -57,14 +57,7 @@ def compile_notebook(request, source_notebook_path,
     instance = Kale(source_notebook_path, notebook_metadata_overrides,
                     debug, auto_snapshot)
     instance.logger = request.log if hasattr(request, "log") else logger
-    stream_handlers = [h for h in instance.logger.handlers
-                       if isinstance(h, logging.StreamHandler)]
-    if debug:
-        log_level = logging.DEBUG
-    else:
-        log_level = logging.INFO
-    for stream_handler in stream_handlers:
-        stream_handler.setLevel(log_level)
+
     pipeline_graph, pipeline_parameters = instance.notebook_to_graph()
     script_path = instance.generate_kfp_executable(pipeline_graph,
                                                    pipeline_parameters)


### PR DESCRIPTION
We use a logger adapter with logging level set to DEBUG.
Logger adapters don't have handlers, so these lines were producing
errors.
Also we don't need to change logging level, since the exceptions and
errors where introduced in backend and frontend. The log file contains
everything while UI dialogs show a minimal error message.