### PR TITLE
Notebook metadata validation

### DIFF
--- a/kale/core.py
+++ b/kale/core.py
@@ -16,7 +16,7 @@ from kale.nbparser import parser
 from kale.static_analysis import dependencies, ast
 from kale.codegen import generate_code
 from kale.utils.pod_utils import get_namespace, get_docker_base_image
-from kale.utils.metadata_utils import validate_metadata
+from kale.utils.metadata_utils import parse_metadata
 
 NOTEBOOK_SNAPSHOT_COMMIT_MESSAGE = """\
 This is a snapshot of notebook {} in namespace {}.
@@ -52,7 +52,7 @@ class Kale:
             notebook_metadata.update(notebook_metadata_overrides)
 
         # validate metadata and apply transformations when needed
-        self.pipeline_metadata = validate_metadata(notebook_metadata)
+        self.pipeline_metadata = parse_metadata(notebook_metadata)
 
         self.detect_environment()
 

--- a/kale/core.py
+++ b/kale/core.py
@@ -2,8 +2,6 @@ import os
 import copy
 import json
 import pprint
-import random
-import string
 
 import logging
 import subprocess
@@ -28,11 +26,6 @@ and use them to spawn a Kubeflow pipeline.\
 """
 
 KALE_NOTEBOOK_METADATA_KEY = 'kubeflow_notebook'
-
-
-def random_string(size=5, chars=string.ascii_lowercase + string.digits):
-    """Generate random string."""
-    return "".join(random.choice(chars) for _ in range(size))
 
 
 class Kale:

--- a/kale/core.py
+++ b/kale/core.py
@@ -1,5 +1,4 @@
 import os
-import re
 import copy
 import json
 import pprint
@@ -19,7 +18,7 @@ from kale.nbparser import parser
 from kale.static_analysis import dependencies, ast
 from kale.codegen import generate_code
 from kale.utils.pod_utils import get_namespace, get_docker_base_image
-from kale.utils.pod_utils import is_workspace_dir
+from kale.utils.metadata_utils import validate_metadata
 
 NOTEBOOK_SNAPSHOT_COMMIT_MESSAGE = """\
 This is a snapshot of notebook {} in namespace {}.
@@ -29,10 +28,6 @@ and use them to spawn a Kubeflow pipeline.\
 """
 
 KALE_NOTEBOOK_METADATA_KEY = 'kubeflow_notebook'
