### PR TITLE
Codegen refactoring and tests

### DIFF
--- a/kale/codegen/generate_code.py
+++ b/kale/codegen/generate_code.py
@@ -3,8 +3,19 @@ import autopep8
 
 import networkx as nx
 
-from jinja2 import Environment, PackageLoader
+from jinja2 import Environment, PackageLoader, FileSystemLoader
 from kale.utils.pod_utils import is_workspace_dir
+
+
+def _initialize_templating_env(templates_path=None):
+    if templates_path:
+        loader = FileSystemLoader(templates_path)
+    else:
+        loader = PackageLoader('kale', 'templates')
+    template_env = Environment(loader=loader)
+    # add custom filters
+    template_env.filters['add_suffix'] = lambda s, suffix: s + suffix
+    return template_env
 
 
 def convert_volume_annotations(volumes):
@@ -194,8 +205,7 @@ def gen_kfp_code(nb_graph, nb_path, pipeline_parameters, metadata,
     Returns (str): A Python executable script
     """
     # initialize templating environment
-    template_env = Environment(loader=PackageLoader('kale', 'templates'))
-    template_env.filters['add_suffix'] = lambda s, suffix: s + suffix
+    template_env = _initialize_templating_env()
 
     # Convert volume annotations to a dictionary
     volumes, volume_parameters = convert_volume_annotations(

--- a/kale/codegen/generate_code.py
+++ b/kale/codegen/generate_code.py
@@ -130,9 +130,9 @@ def pipeline_dependencies_tasks(g):
 def generate_lightweight_component(template, step_name, step_data, nb_path,
                                    metadata):
     """Use the function template to generate Python code."""
-    step_source = step_data['source']
-    step_marshal_in = step_data['ins']
-    step_marshal_out = step_data['outs']
+    step_source = step_data.get('source', [])
+    step_marshal_in = step_data.get('ins', [])
+    step_marshal_out = step_data.get('outs', [])
 
     # TODO: Remove some parameters and pass them with **metadata
     fn_code = template.render(

--- a/kale/codegen/generate_code.py
+++ b/kale/codegen/generate_code.py
@@ -140,7 +140,7 @@ def generate_lightweight_component(template, step_name, pipeline_name,
     """Use the function template to generate Python code."""
     step_source = step_data['source']
     step_marshal_in = step_data['ins']
-    step_marshal_out = step_data['out']
+    step_marshal_out = step_data['outs']
 
     # TODO: Remove some parameters and pass them with **metadata
     return template.render(
@@ -184,12 +184,10 @@ def generate_pipeline(template, nb_graph, step_names, lightweight_functions,
     return pipeline_code
 
 
-def gen_kfp_code(nb_graph,
-                 nb_path,
-                 pipeline_parameters,
-                 metadata,
+def gen_kfp_code(nb_graph, nb_path, pipeline_parameters, metadata,
                  auto_snapshot):
-    """
+    """Generate a Python KFP DSL executable starting from the nx graph.
+
     Takes a NetworkX workflow graph with the following properties
 
     - node property 'code' contains the source code
@@ -198,6 +196,16 @@ def gen_kfp_code(nb_graph,
 
     and generated a standalone Python script in KFP DSL to deploy
     a KFP pipeline.
+
+    Args:
+        nb_graph (nx.DiGraph): Pipeline graph
+        nb_path (str): path to the notebook
+        pipeline_parameters (dict): pipeline parameters
+        metadata (dict): metadata to be passed to the Jinja templates
+        auto_snapshot (bool): True if pipeline runs auto snapshot at each
+            pipeline step
+
+    Returns (str): A Python executable script
     """
     # initialize templating environment
     template_env = Environment(loader=PackageLoader('kale', 'templates'))

--- a/kale/codegen/generate_code.py
+++ b/kale/codegen/generate_code.py
@@ -122,8 +122,8 @@ def pipeline_dependencies_tasks(g):
     """
     deps = dict()
     for step_name in nx.topological_sort(g):
-        deps[step_name] = [f"{pred}_task" for pred in
-                           g.predecessors(step_name)]
+        deps[step_name] = [f"{pred}_task"
+                           for pred in g.predecessors(step_name)]
     return deps
 
 

--- a/kale/codegen/generate_code.py
+++ b/kale/codegen/generate_code.py
@@ -209,30 +209,11 @@ def gen_kfp_code(nb_graph,
 
     leaf_nodes = [x for x in nb_graph.nodes() if nb_graph.out_degree(x) == 0]
 
-    function_prevs = pipeline_dependencies_tasks(nb_graph)
-
-    if auto_snapshot:
-        final_auto_snapshot_name = 'final_auto_snapshot'
-        function_blocks.append(function_template.render(
-            pipeline_name=metadata['pipeline_name'],
-            function_name=final_auto_snapshot_name,
-            function_args=generated_args['function_args'],
-            function_blocks=[],
-            in_variables=set(),
-            out_variables=set(),
-            marshal_path=marshal_dict['marshal_path'],
-            auto_snapshot=auto_snapshot,
-            nb_path=nb_path
-        ))
-        function_names.append(final_auto_snapshot_name)
-        function_prevs[final_auto_snapshot_name] = [f"{x}_task"
-                                                    for x in leaf_nodes]
-
     pipeline_template = template_env.get_template('pipeline_template.txt')
     pipeline_code = pipeline_template.render(
         block_functions=function_blocks,
         block_functions_names=function_names,
-        block_function_prevs=function_prevs,
+        block_function_prevs=pipeline_dependencies_tasks(nb_graph),
         experiment_name=metadata['experiment_name'],
         pipeline_name=metadata['pipeline_name'],
         pipeline_description=metadata.get('pipeline_description', ''),

--- a/kale/codegen/generate_code.py
+++ b/kale/codegen/generate_code.py
@@ -135,7 +135,7 @@ def generate_lightweight_component(template, step_name, step_data, nb_path,
     step_marshal_out = step_data['outs']
 
     # TODO: Remove some parameters and pass them with **metadata
-    return template.render(
+    fn_code = template.render(
         step_name=step_name,
         function_body=[step_source],
         in_variables=step_marshal_in,
@@ -143,11 +143,13 @@ def generate_lightweight_component(template, step_name, step_data, nb_path,
         nb_path=nb_path,
         **metadata
     )
+    # fix code style using pep8 guidelines
+    return autopep8.fix_code(fn_code)
 
 
 def generate_pipeline(template, nb_graph, step_names, lightweight_components,
                       metadata):
-    """Use the pipeline template to generate Python code"""
+    """Use the pipeline template to generate Python code."""
     # All the Pipeline steps that do not have children
     leaf_steps = [x for x in nb_graph.nodes() if
                   nb_graph.out_degree(x) == 0]
@@ -160,7 +162,8 @@ def generate_pipeline(template, nb_graph, step_names, lightweight_components,
         leaf_steps=leaf_steps,
         **metadata
     )
-    return pipeline_code
+    # fix code style using pep8 guidelines
+    return autopep8.fix_code(pipeline_code)
 
 
 def gen_kfp_code(nb_graph, nb_path, pipeline_parameters, metadata,
@@ -217,6 +220,4 @@ def gen_kfp_code(nb_graph, nb_path, pipeline_parameters, metadata,
     pipeline_template = template_env.get_template('pipeline_template.jinja2')
     pipeline_code = generate_pipeline(pipeline_template, nb_graph, step_names,
                                       lightweight_components, metadata)
-    # fix code style using pep8 guidelines
-    pipeline_code = autopep8.fix_code(pipeline_code)
     return pipeline_code

--- a/kale/codegen/generate_code.py
+++ b/kale/codegen/generate_code.py
@@ -134,7 +134,6 @@ def generate_lightweight_component(template, step_name, step_data, nb_path,
     step_marshal_in = step_data.get('ins', [])
     step_marshal_out = step_data.get('outs', [])
 
-    # TODO: Remove some parameters and pass them with **metadata
     fn_code = template.render(
         step_name=step_name,
         function_body=[step_source],
@@ -151,10 +150,9 @@ def generate_pipeline(template, nb_graph, step_names, lightweight_components,
                       metadata):
     """Use the pipeline template to generate Python code."""
     # All the Pipeline steps that do not have children
-    leaf_steps = [x for x in nb_graph.nodes() if
-                  nb_graph.out_degree(x) == 0]
+    leaf_steps = [x for x in nb_graph.nodes()
+                  if nb_graph.out_degree(x) == 0]
 
-    # TODO: Pass arguments as **metadata.
     pipeline_code = template.render(
         lightweight_components=lightweight_components,
         step_names=step_names,

--- a/kale/command_line.py
+++ b/kale/command_line.py
@@ -68,7 +68,8 @@ def main():
                parser._action_groups))
     # get the single args of that group
     mt_overrides_group_dict = {a.dest: getattr(args, a.dest, None)
-                               for a in mt_overrides_group._group_actions}
+                               for a in mt_overrides_group._group_actions
+                               if getattr(args, a.dest, None) is not None}
 
     kale = Kale(
         source_notebook_path=args.nb,

--- a/kale/command_line.py
+++ b/kale/command_line.py
@@ -6,7 +6,6 @@ from argparse import RawTextHelpFormatter
 from kale.core import Kale
 from kale.utils import kfp_utils
 
-
 ARGS_DESC = """
 KALE: Kubeflow Automated pipeLines Engine\n
 \n
@@ -27,42 +26,62 @@ will take precedence.\n
 """
 
 METADATA_GROUP_DESC = """
-Override the arguments provided in the Kale metadata section of the source Notebook
+Override the arguments of the source Notebook's Kale metadata section
 """
 
 
 def main():
-    parser = argparse.ArgumentParser(description=ARGS_DESC, formatter_class=RawTextHelpFormatter)
+    parser = argparse.ArgumentParser(description=ARGS_DESC,
+                                     formatter_class=RawTextHelpFormatter)
     general_group = parser.add_argument_group('General')
-    general_group.add_argument('--nb', type=str, help='Path to source JupyterNotebook', required=True)
-    # use store_const instead of store_true because we None instead of False in case the flag is missing
-    general_group.add_argument('--upload_pipeline', action='store_const', const=True)
-    general_group.add_argument('--run_pipeline', action='store_const', const=True)
+    general_group.add_argument('--nb', type=str,
+                               help='Path to source JupyterNotebook',
+                               required=True)
+    # use store_const instead of store_true because we None instead of
+    # False in case the flag is missing
+    general_group.add_argument('--upload_pipeline', action='store_const',
+                               const=True)
+    general_group.add_argument('--run_pipeline', action='store_const',
+                               const=True)
     general_group.add_argument('--debug', action='store_true')
 
-    metadata_group = parser.add_argument_group('Notebook Metadata Overrides', METADATA_GROUP_DESC)
-    metadata_group.add_argument('--experiment_name', type=str, help='Name of the created experiment')
-    metadata_group.add_argument('--pipeline_name', type=str, help='Name of the deployed pipeline')
-    metadata_group.add_argument('--pipeline_description', type=str, help='Description of the deployed pipeline')
-    metadata_group.add_argument('--docker_image', type=str, help='Docker base image used to build the pipeline steps')
-    metadata_group.add_argument('--kfp_host', type=str, help='KFP endpoint. Provide address as <host>:<port>.')
+    metadata_group = parser.add_argument_group('Notebook Metadata Overrides',
+                                               METADATA_GROUP_DESC)
+    metadata_group.add_argument('--experiment_name', type=str,
+                                help='Name of the created experiment')
+    metadata_group.add_argument('--pipeline_name', type=str,
+                                help='Name of the deployed pipeline')
+    metadata_group.add_argument('--pipeline_description', type=str,
+                                help='Description of the deployed pipeline')
+    metadata_group.add_argument('--docker_image', type=str,
+                                help='Docker base image used to build the '
+                                     'pipeline steps')
+    metadata_group.add_argument('--kfp_host', type=str,
+                                help='KFP endpoint. Provide address as '
+                                     '<host>:<port>.')
 
     args = parser.parse_args()
 
     # get the notebook metadata args group
-    metadata_overrides_group = next(filter(lambda x: x.title == 'Notebook Metadata Overrides', parser._action_groups))
+    mt_overrides_group = next(
+        filter(lambda x: x.title == 'Notebook Metadata Overrides',
+               parser._action_groups))
     # get the single args of that group
-    metadata_overrides_group_dict = {a.dest: getattr(args, a.dest, None) for a in metadata_overrides_group._group_actions}
+    mt_overrides_group_dict = {a.dest: getattr(args, a.dest, None)
+                               for a in mt_overrides_group._group_actions}
 
     kale = Kale(
         source_notebook_path=args.nb,
-        notebook_metadata_overrides=metadata_overrides_group_dict,
+        notebook_metadata_overrides=mt_overrides_group_dict,
         debug=args.debug
     )
     pipeline_graph, pipeline_parameters = kale.notebook_to_graph()
-    script_path = kale.generate_kfp_executable(pipeline_graph, pipeline_parameters)
+    script_path = kale.generate_kfp_executable(pipeline_graph,
+                                               pipeline_parameters)
     # compile the pipeline to kfp tar package
-    pipeline_package_path = kfp_utils.compile_pipeline(script_path, kale.pipeline_metadata['pipeline_name'])
+    pipeline_name = kale.pipeline_metadata['pipeline_name']
+    pipeline_package_path = kfp_utils.compile_pipeline(script_path,
+                                                       pipeline_name)
 
     if args.upload_pipeline:
         kfp_utils.upload_pipeline(

--- a/kale/core.py
+++ b/kale/core.py
@@ -274,10 +274,15 @@ class Kale:
 
         # add an empty step at the end of the pipeline for final snapshot
         if self.auto_snapshot:
-            pipeline_graph.add_node('final_auto_snapshot',
-                                    source='',
-                                    ins=set(),
-                                    outs=set())
+            auto_snapshot_name = 'final_auto_snapshot'
+            # add a link from all the last steps of the pipeline to
+            # the final auto snapshot one.
+            leaf_steps = [x for x in pipeline_graph.nodes() if
+                          pipeline_graph.out_degree(x) == 0]
+            for node in leaf_steps:
+                pipeline_graph.add_edge(node, auto_snapshot_name)
+            data = {auto_snapshot_name: {'source': '', 'ins': [], 'outs': []}}
+            nx.set_node_attributes(pipeline_graph, data)
 
         # TODO: Additional Step required:
         #  Run a static analysis over every step to check that pipeline

--- a/kale/core.py
+++ b/kale/core.py
@@ -277,8 +277,8 @@ class Kale:
             auto_snapshot_name = 'final_auto_snapshot'
             # add a link from all the last steps of the pipeline to
             # the final auto snapshot one.
-            leaf_steps = [x for x in pipeline_graph.nodes() if
-                          pipeline_graph.out_degree(x) == 0]
+            leaf_steps = [x for x in pipeline_graph.nodes()
+                          if pipeline_graph.out_degree(x) == 0]
             for node in leaf_steps:
                 pipeline_graph.add_edge(node, auto_snapshot_name)
             data = {auto_snapshot_name: {'source': '', 'ins': [], 'outs': []}}

--- a/kale/core.py
+++ b/kale/core.py
@@ -243,6 +243,13 @@ class Kale:
         dependencies.dependencies_detection(pipeline_graph,
                                             ignore_symbols=to_ignore)
 
+        # add an empty step at the end of the pipeline for final snapshot
+        if self.auto_snapshot:
+            pipeline_graph.add_node('final_auto_snapshot',
+                                    source='',
+                                    ins=set(),
+                                    outs=set())
+
         # TODO: Additional Step required:
         #  Run a static analysis over every step to check that pipeline
         #  parameters are not assigned with new values.

--- a/kale/core.py
+++ b/kale/core.py
@@ -77,10 +77,7 @@ class Kale:
             self.notebook.metadata.get(KALE_NOTEBOOK_METADATA_KEY, dict()))
         # override notebook metadata with provided arguments
         if notebook_metadata_overrides:
-            self.pipeline_metadata = {**self.pipeline_metadata,
-                                      **{k: v for k, v in
-                                         notebook_metadata_overrides.items()
-                                         if v}}
+            self.pipeline_metadata.update(notebook_metadata_overrides)
 
         pipeline_name = "%s-%s" % (self.pipeline_metadata['pipeline_name'],
                                    random_string())

--- a/kale/core.py
+++ b/kale/core.py
@@ -71,7 +71,7 @@ class Kale:
         self.notebook = nb.read(self.source_path.__str__(),
                                 as_version=nb.NO_CONVERT)
 
-        self.pipeline_metadata = DEFAULT_METADATA.copy()
+        self.pipeline_metadata = copy.deepcopy(DEFAULT_METADATA)
         # read Kale notebook metadata.
         # In case it is not specified get an empty dict
         self.pipeline_metadata.update(
@@ -155,8 +155,8 @@ class Kale:
                         k8s_name_msg)
 
                 # Convert annotations to a dictionary
-                annotations = {a['key']: a['value'] for a in
-                               v['annotations'] or []
+                annotations = {a['key']: a['value']
+                               for a in v['annotations'] or []
                                if a['key'] != '' and a['value'] != ''}
                 v['annotations'] = annotations
                 v['size'] = str(v['size'])
@@ -167,7 +167,7 @@ class Kale:
             volumes = sorted(
                 volumes,
                 reverse=True,
-                key=lambda _v: is_workspace_dir(_v['mount_point']))
+                key=lambda x: is_workspace_dir(x['mount_point']))
             self.pipeline_metadata['volumes'] = volumes
         else:
             raise ValueError("Volumes must be a valid list of volumes spec")

--- a/kale/core.py
+++ b/kale/core.py
@@ -35,6 +35,20 @@ METADATA_REQUIRED_KEYS = [
     'pipeline_name',
 ]
 
+DEFAULT_METADATA = {
+    'experiment_name': '',
+    'pipeline_name': '',
+    'pipeline_description': '',
+    'pipeline_args': '',
+    'pipeline_args_names': '',
+    'docker_image': '',
+    'volumes': [],
+    'abs_working_dir': None,
+    'marshal_volume': False,
+    'marshal_path': '',
+    'auto_snapshot': False
+}
+
 
 def random_string(size=5, chars=string.ascii_lowercase + string.digits):
     """Generate random string."""
@@ -56,10 +70,11 @@ class Kale:
         self.notebook = nb.read(self.source_path.__str__(),
                                 as_version=nb.NO_CONVERT)
 
+        self.pipeline_metadata = DEFAULT_METADATA.copy()
         # read Kale notebook metadata.
         # In case it is not specified get an empty dict
-        self.pipeline_metadata = self.notebook.metadata.get(
-            KALE_NOTEBOOK_METADATA_KEY, dict())
+        self.pipeline_metadata.update(
+            self.notebook.metadata.get(KALE_NOTEBOOK_METADATA_KEY, dict()))
         # override notebook metadata with provided arguments
         if notebook_metadata_overrides:
             self.pipeline_metadata = {**self.pipeline_metadata,

--- a/kale/templates/function_template.jinja2
+++ b/kale/templates/function_template.jinja2
@@ -1,5 +1,4 @@
 def {{ step_name }}({{ function_args }}):
-
     import os
     import shutil
     from kale.utils import pod_utils as _kale_pod_utils
@@ -12,12 +11,13 @@ def {{ step_name }}({{ function_args }}):
         os.makedirs(_kale_data_directory, exist_ok=True)
 
     {% if auto_snapshot -%}
-    _kale_pod_utils.snapshot_pipeline_step("{{ pipeline_name }}",
-                                     "{{ step_name }}",
-                                     "{{ nb_path }}")
+    _kale_pod_utils.snapshot_pipeline_step(
+        "{{ pipeline_name }}",
+        "{{ step_name }}",
+        "{{ nb_path }}")
     {% endif -%}
 
-{%- if in_variables|length > 0 %}
+{%- if in_variables|length > 0 -%}
     # -----------------------DATA LOADING START--------------------------------
     _kale_directory_file_names = [
         os.path.splitext(f)[0]
@@ -25,7 +25,7 @@ def {{ step_name }}({{ function_args }}):
         if os.path.isfile(os.path.join(_kale_data_directory, f))
     ]
 
-{%- for in_var in in_variables %}
+{%- for in_var in in_variables -%}
     {#- First check that the variable exists in the path #}
     if "{{ in_var }}" not in _kale_directory_file_names:
         raise ValueError("{{ in_var }}" + " does not exists in directory")
@@ -34,25 +34,28 @@ def {{ step_name }}({{ function_args }}):
     _kale_load_file_name = [
         f
         for f in os.listdir(_kale_data_directory)
-        if os.path.isfile(os.path.join(_kale_data_directory, f)) and
-           os.path.splitext(f)[0] == "{{ in_var }}"
+        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
+            os.path.splitext(f)[0] == "{{ in_var }}")
     ]
     if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name " + "{{ in_var }}" + ": " + str(_kale_load_file_name))
+        raise ValueError("Found multiple files with name %s: %s"
+                         % ("{{ in_var }}", str(_kale_load_file_name)))
     _kale_load_file_name = _kale_load_file_name[0]
-    {{ in_var }} = _kale_resource_load(os.path.join(_kale_data_directory, _kale_load_file_name))
+    {{ in_var }} = _kale_resource_load(
+        os.path.join(_kale_data_directory, _kale_load_file_name))
 {%- endfor %}
     # -----------------------DATA LOADING END----------------------------------
-{%- endif %}
+{%- endif -%}
 {%- for block in function_body %}
 {{block|indent(4, True)}}
 {%- endfor %}
-{%- if out_variables|length > 0 %}
+{% if out_variables|length > 0 %}
     # -----------------------DATA SAVING START---------------------------------
 {%- for out_var in out_variables %}
     if "{{ out_var }}" in locals():
         {#-  `_kale_resource_save` will automatically add the correct extension #}
-        _kale_resource_save({{ out_var }}, os.path.join(_kale_data_directory, "{{ out_var }}"))
+        _kale_resource_save(
+            {{ out_var }}, os.path.join(_kale_data_directory, "{{ out_var }}"))
     else:
         print("_kale_resource_save: `{{ out_var }}` not found.")
 {%- endfor %}

--- a/kale/templates/function_template.jinja2
+++ b/kale/templates/function_template.jinja2
@@ -7,7 +7,7 @@ def {{ step_name }}({{ function_args }}):
     from kale.marshal import resource_load as _kale_resource_load
 
     _kale_data_directory = "{{ marshal_path }}"
-    {# Verify directory exists #}
+    {#- Verify directory exists #}
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
 
@@ -26,11 +26,11 @@ def {{ step_name }}({{ function_args }}):
     ]
 
 {%- for in_var in in_variables %}
-    {# First check that the variable exists in the path #}
+    {#- First check that the variable exists in the path #}
     if "{{ in_var }}" not in _kale_directory_file_names:
         raise ValueError("{{ in_var }}" + " does not exists in directory")
 
-    {# Load variable -#}
+    {#- Load variable #}
     _kale_load_file_name = [
         f
         for f in os.listdir(_kale_data_directory)
@@ -44,11 +44,9 @@ def {{ step_name }}({{ function_args }}):
 {%- endfor %}
     # -----------------------DATA LOADING END----------------------------------
 {%- endif %}
-
-
-{% for block in function_body %}
+{%- for block in function_body %}
 {{block|indent(4, True)}}
-{% endfor %}
+{%- endfor %}
 {%- if out_variables|length > 0 %}
     # -----------------------DATA SAVING START---------------------------------
 {%- for out_var in out_variables %}

--- a/kale/templates/function_template.jinja2
+++ b/kale/templates/function_template.jinja2
@@ -1,4 +1,4 @@
-def {{ function_name }}({{ function_args }}):
+def {{ step_name }}({{ function_args }}):
 
     import os
     import shutil
@@ -13,7 +13,7 @@ def {{ function_name }}({{ function_args }}):
 
     {% if auto_snapshot -%}
     _kale_pod_utils.snapshot_pipeline_step("{{ pipeline_name }}",
-                                     "{{ function_name }}",
+                                     "{{ step_name }}",
                                      "{{ nb_path }}")
     {% endif -%}
 
@@ -46,7 +46,7 @@ def {{ function_name }}({{ function_args }}):
 {%- endif %}
 
 
-{% for block in function_blocks %}
+{% for block in function_body %}
 {{block|indent(4, True)}}
 {% endfor %}
 {%- if out_variables|length > 0 %}

--- a/kale/templates/function_template.txt
+++ b/kale/templates/function_template.txt
@@ -2,7 +2,7 @@ def {{ function_name }}({{ function_args }}):
 
     import os
     import shutil
-    from kale.utils import pod_utils
+    from kale.utils import pod_utils as _kale_pod_utils
     from kale.marshal import resource_save as _kale_resource_save
     from kale.marshal import resource_load as _kale_resource_load
 
@@ -12,7 +12,7 @@ def {{ function_name }}({{ function_args }}):
         os.makedirs(_kale_data_directory, exist_ok=True)
 
     {% if auto_snapshot -%}
-    pod_utils.snapshot_pipeline_step("{{ pipeline_name }}",
+    _kale_pod_utils.snapshot_pipeline_step("{{ pipeline_name }}",
                                      "{{ function_name }}",
                                      "{{ nb_path }}")
     {% endif -%}

--- a/kale/templates/pipeline_template.jinja2
+++ b/kale/templates/pipeline_template.jinja2
@@ -2,15 +2,15 @@ import kfp.components as comp
 from collections import OrderedDict
 from kubernetes import client as k8s_client
 
-{# PIPELINE FUNCTION BLOCKS #}
-{% for func in block_functions -%}
+{# PIPELINE LIGHTWEIGHT COMPONENTS #}
+{% for func in lightweight_components -%}
 {{func}}
 {% endfor -%}
 
 {# DEFINE PIPELINE TASKS FROM FUNCTIONS #}
-{%- for name in block_functions_names -%}
-{% if docker_base_image != '' %}
-{{ name }}_op = comp.func_to_container_op({{ name }}, base_image='{{ docker_base_image }}')
+{%- for name in step_names -%}
+{% if docker_image != '' %}
+{{ name }}_op = comp.func_to_container_op({{ name }}, base_image='{{ docker_image }}')
 {% else %}
 {{ name }}_op = comp.func_to_container_op({{ name }})
 {% endif %}
@@ -22,7 +22,7 @@ import kfp.dsl as dsl
    name='{{ pipeline_name }}',
    description='{{ pipeline_description }}'
 )
-def auto_generated_pipeline({{ pipeline_arguments }}):
+def auto_generated_pipeline({{ pipeline_args }}):
     pvolumes_dict = OrderedDict()
 
     {% for vol in volumes -%}
@@ -91,12 +91,12 @@ def auto_generated_pipeline({{ pipeline_arguments }}):
     pvolumes_dict['{{ marshal_path }}'] = marshal_vop.volume
     {% endif %}
 
-    {% for name in block_functions_names %}
+    {% for name in step_names %}
 
-    {{ name }}_task = {{ name }}_op({{ pipeline_arguments_names }})\
+    {{ name }}_task = {{ name }}_op({{ pipeline_args_names }})\
                             .add_pvolumes(pvolumes_dict)\
-                            .after({{ block_function_prevs[ name ]|join(', ') }})
-    {{ name }}_task.container.working_dir = "{{ working_dir }}"
+                            .after({{ step_prevs[ name ]|join(', ') }})
+    {{ name }}_task.container.working_dir = "{{ abs_working_dir }}"
     {{ name }}_task.container.set_security_context(k8s_client.V1SecurityContext(run_as_user=0))
     {% if auto_snapshot -%}
     mlpipeline_ui_metadata = {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'}
@@ -111,7 +111,7 @@ def auto_generated_pipeline({{ pipeline_arguments }}):
     snapshot{{ loop.index }} = dsl.VolumeSnapshotOp(
         name='snapshot-volume-{{ loop.index }}',
         resource_name='{{ vol['snapshot_name'] }}',
-        volume=vop{{ loop.index }}.volume.after({{ leaf_nodes| map('add_suffix', '_task') | join(', ') }})
+        volume=vop{{ loop.index }}.volume.after({{ leaf_steps| map('add_suffix', '_task') | join(', ') }})
     )
     {% endif %}
     {% endfor %}

--- a/kale/tests/assets/func01.out.py
+++ b/kale/tests/assets/func01.out.py
@@ -1,0 +1,10 @@
+def test():
+    import os
+    import shutil
+    from kale.utils import pod_utils as _kale_pod_utils
+    from kale.marshal import resource_save as _kale_resource_save
+    from kale.marshal import resource_load as _kale_resource_load
+
+    _kale_data_directory = ""
+    if not os.path.isdir(_kale_data_directory):
+        os.makedirs(_kale_data_directory, exist_ok=True)

--- a/kale/tests/assets/func02.out.py
+++ b/kale/tests/assets/func02.out.py
@@ -1,0 +1,10 @@
+def test(arg1, arg2, arg3):
+    import os
+    import shutil
+    from kale.utils import pod_utils as _kale_pod_utils
+    from kale.marshal import resource_save as _kale_resource_save
+    from kale.marshal import resource_load as _kale_resource_load
+
+    _kale_data_directory = ""
+    if not os.path.isdir(_kale_data_directory):
+        os.makedirs(_kale_data_directory, exist_ok=True)

--- a/kale/tests/assets/func03.out.py
+++ b/kale/tests/assets/func03.out.py
@@ -1,0 +1,15 @@
+def test():
+    import os
+    import shutil
+    from kale.utils import pod_utils as _kale_pod_utils
+    from kale.marshal import resource_save as _kale_resource_save
+    from kale.marshal import resource_load as _kale_resource_load
+
+    _kale_data_directory = "/path"
+    if not os.path.isdir(_kale_data_directory):
+        os.makedirs(_kale_data_directory, exist_ok=True)
+
+    _kale_pod_utils.snapshot_pipeline_step(
+        "T",
+        "test",
+        "/path/to/nb")

--- a/kale/tests/assets/func04.out.py
+++ b/kale/tests/assets/func04.out.py
@@ -1,0 +1,32 @@
+def test():
+    import os
+    import shutil
+    from kale.utils import pod_utils as _kale_pod_utils
+    from kale.marshal import resource_save as _kale_resource_save
+    from kale.marshal import resource_load as _kale_resource_load
+
+    _kale_data_directory = ""
+    if not os.path.isdir(_kale_data_directory):
+        os.makedirs(_kale_data_directory, exist_ok=True)
+
+    # -----------------------DATA LOADING START--------------------------------
+    _kale_directory_file_names = [
+        os.path.splitext(f)[0]
+        for f in os.listdir(_kale_data_directory)
+        if os.path.isfile(os.path.join(_kale_data_directory, f))
+    ]
+    if "v1" not in _kale_directory_file_names:
+        raise ValueError("v1" + " does not exists in directory")
+    _kale_load_file_name = [
+        f
+        for f in os.listdir(_kale_data_directory)
+        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
+            os.path.splitext(f)[0] == "v1")
+    ]
+    if len(_kale_load_file_name) > 1:
+        raise ValueError("Found multiple files with name %s: %s"
+                         % ("v1", str(_kale_load_file_name)))
+    _kale_load_file_name = _kale_load_file_name[0]
+    v1 = _kale_resource_load(
+        os.path.join(_kale_data_directory, _kale_load_file_name))
+    # -----------------------DATA LOADING END----------------------------------

--- a/kale/tests/assets/func05.out.py
+++ b/kale/tests/assets/func05.out.py
@@ -1,0 +1,21 @@
+def test():
+    import os
+    import shutil
+    from kale.utils import pod_utils as _kale_pod_utils
+    from kale.marshal import resource_save as _kale_resource_save
+    from kale.marshal import resource_load as _kale_resource_load
+
+    _kale_data_directory = ""
+    if not os.path.isdir(_kale_data_directory):
+        os.makedirs(_kale_data_directory, exist_ok=True)
+
+    v1 = "Hello"
+    print(v1)
+
+    # -----------------------DATA SAVING START---------------------------------
+    if "v1" in locals():
+        _kale_resource_save(
+            v1, os.path.join(_kale_data_directory, "v1"))
+    else:
+        print("_kale_resource_save: `v1` not found.")
+    # -----------------------DATA SAVING END-----------------------------------

--- a/kale/tests/assets/func06.out.py
+++ b/kale/tests/assets/func06.out.py
@@ -1,0 +1,12 @@
+def test():
+    import os
+    import shutil
+    from kale.utils import pod_utils as _kale_pod_utils
+    from kale.marshal import resource_save as _kale_resource_save
+    from kale.marshal import resource_load as _kale_resource_load
+
+    _kale_data_directory = ""
+    if not os.path.isdir(_kale_data_directory):
+        os.makedirs(_kale_data_directory, exist_ok=True)
+
+    print("hello")

--- a/kale/tests/unit_tests/test_generate_code.py
+++ b/kale/tests/unit_tests/test_generate_code.py
@@ -1,0 +1,155 @@
+import os
+import pytest
+
+from kale.codegen import generate_code
+
+THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+@pytest.mark.parametrize("volumes,target", [
+    ([], ({})),
+    # ---
+    ([{
+        'annotations': [{'key': 'a1', 'value': 'v1'}],
+        'size': 5,
+        'type': 'pv',
+        'mount_point': '/'
+    }],
+     ({})),
+    # ---
+    ([{
+        'name': 'test_volume',
+        'type': 'pvc',
+        'mount_point': '/'
+    }],
+     {'vol_': ('str', 'test_volume')}),
+    # ---
+    ([{
+        'name': 'test_volume',
+        'type': 'pvc',
+        'mount_point': '/root'
+    }],
+     {'vol_root': ('str', 'test_volume')}),
+    # ---
+    ([{
+        'name': 'test_volume',
+        'type': 'pvc',
+        'mount_point': '/root/user/'
+    }],
+     {'vol_root_user': ('str', 'test_volume')}),
+    # ---
+    ([{
+        'name': 'test_volume',
+        'type': 'new_pvc',
+        'mount_point': '/',
+        'annotations': {}
+    }],
+     {}),
+    # ---
+    ([{
+        'name': 'test-volume',
+        'type': 'new_pvc',
+        'mount_point': '/root',
+        'annotations': {'rok/origin': 'url'}
+    }],
+     {'rok_test_volume_url': ('str', 'url')}),
+])
+def test_get_volumes_parameters(volumes, target):
+    """Tests that volumes are correctly converted from list into dict."""
+    assert target == generate_code.get_volume_parameters(volumes)
+
+
+@pytest.mark.parametrize("volumes", [
+    ([{
+        'annotations': [{'key': 'a1', 'value': 'v1'}],
+        'size': 5,
+        'type': 'unknown'
+    }])
+])
+def test_get_volumes_parameters_exc(volumes):
+    """Tests that volumes are correctly converted from list into dict."""
+    with pytest.raises(ValueError, match="Unknown volume type: unknown"):
+        generate_code.get_volume_parameters(volumes)
+
+
+@pytest.mark.parametrize("args,target", [
+    ((None, None, None),
+     {'marshal_volume': True, 'marshal_path': '/marshal'}),
+    # ---
+    (('/users', [{'mount_point': '/root'}], None),
+     {'marshal_volume': True, 'marshal_path': '/marshal'}),
+    # ---
+    (('/user/kale/test', [{'mount_point': '/user/kale'}],
+      '/user/kale/test/mynb.ipynb'),
+     {'marshal_volume': False,
+      'marshal_path': '/user/kale/test/.mynb.ipynb.kale.marshal.dir'}),
+    # ---
+    (('/user/kale/', [{'mount_point': '/user/kale/test'}], None),
+     {'marshal_volume': True, 'marshal_path': '/marshal'}),
+])
+def test_get_marshal_data(args, target):
+    """Test that marshal volume path is correctly computed."""
+    assert target == generate_code.get_marshal_data(*args)
+
+
+def _test_args_dict(f1, f2, f3):
+    return {
+        'pipeline_args_names': f1,
+        'pipeline_args': f2,
+        'function_args': f3
+    }
+
+
+@pytest.mark.parametrize("pipeline_parameters,target", [
+    ({},
+     _test_args_dict('', '', '')),
+    # ---
+    ({'param1': ('str', 'v1')},
+     _test_args_dict('param1', "param1='v1'", 'param1: str')),
+    # ---
+    ({'param1': ('int', 1)},
+     _test_args_dict('param1', "param1='1'", 'param1: int')),
+    # ---
+    ({'p1': ('int', 1), 'p2': ('str', 'v')},
+     _test_args_dict('p1, p2', "p1='1', p2='v'", 'p1: int, p2: str')),
+])
+def test_get_args(pipeline_parameters, target):
+    """Test that argument string are properly formatted"""
+    assert target == generate_code.get_args(pipeline_parameters)
+
+
+@pytest.fixture(scope='module')
+def template():
+    """Reusable function template"""
+    tmpl_dir = os.path.join(THIS_DIR, '../../templates')
+    env = generate_code._initialize_templating_env(tmpl_dir)
+    return env.get_template('function_template.jinja2')
+
+
+@pytest.mark.parametrize('step_name,source,ins,outs,nb_path,metadata,target', [
+    ('test', '', '', '', '', {}, 'func01.out.py'),
+    # ---
+    ('test', '', '', '', '', {'function_args': 'arg1, arg2, arg3'},
+     'func02.out.py'),
+    # ---
+    ('test', '', '', '', '/path/to/nb',
+     {'marshal_path': '/path', 'auto_snapshot': True, 'pipeline_name': 'T'},
+     'func03.out.py'),
+    # ---
+    ('test', '', ['v1'], '', '', {}, 'func04.out.py'),
+    # ---
+    ('test', 'v1 = "Hello"\nprint(v1)', '', ['v1'], '', {}, 'func05.out.py'),
+    # ---
+    ('test', 'print("hello")', '', '', '', {}, 'func06.out.py')
+])
+def test_generate_function(template, step_name, source, ins, outs, nb_path,
+                           metadata, target):
+    """Test python code is generated correctly"""
+    component_data = {'source': source, 'ins': ins, 'outs': outs}
+    res = generate_code.generate_lightweight_component(template,
+                                                       step_name,
+                                                       component_data,
+                                                       nb_path,
+                                                       metadata)
+    target = open(os.path.join(THIS_DIR, "../assets/", target)).read()
+    assert target.strip() == res.strip()

--- a/kale/tests/unit_tests/test_parser.py
+++ b/kale/tests/unit_tests/test_parser.py
@@ -54,8 +54,6 @@ empty_tag = {'step_names': [], 'prev_steps': []}
      {'step_names': ['step1', 'step2'], 'prev_steps': []}),
     ({'tags': ['block:step1', 'prev:step2']},
      {'step_names': ['step1'], 'prev_steps': ['step2']}),
-    ({'tags': ['prev:step2']},
-     {'step_names': [], 'prev_steps': ['step2']}),
 ])
 def test_parse_metadata(metadata, target):
     """Test parse_metadata function."""
@@ -65,6 +63,7 @@ def test_parse_metadata(metadata, target):
 @pytest.mark.parametrize("metadata", [
     ({'tags': ["random_value"]}),
     ({'tags': [0]}),
+    ({'tags': ['prev:step2']}),
 ])
 def test_parse_metadata_exc(metadata):
     """Test parse_metadata exception cases."""


### PR DESCRIPTION
This PR contains 

- a refactoring of the codegen module, basically splitting up the previously monolithic function into multiple smaller and testable functions.
- some polishing of the Jinja templates
- improvements in notebook metadata handling from CLI args to code generation
- fixes here and there to make the gen features work more organically
- unit tests for gen module