### PR TITLE
Convert ins to a set to perform set difference

### DIFF
--- a/kale/static_analysis/dependencies.py
+++ b/kale/static_analysis/dependencies.py
@@ -98,7 +98,7 @@ def detect_out_dependencies(nb_graph: nx.DiGraph, ignore_symbols: set = None):
             outs.update(father_data['outs'])
             # remove symbols to ignore
             if ignore_symbols:
-                ins.difference_update(set(ignore_symbols))
+                ins = list(set(ins) - set(ignore_symbols))
             # add to father the new `outs` variables
             nx.set_node_attributes(nb_graph, {_a: {'outs': sorted(outs)}})
 


### PR DESCRIPTION
The `ins` variable was treated as a `set` to perform a set difference in case pipeline parameters were provided as part of the notebook