-METADATA_REQUIRED_KEYS = [
-    'experiment_name',
-    'pipeline_name',
-]
 
 DEFAULT_METADATA = {
     'experiment_name': '',
@@ -81,7 +76,10 @@ class Kale:
         pipeline_name = "%s-%s" % (self.pipeline_metadata['pipeline_name'],
                                    random_string())
         self.pipeline_metadata['pipeline_name'] = pipeline_name
-        self.validate_metadata()
+
+        # validate metadata and update inplace when needed
+        validate_metadata(self.pipeline_metadata)
+
         self.detect_environment()
 
         # setup logging
@@ -114,62 +112,6 @@ class Kale:
         volumes = self.pipeline_metadata['volumes'][:] \
             if self.pipeline_metadata['volumes'] else []
         self.pipeline_metadata['volumes'] = self.create_cloned_volumes(volumes)
-
-    def validate_metadata(self):
-        kale_block_name_regex = r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
-        kale_name_msg = ("must consist of lower case alphanumeric characters "
-                         "or '-', and must start and end with an alphanumeric"
-                         " character.")
-        k8s_valid_name_regex = r'^[\.\-a-z0-9]+$'
-        k8s_name_msg = ("must consist of lower case alphanumeric characters, "
-                        "'-' or '.'")
-
-        # check for required fields
-        for required in METADATA_REQUIRED_KEYS:
-            if required not in self.pipeline_metadata:
-                raise ValueError("Key %s not found. Add this field either on "
-                                 "the notebook metadata or as an override" %
-                                 required)
-
-        if not re.match(kale_block_name_regex,
-                        self.pipeline_metadata['pipeline_name']):
-            raise ValueError("Pipeline name  %s" % kale_name_msg)
-
-        volumes = self.pipeline_metadata.get('volumes', [])
-        if volumes or isinstance(volumes, list):
-            for v in volumes:
-                if 'name' not in v:
-                    raise ValueError("Provide a valid name for every volume")
-                if not re.match(k8s_valid_name_regex, v['name']):
-                    raise ValueError("PV/PVC resource name {}"
-                                     .format(k8s_name_msg))
-                if ('snapshot' in v and
-                        v['snapshot'] and
-                        (('snapshot_name' not in v) or
-                         not re.match(k8s_valid_name_regex,
-                                      v['snapshot_name']))):
-                    raise ValueError(
-                        "Provide a valid snapshot resource name if you want to"
-                        " snapshot a volume. Snapshot resource name %s" %
-                        k8s_name_msg)
-
-                # Convert annotations to a dictionary
-                annotations = {a['key']: a['value']
-                               for a in v['annotations'] or []
-                               if a['key'] != '' and a['value'] != ''}
-                v['annotations'] = annotations
-                v['size'] = str(v['size'])
-
-            # The Jupyter Web App assumes the first volume of the notebook
-            # is the working directory, so we make sure to make it appear
-            # first in the spec.
-            volumes = sorted(
-                volumes,
-                reverse=True,
-                key=lambda x: is_workspace_dir(x['mount_point']))
-            self.pipeline_metadata['volumes'] = volumes
-        else:
-            raise ValueError("Volumes must be a valid list of volumes spec")
 
     def run_cmd(self, cmd):
         p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE,

--- a/kale/core.py
+++ b/kale/core.py
@@ -29,20 +29,6 @@ and use them to spawn a Kubeflow pipeline.\
 
 KALE_NOTEBOOK_METADATA_KEY = 'kubeflow_notebook'
 
-DEFAULT_METADATA = {
-    'experiment_name': '',
-    'pipeline_name': '',
-    'pipeline_description': '',
-    'pipeline_args': '',
-    'pipeline_args_names': '',
-    'docker_image': '',
-    'volumes': [],
-    'abs_working_dir': None,
-    'marshal_volume': False,
-    'marshal_path': '',
-    'auto_snapshot': False
-}
-
 
 def random_string(size=5, chars=string.ascii_lowercase + string.digits):
     """Generate random string."""
@@ -64,21 +50,16 @@ class Kale:
         self.notebook = nb.read(self.source_path,
                                 as_version=nb.NO_CONVERT)
 
-        self.pipeline_metadata = copy.deepcopy(DEFAULT_METADATA)
         # read Kale notebook metadata.
         # In case it is not specified get an empty dict
-        self.pipeline_metadata.update(
-            self.notebook.metadata.get(KALE_NOTEBOOK_METADATA_KEY, dict()))
+        notebook_metadata = self.notebook.metadata.get(
+            KALE_NOTEBOOK_METADATA_KEY, dict())
         # override notebook metadata with provided arguments
         if notebook_metadata_overrides:
-            self.pipeline_metadata.update(notebook_metadata_overrides)
+            notebook_metadata.update(notebook_metadata_overrides)
 
-        pipeline_name = "%s-%s" % (self.pipeline_metadata['pipeline_name'],
-                                   random_string())
-        self.pipeline_metadata['pipeline_name'] = pipeline_name
-
-        # validate metadata and update inplace when needed
-        validate_metadata(self.pipeline_metadata)
+        # validate metadata and apply transformations when needed
+        self.pipeline_metadata = validate_metadata(notebook_metadata)
 
         self.detect_environment()
 

--- a/kale/rpc/run.py
+++ b/kale/rpc/run.py
@@ -2,7 +2,7 @@ import sys
 import logging
 import importlib
 
-from kale.core import random_string
+from kale.utils.utils import random_string
 from kale.rpc import errors, utils
 from kale.rpc.log import create_adapter
 

--- a/kale/tests/unit_tests/test_metadata_utils.py
+++ b/kale/tests/unit_tests/test_metadata_utils.py
@@ -40,7 +40,7 @@ from kale.utils import metadata_utils
 ])
 def test_validate_volumes_metadata(volumes, target):
     """Tests volumes validation method."""
