### PR TITLE
RPC/nb: Remove request argument from unmarshal_data

### DIFF
--- a/kale/rpc/nb.py
+++ b/kale/rpc/nb.py
@@ -76,7 +76,7 @@ def _get_kale_marshal_dir(source_notebook_path):
     return os.path.realpath(os.path.join(nb_dir_name, kale_marshal_dir_name))
 
 
-def unmarshal_data(request, source_notebook_path):
+def unmarshal_data(source_notebook_path):
     kale_marshal_dir = _get_kale_marshal_dir(source_notebook_path)
     if not os.path.exists(kale_marshal_dir):
         return {}


### PR DESCRIPTION
This RPC is called directly, that is, without being wrapped by the run()
function, because it needs to run in the same kernel with the open
notebook. Therefore, there isn't a request object to pass.

If we want to log something inside this RPC in the future, then we
should reconsider its arguments.

Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>