-    assert target == metadata_utils._validate_volumes_metadata(volumes)
+    assert target == metadata_utils._parse_volumes_metadata(volumes)
 
 
 @pytest.mark.parametrize("volumes,match", [
@@ -69,7 +69,7 @@ def test_validate_volumes_metadata(volumes, target):
 def test_convert_volume_annotations_exc(volumes, match):
     """Tests that volume spec errors are caught."""
     with pytest.raises(ValueError, match=match):
-        metadata_utils._validate_volumes_metadata(volumes)
+        metadata_utils._parse_volumes_metadata(volumes)
 
 
 @pytest.mark.parametrize("metadata,target", [
@@ -86,13 +86,13 @@ def test_validate_metadata(random_string, metadata, target):
     # metadata dict
     target.update({'pipeline_name': metadata['pipeline_name'] + '-rnd'})
     target.update({'experiment_name': metadata['experiment_name']})
-    assert target == metadata_utils.validate_metadata(metadata)
+    assert target == metadata_utils.parse_metadata(metadata)
 
 
 def test_validate_metadata_missing_required():
     """Tests that required metadata keys are checked for."""
     with pytest.raises(ValueError, match=r"Key experiment_name not found.*"):
-        metadata_utils.validate_metadata({})
+        metadata_utils.parse_metadata({})
 
     with pytest.raises(ValueError, match=r"Key pipeline_name not found.*"):
-        metadata_utils.validate_metadata({'experiment_name': 'test'})
+        metadata_utils.parse_metadata({'experiment_name': 'test'})

--- a/kale/tests/unit_tests/test_metadata_utils.py
+++ b/kale/tests/unit_tests/test_metadata_utils.py
@@ -1,3 +1,4 @@
+import copy
 import pytest
 
 from unittest import mock
@@ -73,13 +74,9 @@ def test_convert_volume_annotations_exc(volumes, match):
 
 @pytest.mark.parametrize("metadata,target", [
     ({'pipeline_name': 'test',
-      'experiment_name': 'test'},
-     metadata_utils.DEFAULT_METADATA),
-    # ---
-    ({'pipeline_name': 'test',
-      'experiment_name': 'test'},
-     metadata_utils.DEFAULT_METADATA),
-
+      'experiment_name': 'test',
+      'volumes': []},
+     copy.deepcopy(metadata_utils.DEFAULT_METADATA)),
 ])
 @mock.patch('kale.utils.metadata_utils.random_string')
 def test_validate_metadata(random_string, metadata, target):

--- a/kale/tests/unit_tests/test_metadata_utils.py
+++ b/kale/tests/unit_tests/test_metadata_utils.py
@@ -9,14 +9,14 @@ from kale.utils import metadata_utils
     ([], []),
     # ---
     ([{
-        'name': 'v1',
+        'name': 'v',
         'annotations': [{'key': 'a1', 'value': 'v1'}],
         'size': 5,
         'type': 'pv',
         'mount_point': '/'
     }],
      [{
-         'name': 'v1',
+         'name': 'v',
          'annotations': {'a1': 'v1'},
          'size': '5',
          'type': 'pv',
@@ -24,14 +24,14 @@ from kale.utils import metadata_utils
      }]),
     # ---
     ([{
-        'name': 'v1',
+        'name': 'v',
         'annotations': [{'key': 'a1', 'value': 'v1'}],
         'size': 5,
         'type': 'pvc',
         'mount_point': '/'
     }],
      [{
-         'name': 'v1',
+         'name': 'v',
          'annotations': {'a1': 'v1'},
          'size': '5',
          'type': 'pvc',
@@ -51,7 +51,7 @@ def test_validate_volumes_metadata(volumes, target):
         'mount_point': '/'
     }], "Volume spec: missing name value"),
     ([{
-        'name': 'v1',
+        'name': 'v',
         'annotations': [{'wronkey': 'a1', 'value': 'v1'}],
         'size': 5,
         'type': 'pv',
@@ -59,7 +59,7 @@ def test_validate_volumes_metadata(volumes, target):
     }], "Volume spec: volume annotations must be a "
         "list of {'key': k, 'value': v} dicts"),
     ([{
-        'name': 'v1',
+        'name': 'v',
         'annotations': {'key': 'a1', 'value': 'v1'},
         'size': 5,
         'type': 'pv',

--- a/kale/tests/unit_tests/test_metadata_utils.py
+++ b/kale/tests/unit_tests/test_metadata_utils.py
@@ -1,0 +1,59 @@
+import pytest
+
+from kale.utils.metadata_utils import _validate_volumes_metadata
+
+
+@pytest.mark.parametrize("volumes,target", [
+    ([], []),
+    # ---
+    ([{
+        'name': 'v1',
+        'annotations': [{'key': 'a1', 'value': 'v1'}],
+        'size': 5,
+        'type': 'pv',
+        'mount_point': '/'
+    }],
+     [{
+         'name': 'v1',
+         'annotations': {'a1': 'v1'},
+         'size': '5',
+         'type': 'pv',
+         'mount_point': '/'
+     }]),
+    # ---
+    ([{
+        'name': 'v1',
+        'annotations': [{'key': 'a1', 'value': 'v1'}],
+        'size': 5,
+        'type': 'pvc',
+        'mount_point': '/'
+    }],
+     [{
+         'name': 'v1',
+         'annotations': {'a1': 'v1'},
+         'size': '5',
+         'type': 'pvc',
+         'mount_point': '/'
+     }])
+])
+def test_validate_volumes_metadata(volumes, target):
+    """Tests that volumes are correctly converted from list into dict
+
+    """
+    assert target == _validate_volumes_metadata(volumes)
+
+
+@pytest.mark.parametrize("volumes", [
+    {
+        'annotations': [{'key': 'a1', 'value': 'v1'}],
+        'size': 5,
+        'type': 'pv',
+        'mount_point': '/'
+    }
+])
+def test_convert_volume_annotations_exc(volumes):
+    """Tests that volumes are correctly converted from list into dict
+
+    """
+    with pytest.raises(ValueError):
+        _validate_volumes_metadata(volumes)

--- a/kale/tests/unit_tests/test_metadata_utils.py
+++ b/kale/tests/unit_tests/test_metadata_utils.py
@@ -38,7 +38,7 @@ from kale.utils import metadata_utils
      }])
 ])
 def test_validate_volumes_metadata(volumes, target):
-    """Tests that volumes are correctly converted from list into dict."""
+    """Tests volumes validation method."""
     assert target == metadata_utils._validate_volumes_metadata(volumes)
 
 
@@ -66,7 +66,7 @@ def test_validate_volumes_metadata(volumes, target):
     }], "Volume spec: annotations must be a list"),
 ])
 def test_convert_volume_annotations_exc(volumes, match):
-    """Tests that volumes are correctly converted from list into dict."""
+    """Tests that volume spec errors are caught."""
     with pytest.raises(ValueError, match=match):
         metadata_utils._validate_volumes_metadata(volumes)
 

--- a/kale/utils/metadata_utils.py
+++ b/kale/utils/metadata_utils.py
@@ -49,7 +49,7 @@ def validate_metadata(notebook_metadata):
                              " the notebook metadata or as an override"
                              .format(required))
 
-    metadata = DEFAULT_METADATA.copy()
+    metadata = copy.deepcopy(DEFAULT_METADATA)
     metadata.update(notebook_metadata)
 
     if not re.match(kale_step_name_regex, metadata['pipeline_name']):

--- a/kale/utils/metadata_utils.py
+++ b/kale/utils/metadata_utils.py
@@ -33,8 +33,8 @@ VOLUME_TYPES = ('pv', 'pvc', 'new_pvc', 'clone')
 VOLUME_REQUIRED_FIELDS = ('name', 'annotations', 'size', 'type', 'mount_point')
 
 
-def validate_metadata(notebook_metadata):
-    """Validate the Notebook's metadata and update it when needed.
+def parse_metadata(notebook_metadata):
+    """Parse the Notebook's metadata and update it when needed.
 
     Args:
         notebook_metadata (dict): metadata annotated by Kale.
@@ -62,14 +62,14 @@ def validate_metadata(notebook_metadata):
 
     volumes = metadata.get('volumes', [])
     if isinstance(volumes, list):
-        metadata.update({'volumes': _validate_volumes_metadata(volumes)})
+        metadata.update({'volumes': _parse_volumes_metadata(volumes)})
     else:
         raise ValueError("Volumes spec must be a list")
     return metadata
 
 
-def _validate_volumes_metadata(volumes):
-    """Validate the volume spec and transform it inplace.
+def _parse_volumes_metadata(volumes):
+    """Parse the volume spec.
 
     The transformations applied are the following:
         - The annotations dict from a list of {'key': k, 'value': v} to {k: v}
@@ -79,7 +79,7 @@ def _validate_volumes_metadata(volumes):
     Args:
         volumes: Volume spec
 
-    Returns: Update and validated volume spec
+    Returns: Updated and validated volume spec
     """
     for v in volumes:
         for required in VOLUME_REQUIRED_FIELDS:

--- a/kale/utils/metadata_utils.py
+++ b/kale/utils/metadata_utils.py
@@ -23,12 +23,12 @@ METADATA_REQUIRED_KEYS = [
     'pipeline_name',
 ]
 kale_step_name_regex = r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
-kale_name_msg = ("must consist of lower case alphanumeric characters "
-                 "or '-', and must start and end with an alphanumeric"
+kale_name_msg = ("must consist of lower case alphanumeric characters"
+                 " or '-', and must start and end with an alphanumeric"
                  " character.")
 k8s_valid_name_regex = r'^[\.\-a-z0-9]+$'
-k8s_name_msg = ("must consist of lower case alphanumeric characters, "
-                "'-' or '.'")
+k8s_name_msg = ("must consist of lower case alphanumeric characters,"
+                " '-' or '.'")
 volume_types = ['pv', 'pvc', 'new_pvc', 'clone']
 volume_required_fields = ['name', 'annotations', 'size', 'type', 'mount_point']
 
@@ -45,8 +45,8 @@ def validate_metadata(notebook_metadata):
     # check for required fields before adding all possible defaults
     for required in METADATA_REQUIRED_KEYS:
         if required not in notebook_metadata:
-            raise ValueError("Key {} not found. Add this field either on "
-                             "the notebook metadata or as an override"
+            raise ValueError("Key {} not found. Add this field either on"
+                             " the notebook metadata or as an override"
                              .format(required))
 
     metadata = DEFAULT_METADATA.copy()
@@ -100,8 +100,8 @@ def _validate_volumes_metadata(volumes):
                              " name {}".format(k8s_name_msg))
 
         if not v['type'] in volume_types:
-            raise ValueError("Volume spec: volume type {} not recognized. "
-                             "Allowed volumes type: {}"
+            raise ValueError("Volume spec: volume type {} not recognized."
+                             " Allowed volumes type: {}"
                              .format(v['type'], volume_types))
 
         if not isinstance(v['annotations'], list):
@@ -115,8 +115,8 @@ def _validate_volumes_metadata(volumes):
                            if a['key'] != '' and a['value'] != ''}
         except KeyError as e:
             if str(e) in ["'key'", "'value'"]:
-                raise ValueError("Volume spec: volume annotations must be a "
-                                 "list of {'key': k, 'value': v} dicts")
+                raise ValueError("Volume spec: volume annotations must be a"
+                                 " list of {'key': k, 'value': v} dicts")
             else:
                 raise e
 

--- a/kale/utils/metadata_utils.py
+++ b/kale/utils/metadata_utils.py
@@ -26,9 +26,9 @@ kale_step_name_regex = r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
 kale_name_msg = ("must consist of lower case alphanumeric characters"
                  " or '-', and must start and end with an alphanumeric"
                  " character.")
-k8s_valid_name_regex = r'^[\.\-a-z0-9]+$'
+k8s_valid_name_regex = r'^[a-z]([a-z0-9-.]*[a-z])?$'
 k8s_name_msg = ("must consist of lower case alphanumeric characters,"
-                " '-' or '.'")
+                " '-' or '.', and must start and end with a character.")
 volume_types = ['pv', 'pvc', 'new_pvc', 'clone']
 volume_required_fields = ['name', 'annotations', 'size', 'type', 'mount_point']
 

--- a/kale/utils/metadata_utils.py
+++ b/kale/utils/metadata_utils.py
@@ -61,7 +61,7 @@ def validate_metadata(notebook_metadata):
     metadata['pipeline_name'] = random_pipeline_name
 
     volumes = metadata.get('volumes', [])
-    if volumes or isinstance(volumes, list):
+    if isinstance(volumes, list):
         metadata.update({'volumes': _validate_volumes_metadata(volumes)})
     else:
         raise ValueError("Volumes spec must be a list")

--- a/kale/utils/metadata_utils.py
+++ b/kale/utils/metadata_utils.py
@@ -1,7 +1,7 @@
 import re
 import copy
 
-from kale.core import random_string
+from kale.utils.utils import random_string
 from kale.utils.pod_utils import is_workspace_dir
 
 DEFAULT_METADATA = {

--- a/kale/utils/metadata_utils.py
+++ b/kale/utils/metadata_utils.py
@@ -53,10 +53,11 @@ def validate_metadata(notebook_metadata):
     metadata.update(notebook_metadata)
 
     if not re.match(kale_step_name_regex, metadata['pipeline_name']):
-        raise ValueError("Pipeline name  %s" % kale_name_msg)
+        raise ValueError("Pipeline name  {}".format(kale_name_msg))
 
     # update the pipeline name with a random string
-    random_pipeline_name = f"{metadata['pipeline_name']}-{random_string()}"
+    random_pipeline_name = "{}-{}".format(metadata['pipeline_name'],
+                                          random_string())
     metadata['pipeline_name'] = random_pipeline_name
 
     volumes = metadata.get('volumes', [])
@@ -84,24 +85,24 @@ def _validate_volumes_metadata(volumes):
         for required in volume_required_fields:
             if required not in v:
                 raise ValueError(
-                    "Volume spec: missing %s value" % required)
+                    "Volume spec: missing {} value".format(required))
 
         if not re.match(k8s_valid_name_regex, v['name']):
-            raise ValueError(f"Volume spec: PV/PVC name {k8s_name_msg}")
+            raise ValueError(
+                "Volume spec: PV/PVC name {}".format(k8s_name_msg))
         if ('snapshot' in v and
                 v['snapshot'] and
                 (('snapshot_name' not in v) or
                  not re.match(k8s_valid_name_regex,
                               v['snapshot_name']))):
-            raise ValueError(
-                "Provide a valid snapshot resource name if you want to"
-                " snapshot a volume. Snapshot resource name %s" %
-                k8s_name_msg)
+            raise ValueError("Provide a valid snapshot resource name if you"
+                             " want to snapshot a volume. Snapshot resource"
+                             " name {}".format(k8s_name_msg))
 
         if not v['type'] in volume_types:
-            raise ValueError("Volume spec: volume type %s not recognized. "
-                             "Allowed volumes type: %s" %
-                             (v['type'], volume_types))
+            raise ValueError("Volume spec: volume type {} not recognized. "
+                             "Allowed volumes type: {}"
+                             .format(v['type'], volume_types))
 
         if not isinstance(v['annotations'], list):
             raise ValueError('Volume spec: annotations must be a list')

--- a/kale/utils/metadata_utils.py
+++ b/kale/utils/metadata_utils.py
@@ -49,20 +49,15 @@ def validate_metadata(notebook_metadata):
                              "the notebook metadata or as an override"
                              .format(required))
 
-    metadata = copy.deepcopy(DEFAULT_METADATA)
+    metadata = DEFAULT_METADATA.copy()
     metadata.update(notebook_metadata)
-    # check for required fields
-    for required in METADATA_REQUIRED_KEYS:
-        if required not in metadata:
-            raise ValueError("Key %s not found. Add this field either on "
-                             "the notebook metadata or as an override" %
-                             required)
-    # update the pipeline name with a random string
-    random_pipeline_name = f"{metadata['pipeline_name']}-{random_string()}"
-    metadata['pipeline_name'] = random_pipeline_name
 
     if not re.match(kale_step_name_regex, metadata['pipeline_name']):
         raise ValueError("Pipeline name  %s" % kale_name_msg)
+
+    # update the pipeline name with a random string
+    random_pipeline_name = f"{metadata['pipeline_name']}-{random_string()}"
+    metadata['pipeline_name'] = random_pipeline_name
 
     volumes = metadata.get('volumes', [])
     if volumes or isinstance(volumes, list):

--- a/kale/utils/metadata_utils.py
+++ b/kale/utils/metadata_utils.py
@@ -1,0 +1,103 @@
+import re
+
+from kale.utils.pod_utils import is_workspace_dir
+
+METADATA_REQUIRED_KEYS = [
+    'experiment_name',
+    'pipeline_name',
+]
+kale_step_name_regex = r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+kale_name_msg = ("must consist of lower case alphanumeric characters "
+                 "or '-', and must start and end with an alphanumeric"
+                 " character.")
+k8s_valid_name_regex = r'^[\.\-a-z0-9]+$'
+k8s_name_msg = ("must consist of lower case alphanumeric characters, "
+                "'-' or '.'")
+volume_types = ['pv', 'pvc', 'new_pvc', 'clone']
+volume_required_fields = ['name', 'annotations', 'size', 'type', 'mount_point']
+
+
+def validate_metadata(metadata):
+    """Validate the Notebook's metadata and update it inplace when needed.
+
+    Args:
+        metadata (dict): metadata annotated by Kale. Refer to DEFAULT_METADATA
+    """
+    # check for required fields
+    for required in METADATA_REQUIRED_KEYS:
+        if required not in metadata:
+            raise ValueError("Key %s not found. Add this field either on "
+                             "the notebook metadata or as an override" %
+                             required)
+
+    if not re.match(kale_step_name_regex, metadata['pipeline_name']):
+        raise ValueError("Pipeline name  %s" % kale_name_msg)
+
+    volumes = metadata.get('volumes', [])
+    if volumes or isinstance(volumes, list):
+        metadata.update({'volumes': _validate_volumes_metadata(volumes)})
+    else:
+        raise ValueError("Volumes spec must be a list")
+
+
+def _validate_volumes_metadata(volumes):
+    """Validate the volume spec and transform it inplace.
+
+    The transformations applied are the following:
+        - The annotations dict from a list of {'key': k, 'value': v} to {k: v}
+        - Convert the size field to str
+        -  Sort the volumes dict to place the workspace volume first
+
+    Args:
+        volumes: Volume spec
+
+    Returns: Update and validated volume spec
+    """
+    for v in volumes:
+        for required in volume_required_fields:
+            if required not in v:
+                raise ValueError(
+                    "Volume spec: missing %s value" % required)
+
+        if not re.match(k8s_valid_name_regex, v['name']):
+            raise ValueError(f"Volume spec: PV/PVC name {k8s_name_msg}")
+        if ('snapshot' in v and
+                v['snapshot'] and
+                (('snapshot_name' not in v) or
+                 not re.match(k8s_valid_name_regex,
+                              v['snapshot_name']))):
+            raise ValueError(
+                "Provide a valid snapshot resource name if you want to"
+                " snapshot a volume. Snapshot resource name %s" %
+                k8s_name_msg)
+
+        if not v['type'] in volume_types:
+            raise ValueError("Volume spec: volume type %s not recognized. "
+                             "Allowed volumes type: %s" %
+                             (v['type'], volume_types))
+
+        if not isinstance(v['annotations'], list):
+            raise ValueError('Volume spec: annotations must be a list')
+
+        # Convert annotations to a {k: v} dictionary
+        try:
+            # TODO: Make JupyterLab annotate with {k: v} instead of
+            #  {'key': k, 'value': v}
+            annotations = {a['key']: a['value'] for a in v['annotations'] or []
+                           if a['key'] != '' and a['value'] != ''}
+        except KeyError as e:
+            if str(e) in ["'key'", "'value'"]:
+                raise ValueError("Volume spec: volume annotations must be a "
+                                 "list of {'key': k, 'value': v} dicts")
+            else:
+                raise e
+
+        v['annotations'] = annotations
+        v['size'] = str(v['size'])
+
+    # The Jupyter Web App assumes the first volume of the notebook is the
+    # working directory, so we make sure to make it appear first in the spec.
+    volumes = sorted(volumes,
+                     reverse=True,
+                     key=lambda _v: is_workspace_dir(_v['mount_point']))
+    return volumes

--- a/kale/utils/metadata_utils.py
+++ b/kale/utils/metadata_utils.py
@@ -18,19 +18,19 @@ DEFAULT_METADATA = {
     'auto_snapshot': False
 }
 
-METADATA_REQUIRED_KEYS = [
+METADATA_REQUIRED_KEYS = (
     'experiment_name',
     'pipeline_name',
-]
-kale_step_name_regex = r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
-kale_name_msg = ("must consist of lower case alphanumeric characters"
+)
+KALE_STEP_NAME_REGEX = r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+KALE_NAME_MSG = ("must consist of lower case alphanumeric characters"
                  " or '-', and must start and end with an alphanumeric"
                  " character.")
-k8s_valid_name_regex = r'^[a-z]([a-z0-9-.]*[a-z])?$'
-k8s_name_msg = ("must consist of lower case alphanumeric characters,"
+K8S_VALID_NAME_REGEX = r'^[a-z]([a-z0-9-.]*[a-z])?$'
+K8S_NAME_MSG = ("must consist of lower case alphanumeric characters,"
                 " '-' or '.', and must start and end with a character.")
-volume_types = ['pv', 'pvc', 'new_pvc', 'clone']
-volume_required_fields = ['name', 'annotations', 'size', 'type', 'mount_point']
+VOLUME_TYPES = ('pv', 'pvc', 'new_pvc', 'clone')
+VOLUME_REQUIRED_FIELDS = ('name', 'annotations', 'size', 'type', 'mount_point')
 
 
 def validate_metadata(notebook_metadata):
@@ -52,8 +52,8 @@ def validate_metadata(notebook_metadata):
     metadata = copy.deepcopy(DEFAULT_METADATA)
     metadata.update(notebook_metadata)
 
-    if not re.match(kale_step_name_regex, metadata['pipeline_name']):
-        raise ValueError("Pipeline name  {}".format(kale_name_msg))
+    if not re.match(KALE_STEP_NAME_REGEX, metadata['pipeline_name']):
+        raise ValueError("Pipeline name  {}".format(KALE_NAME_MSG))
 
     # update the pipeline name with a random string
     random_pipeline_name = "{}-{}".format(metadata['pipeline_name'],
@@ -82,27 +82,27 @@ def _validate_volumes_metadata(volumes):
     Returns: Update and validated volume spec
     """
     for v in volumes:
-        for required in volume_required_fields:
+        for required in VOLUME_REQUIRED_FIELDS:
             if required not in v:
                 raise ValueError(
                     "Volume spec: missing {} value".format(required))
 
-        if not re.match(k8s_valid_name_regex, v['name']):
+        if not re.match(K8S_VALID_NAME_REGEX, v['name']):
             raise ValueError(
-                "Volume spec: PV/PVC name {}".format(k8s_name_msg))
+                "Volume spec: PV/PVC name {}".format(K8S_NAME_MSG))
         if ('snapshot' in v and
                 v['snapshot'] and
                 (('snapshot_name' not in v) or
-                 not re.match(k8s_valid_name_regex,
+                 not re.match(K8S_VALID_NAME_REGEX,
                               v['snapshot_name']))):
             raise ValueError("Provide a valid snapshot resource name if you"
                              " want to snapshot a volume. Snapshot resource"
-                             " name {}".format(k8s_name_msg))
+                             " name {}".format(K8S_NAME_MSG))
 
-        if not v['type'] in volume_types:
+        if not v['type'] in VOLUME_TYPES:
             raise ValueError("Volume spec: volume type {} not recognized."
                              " Allowed volumes type: {}"
-                             .format(v['type'], volume_types))
+                             .format(v['type'], VOLUME_TYPES))
 
         if not isinstance(v['annotations'], list):
             raise ValueError('Volume spec: annotations must be a list')

--- a/kale/utils/metadata_utils.py
+++ b/kale/utils/metadata_utils.py
@@ -43,14 +43,15 @@ def parse_metadata(notebook_metadata):
     Returns (dict): updated and validated metadata
     """
     # check for required fields before adding all possible defaults
+    validated_notebook_metadata = copy.deepcopy(notebook_metadata)
     for required in METADATA_REQUIRED_KEYS:
-        if required not in notebook_metadata:
+        if required not in validated_notebook_metadata:
             raise ValueError("Key {} not found. Add this field either on"
                              " the notebook metadata or as an override"
                              .format(required))
 
     metadata = copy.deepcopy(DEFAULT_METADATA)
-    metadata.update(notebook_metadata)
+    metadata.update(validated_notebook_metadata)
 
     if not re.match(KALE_STEP_NAME_REGEX, metadata['pipeline_name']):
         raise ValueError("Pipeline name  {}".format(KALE_NAME_MSG))
@@ -81,7 +82,8 @@ def _parse_volumes_metadata(volumes):
 
     Returns: Updated and validated volume spec
     """
-    for v in volumes:
+    validated_volumes = copy.deepcopy(volumes)
+    for v in validated_volumes:
         for required in VOLUME_REQUIRED_FIELDS:
             if required not in v:
                 raise ValueError(
@@ -125,7 +127,8 @@ def _parse_volumes_metadata(volumes):
 
     # The Jupyter Web App assumes the first volume of the notebook is the
     # working directory, so we make sure to make it appear first in the spec.
-    volumes = sorted(volumes,
-                     reverse=True,
-                     key=lambda _v: is_workspace_dir(_v['mount_point']))
-    return volumes
+    validated_volumes = sorted(validated_volumes,
+                               reverse=True,
+                               key=lambda _v: is_workspace_dir(
+                                   _v['mount_point']))
+    return validated_volumes

--- a/kale/utils/utils.py
+++ b/kale/utils/utils.py
@@ -1,0 +1,7 @@
+import random
+import string
+
+
+def random_string(size=5, chars=string.ascii_lowercase + string.digits):
+    """Generate random string."""
+    return "".join(random.choice(chars) for _ in range(size))


### PR DESCRIPTION
- Move metadata validation from `core` to `utils` module.
- Move some volumes metadata validation from `codegen` to `utils`.
- Add base default metadata dict to standardise fields and values
- Add tests for metadata