### PR TITLE
Run code inside an IPython kernel and capture artifacts

### DIFF
--- a/kale/codegen/generate_code.py
+++ b/kale/codegen/generate_code.py
@@ -1,4 +1,5 @@
 import os
+import re
 import autopep8
 
 import networkx as nx
@@ -128,6 +129,14 @@ def generate_lightweight_component(template, step_name, step_data, nb_path,
                                    metadata):
     """Use the function template to generate Python code."""
     step_source = step_data.get('source', [])
+    # Escape triple quotes strings, as the code blocks will be wrapped in
+    # a triple quote string in the python executable
+    # XXX: This approach can cause issues in case the code itself contains
+    # XXX: escaped triple quotes. This is clearly a corner case and it would
+    # XXX: have to be tackled in a recursive way. An approach to avoid these
+    # XXX: issue could be to run the notebook directly, without having to
+    # XXX: copy the user code into the template.
+    step_source = [re.sub(r"'''", "\\'\\'\\'", s) for s in step_source]
     step_marshal_in = step_data.get('ins', [])
     step_marshal_out = step_data.get('outs', [])
 

--- a/kale/codegen/generate_code.py
+++ b/kale/codegen/generate_code.py
@@ -140,7 +140,7 @@ def generate_lightweight_component(template, step_name, step_data, nb_path,
 
     fn_code = template.render(
         step_name=step_name,
-        function_body=[step_source],
+        function_body=step_source,
         in_variables=step_marshal_in,
         out_variables=step_marshal_out,
         nb_path=nb_path,

--- a/kale/codegen/generate_code.py
+++ b/kale/codegen/generate_code.py
@@ -87,7 +87,7 @@ def get_marshal_data(wd, volumes, nb_path):
 def get_args(pipeline_parameters):
     """Generate pipeline and function parameter.
 
-    The generated strings will be passed to the rendering template.
+    The generated lists will be passed to the rendering template.
 
     Args:
         pipeline_parameters (dict): pipeline parameters as
@@ -95,24 +95,17 @@ def get_args(pipeline_parameters):
 
     Returns (dict): a dict composed of:
         - 'pipeline_args_names': pipeline argument names as list
-        - 'pipeline_args': pipeline arguments as a comma separated string
-        - 'function_args': function arguments as a comma separated string
+        - 'pipeline_args_type': pipeline arguments types as list
+        - 'pipeline_args_values': function arguments values as list
     """
-    pipeline_args_names = ', '.join(list(pipeline_parameters.keys()))
-    # wrap in quotes every parameter - required by kfp
-    pipeline_args = ', '.join(["{}='{}'".format(arg, 
-                                                pipeline_parameters[arg][1])
-                               for arg in pipeline_parameters])
-    # Arguments are the pipeline arguments. Since we don't know precisely in
-    # what pipeline steps they are needed, we just pass them to every one.
-    # We assume there variables were not re-assigned throughout the notebook
-    function_args = ', '.join(["{}: {}".format(arg, 
-                                               pipeline_parameters[arg][0])
-                               for arg in pipeline_parameters])
+    pipeline_args_names = list(pipeline_parameters.keys())
+    pipeline_args_types = [arg[0] for arg in pipeline_parameters.values()]
+    pipeline_args_values = [arg[1] for arg in pipeline_parameters.values()]
+
     return {
         'pipeline_args_names': pipeline_args_names,
-        'pipeline_args': pipeline_args,
-        'function_args': function_args
+        'pipeline_args_types': pipeline_args_types,
+        'pipeline_args_values': pipeline_args_values
     }
 
 

--- a/kale/core.py
+++ b/kale/core.py
@@ -211,8 +211,10 @@ class Kale:
             template_env = _initialize_templating_env()
             metrics_template = template_env.get_template(
                 'pipeline_metrics_template.jinja2')
-            metrics_source = metrics_template.render(
-                pipeline_metrics=pipeline_metrics)
+            # need to be a list since it will be treated as a code cell and
+            # passed to the ipykernel
+            metrics_source = [metrics_template.render(
+                pipeline_metrics=pipeline_metrics)]
             data = {pipeline_metrics_name: {'source': metrics_source,
                                             'ins': [],
                                             'outs': []}}

--- a/kale/nbparser/parser.py
+++ b/kale/nbparser/parser.py
@@ -322,11 +322,4 @@ def parse_notebook(notebook):
     # merge together pipeline metrics
     pipeline_metrics = '\n'.join(pipeline_metrics)
 
-    # make the nodes' code a single multiline string
-    # NOTICE: this is temporary, waiting for the artifacts-viz-feature
-    for step in nb_graph:
-        step_source = nb_graph.nodes(data=True)[step]['source']
-        nx.set_node_attributes(nb_graph,
-                               {step: {'source': '\n'.join(step_source)}})
-
     return nb_graph, pipeline_parameters, pipeline_metrics

--- a/kale/static_analysis/dependencies.py
+++ b/kale/static_analysis/dependencies.py
@@ -5,6 +5,7 @@ import networkx as nx
 from pyflakes import api as pyflakes_api
 from pyflakes import reporter as pyflakes_reporter
 
+from kale.utils import utils
 from kale.static_analysis.ast import get_all_names
 
 
@@ -64,7 +65,8 @@ def detect_in_dependencies(nb_graph: nx.DiGraph, ignore_symbols: set = None):
     block_names = nb_graph.nodes()
     for block in block_names:
         source_code = '\n'.join(nb_graph.nodes(data=True)[block]['source'])
-        ins = pyflakes_report(code=source_code)
+        commented_source_code = utils.comment_magic_commands(source_code)
+        ins = pyflakes_report(code=commented_source_code)
 
         if ignore_symbols:
             ins.difference_update(set(ignore_symbols))

--- a/kale/static_analysis/dependencies.py
+++ b/kale/static_analysis/dependencies.py
@@ -40,6 +40,12 @@ def pyflakes_report(code):
         flakes_stderr.reset())
     pyflakes_api.check(code, filename="kale", reporter=rep)
 
+    # the stderr stream should be used just for compilation error, so if any
+    # message is found in the stderr stream, raise an exception
+    if rep._stderr():
+        raise RuntimeError("Flakes reported the following error:"
+                           "\n{}".format('\t' + '\t'.join(rep._stderr())))
+
     # Match names
     p = r"'(.+?)'"
 

--- a/kale/static_analysis/dependencies.py
+++ b/kale/static_analysis/dependencies.py
@@ -63,7 +63,7 @@ def detect_in_dependencies(nb_graph: nx.DiGraph, ignore_symbols: set = None):
     """
     block_names = nb_graph.nodes()
     for block in block_names:
-        source_code = nb_graph.nodes(data=True)[block]['source']
+        source_code = '\n'.join(nb_graph.nodes(data=True)[block]['source'])
         ins = pyflakes_report(code=source_code)
 
         if ignore_symbols:
@@ -118,7 +118,7 @@ def dependencies_detection(nb_graph: nx.DiGraph, ignore_symbols: set = None):
     # First get all the names of each code block
     for block in nb_graph:
         block_data = nb_graph.nodes(data=True)[block]
-        all_names = get_all_names(block_data['source'])
+        all_names = get_all_names('\n'.join(block_data['source']))
         nx.set_node_attributes(nb_graph, {block: {'all_names': all_names}})
 
     # annotate the graph inplace with all the variables dependencies between

--- a/kale/templates/function_template.jinja2
+++ b/kale/templates/function_template.jinja2
@@ -78,11 +78,15 @@ def {{ step_name }}({{ function_args }}):
 {% if in_variables|length > 0 or out_variables|length > 0 or function_body|length > 0 %}
     # run the code blocks inside a jupyter kernel
     from kale.utils.jupyter_utils import run_code as _kale_run_code
+    from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
     blocks = ({% if in_variables|length > 0 or out_variables|length > 0 %}data_dir_block,{% endif -%}
               {% if in_variables|length > 0 %}data_loading_block,{% endif -%}
 {%- for block in function_body %}
               block{{ loop.index }},
 {%- endfor %}
               {% if out_variables|length > 0 %}data_saving_block{% endif %})
-    _kale_run_code(blocks)
+    html_artifact = _kale_run_code(blocks)
+    with open("/{{ step_name }}.html", "w") as f:
+        f.write(html_artifact)
+    _kale_update_uimetadata('{{ step_name }}')
 {% endif -%}

--- a/kale/templates/function_template.jinja2
+++ b/kale/templates/function_template.jinja2
@@ -1,25 +1,27 @@
 def {{ step_name }}({{ function_args }}):
     from kale.utils import pod_utils as _kale_pod_utils
-    from kale.utils.jupyter_utils import run_code as _kale_run_code
 
-    {% if auto_snapshot -%}
+{% if auto_snapshot %}
     _kale_pod_utils.snapshot_pipeline_step(
         "{{ pipeline_name }}",
         "{{ step_name }}",
         "{{ nb_path }}")
-    {% endif %}
+{% endif %}
 
-{%- if in_variables|length > 0 -%}
-    data_loading_block = '''
+{%- if in_variables|length > 0 or out_variables|length > 0 %}
+    data_dir_block = '''
     import os
-    import shutil
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
     _kale_data_directory = "{{ marshal_path }}"
     {#- Verify directory exists #}
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
+    '''
+{%- endif %}
+
+{% if in_variables|length > 0 %}
+    data_loading_block = '''
+    import os
+    from kale.marshal import resource_load as _kale_resource_load
 
     # -----------------------DATA LOADING START--------------------------------
     _kale_directory_file_names = [
@@ -28,7 +30,7 @@ def {{ step_name }}({{ function_args }}):
         if os.path.isfile(os.path.join(_kale_data_directory, f))
     ]
 
-{%- for in_var in in_variables -%}
+{%- for in_var in in_variables %}
     {#- First check that the variable exists in the path #}
     if "{{ in_var }}" not in _kale_directory_file_names:
         raise ValueError("{{ in_var }}" + " does not exists in directory")
@@ -49,9 +51,7 @@ def {{ step_name }}({{ function_args }}):
 {%- endfor %}
     # -----------------------DATA LOADING END----------------------------------
     '''
-{%- else -%}
-    data_loading_block = ''
-{%- endif %}
+{% endif %}
 
 {% for block in function_body %}
     block{{ loop.index }} = '''
@@ -60,6 +60,8 @@ def {{ step_name }}({{ function_args }}):
 {% endfor %}
 {% if out_variables|length > 0 %}
     data_saving_block = '''
+    import os
+    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
 {%- for out_var in out_variables %}
     if "{{ out_var }}" in locals():
@@ -71,14 +73,16 @@ def {{ step_name }}({{ function_args }}):
 {%- endfor %}
     # -----------------------DATA SAVING END-----------------------------------
     '''
-{%- else %}
-    data_saving_block = ''
 {%- endif %}
 
+{% if in_variables|length > 0 or out_variables|length > 0 or function_body|length > 0 %}
     # run the code blocks inside a jupyter kernel
-    blocks = (data_loading_block,
+    from kale.utils.jupyter_utils import run_code as _kale_run_code
+    blocks = ({% if in_variables|length > 0 or out_variables|length > 0 %}data_dir_block,{% endif -%}
+              {% if in_variables|length > 0 %}data_loading_block,{% endif -%}
 {%- for block in function_body %}
               block{{ loop.index }},
 {%- endfor %}
-              data_saving_block)
+              {% if out_variables|length > 0 %}data_saving_block{% endif %})
     _kale_run_code(blocks)
+{% endif -%}

--- a/kale/templates/function_template.jinja2
+++ b/kale/templates/function_template.jinja2
@@ -1,7 +1,17 @@
-def {{ step_name }}({{ function_args }}):
+def {{ step_name }}({%- for arg in pipeline_args_names -%}
+    {{ arg }}: {{ pipeline_args_types[loop.index-1] }}
+    {%- if loop.index < pipeline_args_names|length -%},
+    {%- endif -%}
+    {%- endfor -%}):
 {%- if not auto_snapshot and in_variables|length == 0 and out_variables|length == 0 and function_body|length == 0 %}
     pass
-{%- endif %}
+{%- elif pipeline_args_names|length > 0 %}
+    pipeline_parameters_block = '''
+{%- for arg in pipeline_args_names %}
+    {% if pipeline_args_types[loop.index-1] == 'str' %}{{ arg }} = "{}"{% else %}{{ arg }} = {}{% endif -%}
+{%- endfor %}
+    '''.format({{ pipeline_args_names|join(', ') }})
+{% endif %}
 {%- if auto_snapshot %}
     from kale.utils import pod_utils as _kale_pod_utils
     _kale_pod_utils.snapshot_pipeline_step(
@@ -82,6 +92,7 @@ def {{ step_name }}({{ function_args }}):
     from kale.utils.jupyter_utils import run_code as _kale_run_code
     from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
     blocks = ({% if in_variables|length > 0 or out_variables|length > 0 %}data_dir_block,{% endif -%}
+              {% if pipeline_args_names|length > 0 %}pipeline_parameters_block,{% endif -%}
               {% if in_variables|length > 0 %}data_loading_block,{% endif -%}
 {%- for block in function_body %}
               block{{ loop.index }},

--- a/kale/templates/function_template.jinja2
+++ b/kale/templates/function_template.jinja2
@@ -1,7 +1,18 @@
 def {{ step_name }}({{ function_args }}):
+    from kale.utils import pod_utils as _kale_pod_utils
+    from kale.utils.jupyter_utils import run_code as _kale_run_code
+
+    {% if auto_snapshot -%}
+    _kale_pod_utils.snapshot_pipeline_step(
+        "{{ pipeline_name }}",
+        "{{ step_name }}",
+        "{{ nb_path }}")
+    {% endif %}
+
+{%- if in_variables|length > 0 -%}
+    data_loading_block = '''
     import os
     import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
     from kale.marshal import resource_save as _kale_resource_save
     from kale.marshal import resource_load as _kale_resource_load
 
@@ -10,14 +21,6 @@ def {{ step_name }}({{ function_args }}):
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
 
-    {% if auto_snapshot -%}
-    _kale_pod_utils.snapshot_pipeline_step(
-        "{{ pipeline_name }}",
-        "{{ step_name }}",
-        "{{ nb_path }}")
-    {% endif -%}
-
-{%- if in_variables|length > 0 -%}
     # -----------------------DATA LOADING START--------------------------------
     _kale_directory_file_names = [
         os.path.splitext(f)[0]
@@ -45,11 +48,18 @@ def {{ step_name }}({{ function_args }}):
         os.path.join(_kale_data_directory, _kale_load_file_name))
 {%- endfor %}
     # -----------------------DATA LOADING END----------------------------------
-{%- endif -%}
-{%- for block in function_body %}
+    '''
+{%- else -%}
+    data_loading_block = ''
+{%- endif %}
+
+{% for block in function_body %}
+    block{{ loop.index }} = '''
 {{block|indent(4, True)}}
-{%- endfor %}
+    '''
+{% endfor %}
 {% if out_variables|length > 0 %}
+    data_saving_block = '''
     # -----------------------DATA SAVING START---------------------------------
 {%- for out_var in out_variables %}
     if "{{ out_var }}" in locals():
@@ -60,4 +70,15 @@ def {{ step_name }}({{ function_args }}):
         print("_kale_resource_save: `{{ out_var }}` not found.")
 {%- endfor %}
     # -----------------------DATA SAVING END-----------------------------------
+    '''
+{%- else %}
+    data_saving_block = ''
 {%- endif %}
+
+    # run the code blocks inside a jupyter kernel
+    blocks = (data_loading_block,
+{%- for block in function_body %}
+              block{{ loop.index }},
+{%- endfor %}
+              data_saving_block)
+    _kale_run_code(blocks)

--- a/kale/templates/function_template.jinja2
+++ b/kale/templates/function_template.jinja2
@@ -1,7 +1,9 @@
 def {{ step_name }}({{ function_args }}):
+{%- if not auto_snapshot and in_variables|length == 0 and out_variables|length == 0 and function_body|length == 0 %}
+    pass
+{%- endif %}
+{%- if auto_snapshot %}
     from kale.utils import pod_utils as _kale_pod_utils
-
-{% if auto_snapshot %}
     _kale_pod_utils.snapshot_pipeline_step(
         "{{ pipeline_name }}",
         "{{ step_name }}",
@@ -16,9 +18,9 @@ def {{ step_name }}({{ function_args }}):
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
     '''
-{%- endif %}
+{% endif %}
 
-{% if in_variables|length > 0 %}
+{%- if in_variables|length > 0 %}
     data_loading_block = '''
     import os
     from kale.marshal import resource_load as _kale_resource_load
@@ -53,12 +55,12 @@ def {{ step_name }}({{ function_args }}):
     '''
 {% endif %}
 
-{% for block in function_body %}
+{%- for block in function_body %}
     block{{ loop.index }} = '''
 {{block|indent(4, True)}}
     '''
 {% endfor %}
-{% if out_variables|length > 0 %}
+{%- if out_variables|length > 0 %}
     data_saving_block = '''
     import os
     from kale.marshal import resource_save as _kale_resource_save

--- a/kale/templates/pipeline_template.jinja2
+++ b/kale/templates/pipeline_template.jinja2
@@ -98,13 +98,18 @@ def auto_generated_pipeline({{ pipeline_args }}):
                             .after({{ step_prevs[ name ]|join(', ') }})
     {{ name }}_task.container.working_dir = "{{ abs_working_dir }}"
     {{ name }}_task.container.set_security_context(k8s_client.V1SecurityContext(run_as_user=0))
-    {% if auto_snapshot -%}
-    mlpipeline_ui_metadata = {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'}
-    {{ name }}_task.output_artifact_paths.update(mlpipeline_ui_metadata)
-    {% endif -%}
-    {% if name == "pipeline_metrics" -%}
-    {{ name }}_task.output_artifact_paths.update({'mlpipeline-metrics': '/mlpipeline-metrics.json'})
-    {% endif -%}
+    output_artifacts = {}
+    {%- if auto_snapshot %}
+    output_artifacts.update({'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
+    {%- endif %}
+    {%- if name == "pipeline_metrics" %}
+    output_artifacts.update({'mlpipeline-metrics': '/mlpipeline-metrics.json'})
+    {%- endif %}
+    {%- if name != "final_auto_snapshot" and name != "pipeline_metrics" %}
+    output_artifacts.update({'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
+    output_artifacts.update({'{{ name }}': '/{{ name }}.html'})
+    {%- endif %}
+    {{ name }}_task.output_artifact_paths.update(output_artifacts)
     {% endfor %}
 
     {# Snaphosts #}

--- a/kale/templates/pipeline_template.jinja2
+++ b/kale/templates/pipeline_template.jinja2
@@ -22,7 +22,11 @@ import kfp.dsl as dsl
    name='{{ pipeline_name }}',
    description='{{ pipeline_description }}'
 )
-def auto_generated_pipeline({{ pipeline_args }}):
+def auto_generated_pipeline({%- for arg in pipeline_args_names -%}
+    {{ arg }}='{{ pipeline_args_values[loop.index-1] }}'
+    {%- if loop.index < pipeline_args_names|length -%},
+    {%- endif -%}
+    {%- endfor -%}):
     pvolumes_dict = OrderedDict()
 
     {% for vol in volumes -%}
@@ -93,7 +97,7 @@ def auto_generated_pipeline({{ pipeline_args }}):
 
     {% for name in step_names %}
 
-    {{ name }}_task = {{ name }}_op({{ pipeline_args_names }})\
+    {{ name }}_task = {{ name }}_op({{ pipeline_args_names|join(', ') }})\
                             .add_pvolumes(pvolumes_dict)\
                             .after({{ step_prevs[ name ]|join(', ') }})
     {{ name }}_task.container.working_dir = "{{ abs_working_dir }}"

--- a/kale/tests/assets/functions/func01.out.py
+++ b/kale/tests/assets/functions/func01.out.py
@@ -1,10 +1,2 @@
 def test():
-    import os
-    import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
-    _kale_data_directory = ""
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
+    pass

--- a/kale/tests/assets/functions/func02.out.py
+++ b/kale/tests/assets/functions/func02.out.py
@@ -1,2 +1,2 @@
-def test(arg1, arg2, arg3):
+def test(arg1: int, arg2: str, arg3: str):
     pass

--- a/kale/tests/assets/functions/func02.out.py
+++ b/kale/tests/assets/functions/func02.out.py
@@ -1,10 +1,2 @@
 def test(arg1, arg2, arg3):
-    import os
-    import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
-    _kale_data_directory = ""
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
+    pass

--- a/kale/tests/assets/functions/func03.out.py
+++ b/kale/tests/assets/functions/func03.out.py
@@ -1,14 +1,5 @@
 def test():
-    import os
-    import shutil
     from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
-    _kale_data_directory = "/path"
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
-
     _kale_pod_utils.snapshot_pipeline_step(
         "T",
         "test",

--- a/kale/tests/assets/functions/func04.out.py
+++ b/kale/tests/assets/functions/func04.out.py
@@ -1,13 +1,14 @@
 def test():
+    data_dir_block = '''
     import os
-    import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
     _kale_data_directory = ""
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
+    '''
+
+    data_loading_block = '''
+    import os
+    from kale.marshal import resource_load as _kale_resource_load
 
     # -----------------------DATA LOADING START--------------------------------
     _kale_directory_file_names = [
@@ -30,3 +31,14 @@ def test():
     v1 = _kale_resource_load(
         os.path.join(_kale_data_directory, _kale_load_file_name))
     # -----------------------DATA LOADING END----------------------------------
+    '''
+
+    # run the code blocks inside a jupyter kernel
+    from kale.utils.jupyter_utils import run_code as _kale_run_code
+    from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
+    blocks = (data_dir_block, data_loading_block,
+              )
+    html_artifact = _kale_run_code(blocks)
+    with open("/test.html", "w") as f:
+        f.write(html_artifact)
+    _kale_update_uimetadata('test')

--- a/kale/tests/assets/functions/func05.out.py
+++ b/kale/tests/assets/functions/func05.out.py
@@ -1,17 +1,22 @@
 def test():
+    data_dir_block = '''
     import os
-    import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
     _kale_data_directory = ""
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
+    '''
 
+    block1 = '''
     v1 = "Hello"
-    print(v1)
+    '''
 
+    block2 = '''
+    print(v1)
+    '''
+
+    data_saving_block = '''
+    import os
+    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
     if "v1" in locals():
         _kale_resource_save(
@@ -19,3 +24,17 @@ def test():
     else:
         print("_kale_resource_save: `v1` not found.")
     # -----------------------DATA SAVING END-----------------------------------
+    '''
+
+    # run the code blocks inside a jupyter kernel
+    from kale.utils.jupyter_utils import run_code as _kale_run_code
+    from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
+    blocks = (data_dir_block,
+              block1,
+              block2,
+              data_saving_block)
+    html_artifact = _kale_run_code(blocks)
+    with open("/test.html", "w") as f:
+        f.write(html_artifact)
+    _kale_update_uimetadata('test')
+

--- a/kale/tests/assets/functions/func06.out.py
+++ b/kale/tests/assets/functions/func06.out.py
@@ -1,12 +1,17 @@
 def test():
-    import os
-    import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
-    _kale_data_directory = ""
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
-
+    block1 = '''
     print("hello")
+    '''
+
+    # run the code blocks inside a jupyter kernel
+    from kale.utils.jupyter_utils import run_code as _kale_run_code
+    from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
+    blocks = (
+        block1,
+    )
+    html_artifact = _kale_run_code(blocks)
+    with open("/test.html", "w") as f:
+        f.write(html_artifact)
+    _kale_update_uimetadata('test')
+
+

--- a/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
+++ b/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
@@ -4,20 +4,32 @@ from collections import OrderedDict
 from kubernetes import client as k8s_client
 
 
-def create_matrix(d1: int, d2: int):
-    import os
-    import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
+def create_matrix(d1: int, d2: int, booltest: bool, strtest: str):
+    pipeline_parameters_block = '''
+    d1 = {}
+    d2 = {}
+    booltest = {}
+    strtest = "{}"
+    '''.format(d1, d2, booltest, strtest)
 
+    data_dir_block = '''
+    import os
     _kale_data_directory = "/marshal"
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
+    '''
 
+    block1 = '''
     import numpy as np
-    rnd_matrix = np.random.rand(d1, d2)
+    '''
 
+    block2 = '''
+    rnd_matrix = np.random.rand(d1, d2)
+    '''
+
+    data_saving_block = '''
+    import os
+    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
     if "rnd_matrix" in locals():
         _kale_resource_save(
@@ -25,18 +37,39 @@ def create_matrix(d1: int, d2: int):
     else:
         print("_kale_resource_save: `rnd_matrix` not found.")
     # -----------------------DATA SAVING END-----------------------------------
+    '''
+
+    # run the code blocks inside a jupyter kernel
+    from kale.utils.jupyter_utils import run_code as _kale_run_code
+    from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
+    blocks = (data_dir_block, pipeline_parameters_block,
+              block1,
+              block2,
+              data_saving_block)
+    html_artifact = _kale_run_code(blocks)
+    with open("/create_matrix.html", "w") as f:
+        f.write(html_artifact)
+    _kale_update_uimetadata('create_matrix')
 
 
-def sum_matrix(d1: int, d2: int):
+def sum_matrix(d1: int, d2: int, booltest: bool, strtest: str):
+    pipeline_parameters_block = '''
+    d1 = {}
+    d2 = {}
+    booltest = {}
+    strtest = "{}"
+    '''.format(d1, d2, booltest, strtest)
+
+    data_dir_block = '''
     import os
-    import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
     _kale_data_directory = "/marshal"
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
+    '''
+
+    data_loading_block = '''
+    import os
+    from kale.marshal import resource_load as _kale_resource_load
 
     # -----------------------DATA LOADING START--------------------------------
     _kale_directory_file_names = [
@@ -59,9 +92,19 @@ def sum_matrix(d1: int, d2: int):
     rnd_matrix = _kale_resource_load(
         os.path.join(_kale_data_directory, _kale_load_file_name))
     # -----------------------DATA LOADING END----------------------------------
-    import numpy as np
-    result = rnd_matrix.sum()
+    '''
 
+    block1 = '''
+    import numpy as np
+    '''
+
+    block2 = '''
+    result = rnd_matrix.sum()
+    '''
+
+    data_saving_block = '''
+    import os
+    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
     if "result" in locals():
         _kale_resource_save(
@@ -69,18 +112,39 @@ def sum_matrix(d1: int, d2: int):
     else:
         print("_kale_resource_save: `result` not found.")
     # -----------------------DATA SAVING END-----------------------------------
+    '''
+
+    # run the code blocks inside a jupyter kernel
+    from kale.utils.jupyter_utils import run_code as _kale_run_code
+    from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
+    blocks = (data_dir_block, pipeline_parameters_block, data_loading_block,
+              block1,
+              block2,
+              data_saving_block)
+    html_artifact = _kale_run_code(blocks)
+    with open("/sum_matrix.html", "w") as f:
+        f.write(html_artifact)
+    _kale_update_uimetadata('sum_matrix')
 
 
-def pipeline_metrics(d1: int, d2: int):
+def pipeline_metrics(d1: int, d2: int, booltest: bool, strtest: str):
+    pipeline_parameters_block = '''
+    d1 = {}
+    d2 = {}
+    booltest = {}
+    strtest = "{}"
+    '''.format(d1, d2, booltest, strtest)
+
+    data_dir_block = '''
     import os
-    import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
     _kale_data_directory = "/marshal"
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
+    '''
+
+    data_loading_block = '''
+    import os
+    from kale.marshal import resource_load as _kale_resource_load
 
     # -----------------------DATA LOADING START--------------------------------
     _kale_directory_file_names = [
@@ -103,13 +167,16 @@ def pipeline_metrics(d1: int, d2: int):
     result = _kale_resource_load(
         os.path.join(_kale_data_directory, _kale_load_file_name))
     # -----------------------DATA LOADING END----------------------------------
+    '''
+
+    block1 = '''
     import json
 
     metrics_metadata = list()
     metrics = {
-        "d1": d1,
-        "d2": d2,
-        "result": result,
+    "d1": d1,
+    "d2": d2,
+    "result": result,
     }
 
     for k in metrics:
@@ -124,13 +191,25 @@ def pipeline_metrics(d1: int, d2: int):
                       " pipeline metrics".format(k, type(k)))
                 continue
         metrics_metadata.append({
-            'name': k,
-            'numberValue': metric,
-            'format': "RAW",
-        })
+                    'name': k,
+                    'numberValue': metric,
+                    'format': "RAW",
+                })
 
     with open('/mlpipeline-metrics.json', 'w') as f:
         json.dump({'metrics': metrics_metadata}, f)
+    '''
+
+    # run the code blocks inside a jupyter kernel
+    from kale.utils.jupyter_utils import run_code as _kale_run_code
+    from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
+    blocks = (data_dir_block, pipeline_parameters_block, data_loading_block,
+              block1,
+              )
+    html_artifact = _kale_run_code(blocks)
+    with open("/pipeline_metrics.html", "w") as f:
+        f.write(html_artifact)
+    _kale_update_uimetadata('pipeline_metrics')
 
 
 create_matrix_op = comp.func_to_container_op(create_matrix)
@@ -146,7 +225,7 @@ pipeline_metrics_op = comp.func_to_container_op(pipeline_metrics)
     name='hp-test-rnd',
     description=''
 )
-def auto_generated_pipeline(d1='5', d2='6'):
+def auto_generated_pipeline(d1='5', d2='6', booltest='True', strtest='test'):
     pvolumes_dict = OrderedDict()
 
     marshal_vop = dsl.VolumeOp(
@@ -157,28 +236,39 @@ def auto_generated_pipeline(d1='5', d2='6'):
     )
     pvolumes_dict['/marshal'] = marshal_vop.volume
 
-    create_matrix_task = create_matrix_op(d1, d2)\
+    create_matrix_task = create_matrix_op(d1, d2, booltest, strtest)\
         .add_pvolumes(pvolumes_dict)\
         .after()
     create_matrix_task.container.working_dir = "/kale"
     create_matrix_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
+    output_artifacts = {}
+    output_artifacts.update(
+        {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
+    output_artifacts.update({'create_matrix': '/create_matrix.html'})
+    create_matrix_task.output_artifact_paths.update(output_artifacts)
 
-    sum_matrix_task = sum_matrix_op(d1, d2)\
+    sum_matrix_task = sum_matrix_op(d1, d2, booltest, strtest)\
         .add_pvolumes(pvolumes_dict)\
         .after(create_matrix_task)
     sum_matrix_task.container.working_dir = "/kale"
     sum_matrix_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
+    output_artifacts = {}
+    output_artifacts.update(
+        {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
+    output_artifacts.update({'sum_matrix': '/sum_matrix.html'})
+    sum_matrix_task.output_artifact_paths.update(output_artifacts)
 
-    pipeline_metrics_task = pipeline_metrics_op(d1, d2)\
+    pipeline_metrics_task = pipeline_metrics_op(d1, d2, booltest, strtest)\
         .add_pvolumes(pvolumes_dict)\
         .after(sum_matrix_task)
     pipeline_metrics_task.container.working_dir = "/kale"
     pipeline_metrics_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
-    pipeline_metrics_task.output_artifact_paths.update(
-        {'mlpipeline-metrics': '/mlpipeline-metrics.json'})
+    output_artifacts = {}
+    output_artifacts.update({'mlpipeline-metrics': '/mlpipeline-metrics.json'})
+    pipeline_metrics_task.output_artifact_paths.update(output_artifacts)
 
 
 if __name__ == "__main__":

--- a/kale/tests/assets/kfp_dsl/titanic.py
+++ b/kale/tests/assets/kfp_dsl/titanic.py
@@ -5,18 +5,16 @@ from kubernetes import client as k8s_client
 
 
 def loaddata():
+    data_dir_block = '''
     import os
-    import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
     _kale_data_directory = "/marshal"
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
+    '''
 
-    import numpy as np
-    import pandas as pd
+    block1 = '''
+    import numpy as np 
+    import pandas as pd 
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -30,13 +28,20 @@ def loaddata():
     from sklearn.neighbors import KNeighborsClassifier
     from sklearn.svm import SVC
     from sklearn.naive_bayes import GaussianNB
+    '''
+
+    block2 = '''
     path = "data/"
 
     PREDICTION_LABEL = 'Survived'
 
     test_df = pd.read_csv(path + "test.csv")
     train_df = pd.read_csv(path + "train.csv")
+    '''
 
+    data_saving_block = '''
+    import os
+    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
     if "PREDICTION_LABEL" in locals():
         _kale_resource_save(
@@ -54,18 +59,32 @@ def loaddata():
     else:
         print("_kale_resource_save: `train_df` not found.")
     # -----------------------DATA SAVING END-----------------------------------
+    '''
+
+    # run the code blocks inside a jupyter kernel
+    from kale.utils.jupyter_utils import run_code as _kale_run_code
+    from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
+    blocks = (data_dir_block,
+              block1,
+              block2,
+              data_saving_block)
+    html_artifact = _kale_run_code(blocks)
+    with open("/loaddata.html", "w") as f:
+        f.write(html_artifact)
+    _kale_update_uimetadata('loaddata')
 
 
 def datapreprocessing():
+    data_dir_block = '''
     import os
-    import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
     _kale_data_directory = "/marshal"
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
+    '''
+
+    data_loading_block = '''
+    import os
+    from kale.marshal import resource_load as _kale_resource_load
 
     # -----------------------DATA LOADING START--------------------------------
     _kale_directory_file_names = [
@@ -102,8 +121,11 @@ def datapreprocessing():
     train_df = _kale_resource_load(
         os.path.join(_kale_data_directory, _kale_load_file_name))
     # -----------------------DATA LOADING END----------------------------------
-    import numpy as np
-    import pandas as pd
+    '''
+
+    block1 = '''
+    import numpy as np 
+    import pandas as pd 
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -117,6 +139,9 @@ def datapreprocessing():
     from sklearn.neighbors import KNeighborsClassifier
     from sklearn.svm import SVC
     from sklearn.naive_bayes import GaussianNB
+    '''
+
+    block2 = '''
     data = [train_df, test_df]
     for dataset in data:
         dataset['relatives'] = dataset['SibSp'] + dataset['Parch']
@@ -124,22 +149,30 @@ def datapreprocessing():
         dataset.loc[dataset['relatives'] == 0, 'not_alone'] = 1
         dataset['not_alone'] = dataset['not_alone'].astype(int)
     train_df['not_alone'].value_counts()
+    '''
+
+    block3 = '''
     # This does not contribute to a person survival probability
     train_df = train_df.drop(['PassengerId'], axis=1)
+    '''
+
+    block4 = '''
     import re
     deck = {"A": 1, "B": 2, "C": 3, "D": 4, "E": 5, "F": 6, "G": 7, "U": 8}
     data = [train_df, test_df]
 
     for dataset in data:
         dataset['Cabin'] = dataset['Cabin'].fillna("U0")
-        dataset['Deck'] = dataset['Cabin'].map(
-            lambda x: re.compile("([a-zA-Z]+)").search(x).group())
+        dataset['Deck'] = dataset['Cabin'].map(lambda x: re.compile("([a-zA-Z]+)").search(x).group())
         dataset['Deck'] = dataset['Deck'].map(deck)
         dataset['Deck'] = dataset['Deck'].fillna(0)
         dataset['Deck'] = dataset['Deck'].astype(int)
     # we can now drop the cabin feature
     train_df = train_df.drop(['Cabin'], axis=1)
     test_df = test_df.drop(['Cabin'], axis=1)
+    '''
+
+    block5 = '''
     data = [train_df, test_df]
 
     for dataset in data:
@@ -147,22 +180,35 @@ def datapreprocessing():
         std = test_df["Age"].std()
         is_null = dataset["Age"].isnull().sum()
         # compute random numbers between the mean, std and is_null
-        rand_age = np.random.randint(mean - std, mean + std, size=is_null)
+        rand_age = np.random.randint(mean - std, mean + std, size = is_null)
         # fill NaN values in Age column with random values generated
         age_slice = dataset["Age"].copy()
         age_slice[np.isnan(age_slice)] = rand_age
         dataset["Age"] = age_slice
         dataset["Age"] = train_df["Age"].astype(int)
     train_df["Age"].isnull().sum()
+    '''
+
+    block6 = '''
     train_df['Embarked'].describe()
+    '''
+
+    block7 = '''
     # fill with most common value
     common_value = 'S'
     data = [train_df, test_df]
 
     for dataset in data:
         dataset['Embarked'] = dataset['Embarked'].fillna(common_value)
-    train_df.info()
+    '''
 
+    block8 = '''
+    train_df.info()
+    '''
+
+    data_saving_block = '''
+    import os
+    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
     if "test_df" in locals():
         _kale_resource_save(
@@ -175,18 +221,38 @@ def datapreprocessing():
     else:
         print("_kale_resource_save: `train_df` not found.")
     # -----------------------DATA SAVING END-----------------------------------
+    '''
+
+    # run the code blocks inside a jupyter kernel
+    from kale.utils.jupyter_utils import run_code as _kale_run_code
+    from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
+    blocks = (data_dir_block, data_loading_block,
+              block1,
+              block2,
+              block3,
+              block4,
+              block5,
+              block6,
+              block7,
+              block8,
+              data_saving_block)
+    html_artifact = _kale_run_code(blocks)
+    with open("/datapreprocessing.html", "w") as f:
+        f.write(html_artifact)
+    _kale_update_uimetadata('datapreprocessing')
 
 
 def featureengineering():
+    data_dir_block = '''
     import os
-    import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
     _kale_data_directory = "/marshal"
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
+    '''
+
+    data_loading_block = '''
+    import os
+    from kale.marshal import resource_load as _kale_resource_load
 
     # -----------------------DATA LOADING START--------------------------------
     _kale_directory_file_names = [
@@ -237,8 +303,11 @@ def featureengineering():
     train_df = _kale_resource_load(
         os.path.join(_kale_data_directory, _kale_load_file_name))
     # -----------------------DATA LOADING END----------------------------------
-    import numpy as np
-    import pandas as pd
+    '''
+
+    block1 = '''
+    import numpy as np 
+    import pandas as pd 
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -252,21 +321,26 @@ def featureengineering():
     from sklearn.neighbors import KNeighborsClassifier
     from sklearn.svm import SVC
     from sklearn.naive_bayes import GaussianNB
+    '''
+
+    block2 = '''
     data = [train_df, test_df]
 
     for dataset in data:
         dataset['Fare'] = dataset['Fare'].fillna(0)
         dataset['Fare'] = dataset['Fare'].astype(int)
+    '''
+
+    block3 = '''
     data = [train_df, test_df]
     titles = {"Mr": 1, "Miss": 2, "Mrs": 3, "Master": 4, "Rare": 5}
 
     for dataset in data:
         # extract titles
-        dataset['Title'] = dataset.Name.str.extract(
-            ' ([A-Za-z]+)\.', expand=False)
+        dataset['Title'] = dataset.Name.str.extract(' ([A-Za-z]+)\.', expand=False)
         # replace titles with a more common title or as Rare
-        dataset['Title'] = dataset['Title'].replace(['Lady', 'Countess', 'Capt', 'Col', 'Don', 'Dr',
-                                                     'Major', 'Rev', 'Sir', 'Jonkheer', 'Dona'], 'Rare')
+        dataset['Title'] = dataset['Title'].replace(['Lady', 'Countess','Capt', 'Col','Don', 'Dr',\
+                                                'Major', 'Rev', 'Sir', 'Jonkheer', 'Dona'], 'Rare')
         dataset['Title'] = dataset['Title'].replace('Mlle', 'Miss')
         dataset['Title'] = dataset['Title'].replace('Ms', 'Miss')
         dataset['Title'] = dataset['Title'].replace('Mme', 'Mrs')
@@ -276,56 +350,80 @@ def featureengineering():
         dataset['Title'] = dataset['Title'].fillna(0)
     train_df = train_df.drop(['Name'], axis=1)
     test_df = test_df.drop(['Name'], axis=1)
+    '''
+
+    block4 = '''
     genders = {"male": 0, "female": 1}
     data = [train_df, test_df]
 
     for dataset in data:
         dataset['Sex'] = dataset['Sex'].map(genders)
+    '''
+
+    block5 = '''
     train_df = train_df.drop(['Ticket'], axis=1)
     test_df = test_df.drop(['Ticket'], axis=1)
+    '''
+
+    block6 = '''
     ports = {"S": 0, "C": 1, "Q": 2}
     data = [train_df, test_df]
 
     for dataset in data:
         dataset['Embarked'] = dataset['Embarked'].map(ports)
+    '''
+
+    block7 = '''
     data = [train_df, test_df]
     for dataset in data:
         dataset['Age'] = dataset['Age'].astype(int)
-        dataset.loc[dataset['Age'] <= 11, 'Age'] = 0
+        dataset.loc[ dataset['Age'] <= 11, 'Age'] = 0
         dataset.loc[(dataset['Age'] > 11) & (dataset['Age'] <= 18), 'Age'] = 1
         dataset.loc[(dataset['Age'] > 18) & (dataset['Age'] <= 22), 'Age'] = 2
         dataset.loc[(dataset['Age'] > 22) & (dataset['Age'] <= 27), 'Age'] = 3
         dataset.loc[(dataset['Age'] > 27) & (dataset['Age'] <= 33), 'Age'] = 4
         dataset.loc[(dataset['Age'] > 33) & (dataset['Age'] <= 40), 'Age'] = 5
         dataset.loc[(dataset['Age'] > 40) & (dataset['Age'] <= 66), 'Age'] = 6
-        dataset.loc[dataset['Age'] > 66, 'Age'] = 6
+        dataset.loc[ dataset['Age'] > 66, 'Age'] = 6
 
     # let's see how it's distributed train_df['Age'].value_counts()
+    '''
+
+    block8 = '''
     data = [train_df, test_df]
 
     for dataset in data:
-        dataset.loc[dataset['Fare'] <= 7.91, 'Fare'] = 0
-        dataset.loc[(dataset['Fare'] > 7.91) & (
-            dataset['Fare'] <= 14.454), 'Fare'] = 1
-        dataset.loc[(dataset['Fare'] > 14.454) & (
-            dataset['Fare'] <= 31), 'Fare'] = 2
-        dataset.loc[(dataset['Fare'] > 31) & (
-            dataset['Fare'] <= 99), 'Fare'] = 3
-        dataset.loc[(dataset['Fare'] > 99) & (
-            dataset['Fare'] <= 250), 'Fare'] = 4
-        dataset.loc[dataset['Fare'] > 250, 'Fare'] = 5
+        dataset.loc[ dataset['Fare'] <= 7.91, 'Fare'] = 0
+        dataset.loc[(dataset['Fare'] > 7.91) & (dataset['Fare'] <= 14.454), 'Fare'] = 1
+        dataset.loc[(dataset['Fare'] > 14.454) & (dataset['Fare'] <= 31), 'Fare']   = 2
+        dataset.loc[(dataset['Fare'] > 31) & (dataset['Fare'] <= 99), 'Fare']   = 3
+        dataset.loc[(dataset['Fare'] > 99) & (dataset['Fare'] <= 250), 'Fare']   = 4
+        dataset.loc[ dataset['Fare'] > 250, 'Fare'] = 5
         dataset['Fare'] = dataset['Fare'].astype(int)
+    '''
+
+    block9 = '''
     data = [train_df, test_df]
     for dataset in data:
-        dataset['Age_Class'] = dataset['Age'] * dataset['Pclass']
+        dataset['Age_Class']= dataset['Age']* dataset['Pclass']
+    '''
+
+    block10 = '''
     for dataset in data:
         dataset['Fare_Per_Person'] = dataset['Fare']/(dataset['relatives']+1)
         dataset['Fare_Per_Person'] = dataset['Fare_Per_Person'].astype(int)
     # Let's take a last look at the training set, before we start training the models.
     train_df.head(10)
+    '''
+
+    block11 = '''
     train_labels = train_df[PREDICTION_LABEL]
     train_df = train_df.drop(PREDICTION_LABEL, axis=1)
+    '''
 
+    data_saving_block = '''
+    import os
+    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
     if "train_df" in locals():
         _kale_resource_save(
@@ -338,18 +436,41 @@ def featureengineering():
     else:
         print("_kale_resource_save: `train_labels` not found.")
     # -----------------------DATA SAVING END-----------------------------------
+    '''
+
+    # run the code blocks inside a jupyter kernel
+    from kale.utils.jupyter_utils import run_code as _kale_run_code
+    from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
+    blocks = (data_dir_block, data_loading_block,
+              block1,
+              block2,
+              block3,
+              block4,
+              block5,
+              block6,
+              block7,
+              block8,
+              block9,
+              block10,
+              block11,
+              data_saving_block)
+    html_artifact = _kale_run_code(blocks)
+    with open("/featureengineering.html", "w") as f:
+        f.write(html_artifact)
+    _kale_update_uimetadata('featureengineering')
 
 
 def decisiontree():
+    data_dir_block = '''
     import os
-    import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
     _kale_data_directory = "/marshal"
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
+    '''
+
+    data_loading_block = '''
+    import os
+    from kale.marshal import resource_load as _kale_resource_load
 
     # -----------------------DATA LOADING START--------------------------------
     _kale_directory_file_names = [
@@ -386,8 +507,11 @@ def decisiontree():
     train_labels = _kale_resource_load(
         os.path.join(_kale_data_directory, _kale_load_file_name))
     # -----------------------DATA LOADING END----------------------------------
-    import numpy as np
-    import pandas as pd
+    '''
+
+    block1 = '''
+    import numpy as np 
+    import pandas as pd 
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -401,11 +525,17 @@ def decisiontree():
     from sklearn.neighbors import KNeighborsClassifier
     from sklearn.svm import SVC
     from sklearn.naive_bayes import GaussianNB
+    '''
+
+    block2 = '''
     decision_tree = DecisionTreeClassifier()
     decision_tree.fit(train_df, train_labels)
-    acc_decision_tree = round(decision_tree.score(
-        train_df, train_labels) * 100, 2)
+    acc_decision_tree = round(decision_tree.score(train_df, train_labels) * 100, 2)
+    '''
 
+    data_saving_block = '''
+    import os
+    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
     if "acc_decision_tree" in locals():
         _kale_resource_save(
@@ -413,18 +543,32 @@ def decisiontree():
     else:
         print("_kale_resource_save: `acc_decision_tree` not found.")
     # -----------------------DATA SAVING END-----------------------------------
+    '''
+
+    # run the code blocks inside a jupyter kernel
+    from kale.utils.jupyter_utils import run_code as _kale_run_code
+    from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
+    blocks = (data_dir_block, data_loading_block,
+              block1,
+              block2,
+              data_saving_block)
+    html_artifact = _kale_run_code(blocks)
+    with open("/decisiontree.html", "w") as f:
+        f.write(html_artifact)
+    _kale_update_uimetadata('decisiontree')
 
 
 def svm():
+    data_dir_block = '''
     import os
-    import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
     _kale_data_directory = "/marshal"
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
+    '''
+
+    data_loading_block = '''
+    import os
+    from kale.marshal import resource_load as _kale_resource_load
 
     # -----------------------DATA LOADING START--------------------------------
     _kale_directory_file_names = [
@@ -461,8 +605,11 @@ def svm():
     train_labels = _kale_resource_load(
         os.path.join(_kale_data_directory, _kale_load_file_name))
     # -----------------------DATA LOADING END----------------------------------
-    import numpy as np
-    import pandas as pd
+    '''
+
+    block1 = '''
+    import numpy as np 
+    import pandas as pd 
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -476,10 +623,17 @@ def svm():
     from sklearn.neighbors import KNeighborsClassifier
     from sklearn.svm import SVC
     from sklearn.naive_bayes import GaussianNB
+    '''
+
+    block2 = '''
     linear_svc = SVC(gamma='auto')
     linear_svc.fit(train_df, train_labels)
     acc_linear_svc = round(linear_svc.score(train_df, train_labels) * 100, 2)
+    '''
 
+    data_saving_block = '''
+    import os
+    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
     if "acc_linear_svc" in locals():
         _kale_resource_save(
@@ -487,18 +641,32 @@ def svm():
     else:
         print("_kale_resource_save: `acc_linear_svc` not found.")
     # -----------------------DATA SAVING END-----------------------------------
+    '''
+
+    # run the code blocks inside a jupyter kernel
+    from kale.utils.jupyter_utils import run_code as _kale_run_code
+    from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
+    blocks = (data_dir_block, data_loading_block,
+              block1,
+              block2,
+              data_saving_block)
+    html_artifact = _kale_run_code(blocks)
+    with open("/svm.html", "w") as f:
+        f.write(html_artifact)
+    _kale_update_uimetadata('svm')
 
 
 def naivebayes():
+    data_dir_block = '''
     import os
-    import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
     _kale_data_directory = "/marshal"
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
+    '''
+
+    data_loading_block = '''
+    import os
+    from kale.marshal import resource_load as _kale_resource_load
 
     # -----------------------DATA LOADING START--------------------------------
     _kale_directory_file_names = [
@@ -535,8 +703,11 @@ def naivebayes():
     train_labels = _kale_resource_load(
         os.path.join(_kale_data_directory, _kale_load_file_name))
     # -----------------------DATA LOADING END----------------------------------
-    import numpy as np
-    import pandas as pd
+    '''
+
+    block1 = '''
+    import numpy as np 
+    import pandas as pd 
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -550,10 +721,17 @@ def naivebayes():
     from sklearn.neighbors import KNeighborsClassifier
     from sklearn.svm import SVC
     from sklearn.naive_bayes import GaussianNB
+    '''
+
+    block2 = '''
     gaussian = GaussianNB()
     gaussian.fit(train_df, train_labels)
     acc_gaussian = round(gaussian.score(train_df, train_labels) * 100, 2)
+    '''
 
+    data_saving_block = '''
+    import os
+    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
     if "acc_gaussian" in locals():
         _kale_resource_save(
@@ -561,18 +739,32 @@ def naivebayes():
     else:
         print("_kale_resource_save: `acc_gaussian` not found.")
     # -----------------------DATA SAVING END-----------------------------------
+    '''
+
+    # run the code blocks inside a jupyter kernel
+    from kale.utils.jupyter_utils import run_code as _kale_run_code
+    from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
+    blocks = (data_dir_block, data_loading_block,
+              block1,
+              block2,
+              data_saving_block)
+    html_artifact = _kale_run_code(blocks)
+    with open("/naivebayes.html", "w") as f:
+        f.write(html_artifact)
+    _kale_update_uimetadata('naivebayes')
 
 
 def logisticregression():
+    data_dir_block = '''
     import os
-    import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
     _kale_data_directory = "/marshal"
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
+    '''
+
+    data_loading_block = '''
+    import os
+    from kale.marshal import resource_load as _kale_resource_load
 
     # -----------------------DATA LOADING START--------------------------------
     _kale_directory_file_names = [
@@ -609,8 +801,11 @@ def logisticregression():
     train_labels = _kale_resource_load(
         os.path.join(_kale_data_directory, _kale_load_file_name))
     # -----------------------DATA LOADING END----------------------------------
-    import numpy as np
-    import pandas as pd
+    '''
+
+    block1 = '''
+    import numpy as np 
+    import pandas as pd 
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -624,10 +819,17 @@ def logisticregression():
     from sklearn.neighbors import KNeighborsClassifier
     from sklearn.svm import SVC
     from sklearn.naive_bayes import GaussianNB
+    '''
+
+    block2 = '''
     logreg = LogisticRegression(solver='lbfgs', max_iter=110)
     logreg.fit(train_df, train_labels)
     acc_log = round(logreg.score(train_df, train_labels) * 100, 2)
+    '''
 
+    data_saving_block = '''
+    import os
+    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
     if "acc_log" in locals():
         _kale_resource_save(
@@ -635,18 +837,32 @@ def logisticregression():
     else:
         print("_kale_resource_save: `acc_log` not found.")
     # -----------------------DATA SAVING END-----------------------------------
+    '''
+
+    # run the code blocks inside a jupyter kernel
+    from kale.utils.jupyter_utils import run_code as _kale_run_code
+    from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
+    blocks = (data_dir_block, data_loading_block,
+              block1,
+              block2,
+              data_saving_block)
+    html_artifact = _kale_run_code(blocks)
+    with open("/logisticregression.html", "w") as f:
+        f.write(html_artifact)
+    _kale_update_uimetadata('logisticregression')
 
 
 def randomforest():
+    data_dir_block = '''
     import os
-    import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
     _kale_data_directory = "/marshal"
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
+    '''
+
+    data_loading_block = '''
+    import os
+    from kale.marshal import resource_load as _kale_resource_load
 
     # -----------------------DATA LOADING START--------------------------------
     _kale_directory_file_names = [
@@ -683,8 +899,11 @@ def randomforest():
     train_labels = _kale_resource_load(
         os.path.join(_kale_data_directory, _kale_load_file_name))
     # -----------------------DATA LOADING END----------------------------------
-    import numpy as np
-    import pandas as pd
+    '''
+
+    block1 = '''
+    import numpy as np 
+    import pandas as pd 
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -698,11 +917,17 @@ def randomforest():
     from sklearn.neighbors import KNeighborsClassifier
     from sklearn.svm import SVC
     from sklearn.naive_bayes import GaussianNB
+    '''
+
+    block2 = '''
     random_forest = RandomForestClassifier(n_estimators=100)
     random_forest.fit(train_df, train_labels)
-    acc_random_forest = round(random_forest.score(
-        train_df, train_labels) * 100, 2)
+    acc_random_forest = round(random_forest.score(train_df, train_labels) * 100, 2)
+    '''
 
+    data_saving_block = '''
+    import os
+    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
     if "acc_random_forest" in locals():
         _kale_resource_save(
@@ -710,18 +935,32 @@ def randomforest():
     else:
         print("_kale_resource_save: `acc_random_forest` not found.")
     # -----------------------DATA SAVING END-----------------------------------
+    '''
+
+    # run the code blocks inside a jupyter kernel
+    from kale.utils.jupyter_utils import run_code as _kale_run_code
+    from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
+    blocks = (data_dir_block, data_loading_block,
+              block1,
+              block2,
+              data_saving_block)
+    html_artifact = _kale_run_code(blocks)
+    with open("/randomforest.html", "w") as f:
+        f.write(html_artifact)
+    _kale_update_uimetadata('randomforest')
 
 
 def results():
+    data_dir_block = '''
     import os
-    import shutil
-    from kale.utils import pod_utils as _kale_pod_utils
-    from kale.marshal import resource_save as _kale_resource_save
-    from kale.marshal import resource_load as _kale_resource_load
-
     _kale_data_directory = "/marshal"
     if not os.path.isdir(_kale_data_directory):
         os.makedirs(_kale_data_directory, exist_ok=True)
+    '''
+
+    data_loading_block = '''
+    import os
+    from kale.marshal import resource_load as _kale_resource_load
 
     # -----------------------DATA LOADING START--------------------------------
     _kale_directory_file_names = [
@@ -800,8 +1039,11 @@ def results():
     acc_random_forest = _kale_resource_load(
         os.path.join(_kale_data_directory, _kale_load_file_name))
     # -----------------------DATA LOADING END----------------------------------
-    import numpy as np
-    import pandas as pd
+    '''
+
+    block1 = '''
+    import numpy as np 
+    import pandas as pd 
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -815,14 +1057,30 @@ def results():
     from sklearn.neighbors import KNeighborsClassifier
     from sklearn.svm import SVC
     from sklearn.naive_bayes import GaussianNB
+    '''
+
+    block2 = '''
     results = pd.DataFrame({
-        'Model': ['Support Vector Machines', 'logistic Regression',
+        'Model': ['Support Vector Machines', 'logistic Regression', 
                   'Random Forest', 'Naive Bayes', 'Decision Tree'],
-        'Score': [acc_linear_svc, acc_log,
+        'Score': [acc_linear_svc, acc_log, 
                   acc_random_forest, acc_gaussian, acc_decision_tree]})
     result_df = results.sort_values(by='Score', ascending=False)
     result_df = result_df.set_index('Score')
     print(result_df)
+    '''
+
+    # run the code blocks inside a jupyter kernel
+    from kale.utils.jupyter_utils import run_code as _kale_run_code
+    from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
+    blocks = (data_dir_block, data_loading_block,
+              block1,
+              block2,
+              )
+    html_artifact = _kale_run_code(blocks)
+    with open("/results.html", "w") as f:
+        f.write(html_artifact)
+    _kale_update_uimetadata('results')
 
 
 loaddata_op = comp.func_to_container_op(loaddata)
@@ -873,6 +1131,11 @@ def auto_generated_pipeline():
     loaddata_task.container.working_dir = "/kale"
     loaddata_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
+    output_artifacts = {}
+    output_artifacts.update(
+        {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
+    output_artifacts.update({'loaddata': '/loaddata.html'})
+    loaddata_task.output_artifact_paths.update(output_artifacts)
 
     datapreprocessing_task = datapreprocessing_op()\
         .add_pvolumes(pvolumes_dict)\
@@ -880,6 +1143,11 @@ def auto_generated_pipeline():
     datapreprocessing_task.container.working_dir = "/kale"
     datapreprocessing_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
+    output_artifacts = {}
+    output_artifacts.update(
+        {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
+    output_artifacts.update({'datapreprocessing': '/datapreprocessing.html'})
+    datapreprocessing_task.output_artifact_paths.update(output_artifacts)
 
     featureengineering_task = featureengineering_op()\
         .add_pvolumes(pvolumes_dict)\
@@ -887,6 +1155,11 @@ def auto_generated_pipeline():
     featureengineering_task.container.working_dir = "/kale"
     featureengineering_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
+    output_artifacts = {}
+    output_artifacts.update(
+        {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
+    output_artifacts.update({'featureengineering': '/featureengineering.html'})
+    featureengineering_task.output_artifact_paths.update(output_artifacts)
 
     decisiontree_task = decisiontree_op()\
         .add_pvolumes(pvolumes_dict)\
@@ -894,6 +1167,11 @@ def auto_generated_pipeline():
     decisiontree_task.container.working_dir = "/kale"
     decisiontree_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
+    output_artifacts = {}
+    output_artifacts.update(
+        {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
+    output_artifacts.update({'decisiontree': '/decisiontree.html'})
+    decisiontree_task.output_artifact_paths.update(output_artifacts)
 
     svm_task = svm_op()\
         .add_pvolumes(pvolumes_dict)\
@@ -901,6 +1179,11 @@ def auto_generated_pipeline():
     svm_task.container.working_dir = "/kale"
     svm_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
+    output_artifacts = {}
+    output_artifacts.update(
+        {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
+    output_artifacts.update({'svm': '/svm.html'})
+    svm_task.output_artifact_paths.update(output_artifacts)
 
     naivebayes_task = naivebayes_op()\
         .add_pvolumes(pvolumes_dict)\
@@ -908,6 +1191,11 @@ def auto_generated_pipeline():
     naivebayes_task.container.working_dir = "/kale"
     naivebayes_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
+    output_artifacts = {}
+    output_artifacts.update(
+        {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
+    output_artifacts.update({'naivebayes': '/naivebayes.html'})
+    naivebayes_task.output_artifact_paths.update(output_artifacts)
 
     logisticregression_task = logisticregression_op()\
         .add_pvolumes(pvolumes_dict)\
@@ -915,6 +1203,11 @@ def auto_generated_pipeline():
     logisticregression_task.container.working_dir = "/kale"
     logisticregression_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
+    output_artifacts = {}
+    output_artifacts.update(
+        {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
+    output_artifacts.update({'logisticregression': '/logisticregression.html'})
+    logisticregression_task.output_artifact_paths.update(output_artifacts)
 
     randomforest_task = randomforest_op()\
         .add_pvolumes(pvolumes_dict)\
@@ -922,6 +1215,11 @@ def auto_generated_pipeline():
     randomforest_task.container.working_dir = "/kale"
     randomforest_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
+    output_artifacts = {}
+    output_artifacts.update(
+        {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
+    output_artifacts.update({'randomforest': '/randomforest.html'})
+    randomforest_task.output_artifact_paths.update(output_artifacts)
 
     results_task = results_op()\
         .add_pvolumes(pvolumes_dict)\
@@ -929,6 +1227,11 @@ def auto_generated_pipeline():
     results_task.container.working_dir = "/kale"
     results_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
+    output_artifacts = {}
+    output_artifacts.update(
+        {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
+    output_artifacts.update({'results': '/results.html'})
+    results_task.output_artifact_paths.update(output_artifacts)
 
 
 if __name__ == "__main__":

--- a/kale/tests/assets/notebooks/pipeline_parameters_and_metrics.ipynb
+++ b/kale/tests/assets/notebooks/pipeline_parameters_and_metrics.ipynb
@@ -24,7 +24,9 @@
    "outputs": [],
    "source": [
     "d1 = 5\n",
-    "d2 = 6"
+    "d2 = 6\n",
+    "booltest = True\n",
+    "strtest = 'test'"
    ]
   },
   {
@@ -83,6 +85,7 @@
     "name": "hp tuning"
    },
    "experiment_name": "hp tuning",
+   "katib_run": false,
    "pipeline_description": "",
    "pipeline_name": "hp-test",
    "volumes": []

--- a/kale/tests/unit_tests/test_generate_code.py
+++ b/kale/tests/unit_tests/test_generate_code.py
@@ -127,20 +127,21 @@ def template():
 
 
 @pytest.mark.parametrize('step_name,source,ins,outs,nb_path,metadata,target', [
-    ('test', '', '', '', '', {}, 'func01.out.py'),
+    ('test', [], '', '', '', {}, 'func01.out.py'),
     # ---
-    ('test', '', '', '', '', {'function_args': 'arg1, arg2, arg3'},
+    ('test', [], '', '', '', {'function_args': 'arg1, arg2, arg3'},
      'func02.out.py'),
     # ---
-    ('test', '', '', '', '/path/to/nb',
+    ('test', [], '', '', '/path/to/nb',
      {'marshal_path': '/path', 'auto_snapshot': True, 'pipeline_name': 'T'},
      'func03.out.py'),
     # ---
-    ('test', '', ['v1'], '', '', {}, 'func04.out.py'),
+    ('test', [], ['v1'], '', '', {}, 'func04.out.py'),
     # ---
-    ('test', 'v1 = "Hello"\nprint(v1)', '', ['v1'], '', {}, 'func05.out.py'),
+    ('test', ['v1 = "Hello"', 'print(v1)'], '', ['v1'], '', {},
+     'func05.out.py'),
     # ---
-    ('test', 'print("hello")', '', '', '', {}, 'func06.out.py')
+    ('test', ['print("hello")'], '', '', '', {}, 'func06.out.py')
 ])
 def test_generate_function(template, step_name, source, ins, outs, nb_path,
                            metadata, target):

--- a/kale/tests/unit_tests/test_generate_code.py
+++ b/kale/tests/unit_tests/test_generate_code.py
@@ -95,23 +95,23 @@ def test_get_marshal_data(args, target):
 def _test_args_dict(f1, f2, f3):
     return {
         'pipeline_args_names': f1,
-        'pipeline_args': f2,
-        'function_args': f3
+        'pipeline_args_types': f2,
+        'pipeline_args_values': f3
     }
 
 
 @pytest.mark.parametrize("pipeline_parameters,target", [
     ({},
-     _test_args_dict('', '', '')),
+     _test_args_dict([], [], [])),
     # ---
     ({'param1': ('str', 'v1')},
-     _test_args_dict('param1', "param1='v1'", 'param1: str')),
+     _test_args_dict(["param1"], ["str"], ["v1"])),
     # ---
     ({'param1': ('int', 1)},
-     _test_args_dict('param1', "param1='1'", 'param1: int')),
+     _test_args_dict(["param1"], ["int"], [1])),
     # ---
-    ({'p1': ('int', 1), 'p2': ('str', 'v')},
-     _test_args_dict('p1, p2', "p1='1', p2='v'", 'p1: int, p2: str')),
+    ({'p1': ('int', 1), 'p2': ('str', 'v'), 'p3': ('bool', True)},
+     _test_args_dict(["p1", "p2", "p3"], ["int", "str", "bool"], [1, "v", True])),
 ])
 def test_get_args(pipeline_parameters, target):
     """Test that argument string are properly formatted"""
@@ -129,7 +129,8 @@ def template():
 @pytest.mark.parametrize('step_name,source,ins,outs,nb_path,metadata,target', [
     ('test', [], '', '', '', {}, 'func01.out.py'),
     # ---
-    ('test', [], '', '', '', {'function_args': 'arg1, arg2, arg3'},
+    ('test', [], '', '', '', {'pipeline_args_names': ['arg1', 'arg2', 'arg3'],
+                              'pipeline_args_types': ['int', 'str', 'str']},
      'func02.out.py'),
     # ---
     ('test', [], '', '', '/path/to/nb',

--- a/kale/tests/unit_tests/test_jupyter_utils.py
+++ b/kale/tests/unit_tests/test_jupyter_utils.py
@@ -1,0 +1,119 @@
+import os
+import json
+import pytest
+
+from testfixtures import mock
+from kale.utils import jupyter_utils as ju
+
+
+def _output_display(data):
+    # `data` must be a list
+    return [{'output_type': 'display_data', 'data': data}]
+
+
+@pytest.mark.parametrize("outputs,target", [
+    ([], ""),
+    # ---
+    (_output_display({'image/png': "bytes"}),
+     ju.image_html_template.format("", "bytes")),
+    # ---
+    (_output_display({'text/html': "bytes"}), "bytes"),
+    # ---
+    (_output_display({'text/plain': "bytes"}),
+     ju.text_html_template.format("bytes")),
+    # ---
+    (_output_display({'application/javascript': "bytes"}),
+     ju.javascript_html_template.format("bytes")),
+])
+def test_generate_html_output(outputs, target):
+    """Tests html artifact generation from cell outputs."""
+    assert target == ju.generate_html_output(outputs)
+
+
+@mock.patch('kale.utils.jupyter_utils.pod_utils')
+def test_update_uimetadata_not_exists(pod_utils, tmpdir):
+    """Test the uimetadata file is created when it does not exists."""
+    pod_utils.get_pod_name.return_value = 'test_pod'
+    pod_utils.get_namespace.return_value = 'test_ns'
+    pod_utils.get_workflow_name.return_value = 'test_wk'
+
+    filepath = os.path.join(tmpdir, 'tmp_uimetadata.json')
+
+    # update tmp file
+    ju.update_uimetadata('test', uimetadata_path=filepath)
+
+    # check file has been updated correctly
+    updated = json.loads(open(filepath).read())
+    target = {"outputs": [{
+        'type': 'web-app',
+        'storage': 'minio',
+        'source': 'minio://mlpipeline/artifacts/test_wk/test_pod/test.tgz'
+    }]}
+    assert updated == target
+
+
+@mock.patch('kale.utils.jupyter_utils.pod_utils')
+def test_update_uimetadata_from_empty(pod_utils, tmpdir):
+    """Test that the uimetadata file is updated inplace correctly."""
+    pod_utils.get_pod_name.return_value = 'test_pod'
+    pod_utils.get_namespace.return_value = 'test_ns'
+    pod_utils.get_workflow_name.return_value = 'test_wk'
+
+    # create base tmp file
+    base = {"outputs": []}
+    filepath = os.path.join(tmpdir, 'tmp_uimetadata.json')
+    json.dump(base, open(filepath, 'w'))
+
+    # update tmp file
+    ju.update_uimetadata('test', uimetadata_path=filepath)
+
+    # check file has been updated correctly
+    updated = json.loads(open(filepath).read())
+    target = {"outputs": [{
+        'type': 'web-app',
+        'storage': 'minio',
+        'source': 'minio://mlpipeline/artifacts/test_wk/test_pod/test.tgz'
+    }]}
+    assert updated == target
+
+
+@mock.patch('kale.utils.jupyter_utils.pod_utils')
+def test_update_uimetadata_from_not_empty(pod_utils, tmpdir):
+    """Test that the uimetadata file is updated inplace correctly."""
+    pod_utils.get_pod_name.return_value = 'test_pod'
+    pod_utils.get_namespace.return_value = 'test_ns'
+    pod_utils.get_workflow_name.return_value = 'test_wk'
+
+    # create base tmp file
+    markdown = {
+        'type': 'markdown',
+        'storage': 'inline',
+        'source': '#Some markdown'
+    }
+    base = {"outputs": [markdown]}
+    filepath = os.path.join(tmpdir, 'tmp_uimetadata.json')
+    json.dump(base, open(filepath, 'w'))
+
+    # update tmp file
+    ju.update_uimetadata('test', uimetadata_path=filepath)
+
+    # check file has been updated correctly
+    updated = json.loads(open(filepath).read())
+    target = {"outputs": [markdown, {
+        'type': 'web-app',
+        'storage': 'minio',
+        'source': 'minio://mlpipeline/artifacts/test_wk/test_pod/test.tgz'
+    }]}
+    assert updated == target
+
+
+@mock.patch('kale.utils.jupyter_utils.process_outputs', new=lambda x: x)
+def test_run_code():
+    """Test that Python code runs inside a jupyter kernel successfully."""
+    # test standard code
+    code = ("a = 3\nprint(a)", )
+    ju.run_code(code)
+
+    # test magic command
+    code = ("%%time\nprint('Some dull code')", )
+    ju.run_code(code)

--- a/kale/tests/unit_tests/test_utils.py
+++ b/kale/tests/unit_tests/test_utils.py
@@ -1,0 +1,27 @@
+from kale.utils import utils
+
+
+def test_comment_magic_commands():
+    """Test the magic utils properly comments a multiline code block."""
+    code = '''
+%%a magic cell command
+some code
+%matplotlib inline
+%consecutive command
+some other code
+some other code
+%another command
+some other code
+    '''
+
+    target = '''
+#%%a magic cell command
+some code
+#%matplotlib inline
+#%consecutive command
+some other code
+some other code
+#%another command
+some other code
+    '''
+    assert utils.comment_magic_commands(code) == target.strip()

--- a/kale/utils/jupyter_utils.py
+++ b/kale/utils/jupyter_utils.py
@@ -6,6 +6,7 @@ import threading
 
 from queue import Empty
 from jupyter_client.kernelspec import get_kernel_spec
+from kale.utils.utils import remove_ansi_color_sequences
 from nbconvert.preprocessors.execute import ExecutePreprocessor
 
 
@@ -45,9 +46,8 @@ def capture_streams(kc, exit_on_error=False, timeout=10):
                         "stream message content name not recognized: %s"
                         % content['name'])
             if msg_type == 'error':  # error and exceptions
-                sys.stderr.write('\n'.join(content['traceback']) + '\n')
-                sys.stderr.write(
-                    "%s: %s" % (content['ename'], content['evalue']))
+                traceback = remove_ansi_color_sequences(content['traceback'])
+                sys.stderr.write('\n'.join(traceback) + '\n')
                 if exit_on_error:
                     # when receiving an error from the kernel, we don't want
                     # to just print the exception to stderr, otherwise the

--- a/kale/utils/jupyter_utils.py
+++ b/kale/utils/jupyter_utils.py
@@ -1,0 +1,38 @@
+import nbformat
+
+from jupyter_client.kernelspec import get_kernel_spec
+from nbconvert.preprocessors.execute import ExecutePreprocessor
+
+
+def run_code(source: tuple, kernel_name='python3'):
+    # new notebook
+    spec = get_kernel_spec(kernel_name)
+    notebook = nbformat.v4.new_notebook(metadata={
+        'kernelspec': {
+            'display_name': spec.display_name,
+            'language': spec.language,
+            'name': kernel_name,
+        }})
+    notebook.cells = [nbformat.v4.new_code_cell(s) for s in source]
+    # these parameters are passed to nbconvert.ExecutePreprocessor
+    jupyter_execute_kwargs = dict(
+        timeout=-1, allow_errors=True, store_widget_state=True)
+
+    resources = {}
+    # cwd: If supplied, the kernel will run in this directory
+    # resources['metadata'] = {'path': cwd}
+    ep = ExecutePreprocessor(**jupyter_execute_kwargs)
+    km = ep.kernel_manager_class(kernel_name=kernel_name, config=ep.config)
+    # start_kernel supports several additional arguments via **kw
+    km.start_kernel(extra_arguments=ep.extra_arguments)
+    kc = km.client()
+    kc.start_channels()
+    try:
+        kc.wait_for_ready(timeout=60)
+    except RuntimeError:
+        kc.stop_channels()
+        raise
+    kc.allow_stdin = False
+
+    # start preprocessor: run each code cell and capture the output
+    ep.preprocess(notebook, resources, km=km)

--- a/kale/utils/jupyter_utils.py
+++ b/kale/utils/jupyter_utils.py
@@ -41,22 +41,22 @@ html_template = '''
     </style>
 </head>
 <body><div>
-    %s
+{}
 </div></body>
 </html>
 '''
 
 image_html_template = '''
 <div>
-  <p>%s</p>
-  <img src="data:image/png;base64, %s" />
+  <p>{}</p>
+  <img src="data:image/png;base64, {}" />
 </div>
 '''
 
 text_html_template = '''
 <pre>
 ------- CELL OUTPUT -------
-%s
+{}
 ---------------------------
 </pre>
 <br><br>
@@ -64,7 +64,7 @@ text_html_template = '''
 
 javascript_html_template = '''
 <script>
-%s
+{}
 </script>
 '''
 
@@ -84,7 +84,7 @@ def generate_html_output(outputs):
     """
     if not isinstance(outputs, list):
         raise ValueError("A notebook's cell outputs must be a valid list."
-                         " Found %s instead." % type(outputs))
+                         " Found {} instead.".format(type(outputs)))
     html_body = ""
     # run through the list of outputs
     for o in outputs:
@@ -94,7 +94,7 @@ def generate_html_output(outputs):
         output_type = o.get('output_type', None)
         if not output_type:
             raise ValueError("Cell output dict has not `output_type` field."
-                             " Output: %s" % o)
+                             " Output: {}".format(o))
         if o['output_type'] in ['display_data', 'execute_result']:
             # check mime-type of content
             # Currently supported MIME types:
@@ -112,20 +112,20 @@ def generate_html_output(outputs):
             # TODO: Generalize to multiple image types (i.e. jpeg and svg+xml)
             if 'image/png' in data:
                 title = data.get('text/plain', '')
-                html = image_html_template % (title, data['image/png'])
+                html = image_html_template.format(title, data['image/png'])
                 html_body += html
 
             if 'text/html' in data:
                 html_body += data['text/html']
 
-            if 'image/png' not in data \
-                    and 'text/html' not in data \
-                    and 'text/plain' in data:
-                html_body += text_html_template % data['text/plain']
+            if ('image/png' not in data
+                    and 'text/html' not in data
+                    and 'text/plain' in data):
+                html_body += text_html_template.format(data['text/plain'])
 
             if 'application/javascript' in data:
-                html_body += javascript_html_template \
-                             % data['application/javascript']
+                html_body += javascript_html_template.format(
+                    data['application/javascript'])
     return html_body
 
 
@@ -146,9 +146,9 @@ def update_uimetadata(artifact_name,
             if not outputs.get('outputs', None):
                 outputs['outputs'] = []
         except json.JSONDecodeError as e:
-            print("Failed to parse json file %s: %s\n"
+            print("Failed to parse json file {}: {}\n"
                   "This step will not be able to visualize artifacts in the"
-                  " KFP UI" % uimetadata_path, e)
+                  " KFP UI".format(uimetadata_path, e))
 
     pod_name = pod_utils.get_pod_name()
     namespace = pod_utils.get_namespace()
@@ -156,7 +156,7 @@ def update_uimetadata(artifact_name,
     html_artifact_entry = [{
         'type': 'web-app',
         'storage': 'minio',
-        'source': 'minio://mlpipeline/artifacts/%s/%s/%s' % (
+        'source': 'minio://mlpipeline/artifacts/{}/{}/{}'.format(
             workflow_name, pod_name, artifact_name + '.tgz')
     }]
     outputs['outputs'] += html_artifact_entry
@@ -202,9 +202,9 @@ def capture_streams(kc, exit_on_error=False, timeout=10):
                 elif content['name'] == 'stderr':
                     sys.stderr.write(content['text'])
                 else:
-                    raise NotImplementedError(
-                        "stream message content name not recognized: %s"
-                        % content['name'])
+                    raise NotImplementedError("stream message content name not"
+                                              " recognized: {}"
+                                              .format(content['name']))
             if msg_type == 'error':  # error and exceptions
                 traceback = remove_ansi_color_sequences(content['traceback'])
                 sys.stderr.write('\n'.join(traceback) + '\n')
@@ -227,9 +227,9 @@ def run_code(source: tuple, kernel_name='python3'):
     """
     import IPython
     if IPython.__version__ < '7.6.0':
-        raise RuntimeError("IPython version %s not supported."
+        raise RuntimeError("IPython version {} not supported."
                            " Kale requires at least version 7.6.0."
-                           % IPython.__version__)
+                           .format(IPython.__version__))
 
     # new notebook
     spec = get_kernel_spec(kernel_name)

--- a/kale/utils/jupyter_utils.py
+++ b/kale/utils/jupyter_utils.py
@@ -65,6 +65,12 @@ def run_code(source: tuple, kernel_name='python3'):
         source (tuple): source code blocks
         kernel_name: name of the kernel (form the kernel spec) to be created
     """
+    import IPython
+    if IPython.__version__ < '7.6.0':
+        raise RuntimeError("IPython version %s not supported."
+                           " Kale requires at least version 7.6.0."
+                           % IPython.__version__)
+
     # new notebook
     spec = get_kernel_spec(kernel_name)
     notebook = nbformat.v4.new_notebook(metadata={

--- a/kale/utils/jupyter_utils.py
+++ b/kale/utils/jupyter_utils.py
@@ -1,10 +1,70 @@
+import os
+import sys
+import signal
 import nbformat
+import threading
 
+from queue import Empty
 from jupyter_client.kernelspec import get_kernel_spec
 from nbconvert.preprocessors.execute import ExecutePreprocessor
 
 
+class KaleKernelException(Exception):
+    """Raised when signal_handler receives a signal from capture_streams."""
+    pass
+
+
+def capture_streams(kc, exit_on_error=False, timeout=10):
+    """Capture stream and error outputs from a kernel connection.
+
+    Get messages from the iopub channel of the `kc` kernel connection
+    and write to stdout or stderr any message of type `stream`.
+    Capture and exit when receiving an `error` message or when the message
+    queue is done.
+
+    Args:
+        kc: kernel connection
+        exit_on_error (bool): True to call sys.exit() when the kernel sends
+            an error message.
+        timeout (int): number of seconds to wait before quitting the connection
+    """
+    while True:
+        try:
+            # this call will break the outer loop when more than `timeout`
+            # seconds pass without a response.
+            msg = kc.iopub_channel.get_msg(timeout=timeout)
+            msg_type = msg['header']['msg_type']
+            content = msg['content']
+            if msg_type == 'stream':  # stdout or stderr
+                if content['name'] == 'stdout':
+                    sys.stdout.write(content['text'])
+                elif content['name'] == 'stderr':
+                    sys.stderr.write(content['text'])
+                else:
+                    raise NotImplementedError(
+                        "stream message content name not recognized: %s"
+                        % content['name'])
+            if msg_type == 'error':  # error and exceptions
+                sys.stderr.write('\n'.join(content['traceback']) + '\n')
+                sys.stderr.write(
+                    "%s: %s" % (content['ename'], content['evalue']))
+                if exit_on_error:
+                    # when receiving an error from the kernel, we don't want
+                    # to just print the exception to stderr, otherwise the
+                    # pipeline step would complete successfully.
+                    # kill sends the signal to the specific pid (main thread)
+                    os.kill(os.getpid(), signal.SIGUSR1)
+        except Empty:
+            return
+
+
 def run_code(source: tuple, kernel_name='python3'):
+    """Run code blocks inside a jupyter kernel.
+
+    Args:
+        source (tuple): source code blocks
+        kernel_name: name of the kernel (form the kernel spec) to be created
+    """
     # new notebook
     spec = get_kernel_spec(kernel_name)
     notebook = nbformat.v4.new_notebook(metadata={
@@ -34,5 +94,23 @@ def run_code(source: tuple, kernel_name='python3'):
         raise
     kc.allow_stdin = False
 
-    # start preprocessor: run each code cell and capture the output
-    ep.preprocess(notebook, resources, km=km)
+    def signal_handler(_signal, _frame):
+        raise KaleKernelException()
+
+    # this signal is used by the thread in case an error message is received
+    # by the kernel. Running sys.exit() inside the thread would terminate
+    # just the thread itself, not the main process. Calling os._exit() can be
+    # dangerous as the process is killed instantly (files and connections are
+    # not closed, for example). With a signal we can capture the ExitCommand
+    # exception from the main process and exit gracefully.
+    signal.signal(signal.SIGUSR1, signal_handler)
+    # start separate thread to capture and print stdout, stderr, errors
+    x = threading.Thread(target=capture_streams, args=(kc, True,))
+    x.start()
+
+    try:
+        # start preprocessor: run each code cell and capture the output
+        ep.preprocess(notebook, resources, km=km)
+    except KaleKernelException:
+        # exit gracefully with error
+        sys.exit(-1)

--- a/kale/utils/jupyter_utils.py
+++ b/kale/utils/jupyter_utils.py
@@ -1,18 +1,178 @@
 import os
 import sys
+import json
 import signal
 import nbformat
 import threading
 
 from queue import Empty
+from kale.utils import pod_utils
 from jupyter_client.kernelspec import get_kernel_spec
 from kale.utils.utils import remove_ansi_color_sequences
 from nbconvert.preprocessors.execute import ExecutePreprocessor
+
+html_template = '''
+<html><head>
+    <style>
+        table {
+            border: none;
+            border-collapse: collapse;
+            border-spacing: 0;
+            font-size: 14px;
+        }
+        td,
+        th {
+            text-align: right;
+            vertical-align: middle;
+            padding: 0.5em 0.5em;
+            line-height: 1.0;
+            white-space: nowrap;
+            max-width: 100px;
+            text-overflow: ellipsis;
+            overflow: hidden;
+            border: none;
+        }
+        th {
+            font-weight: bold;
+        }
+        tbody tr:nth-child(odd) {
+            background: rgb(245, 245, 245);
+        }
+    </style>
+</head>
+<body><div>
+    %s
+</div></body>
+</html>
+'''
+
+image_html_template = '''
+<div>
+  <p>%s</p>
+  <img src="data:image/png;base64, %s" />
+</div>
+'''
+
+text_html_template = '''
+<pre>
+------- CELL OUTPUT -------
+%s
+---------------------------
+</pre>
+<br><br>
+'''
+
+javascript_html_template = '''
+<script>
+%s
+</script>
+'''
 
 
 class KaleKernelException(Exception):
     """Raised when signal_handler receives a signal from capture_streams."""
     pass
+
+
+def generate_html_output(outputs):
+    """Transform a notebook cell rich outputs into a html page.
+
+    Args:
+        outputs: notebook cell output
+
+    Returns: html multiline string
+    """
+    if not isinstance(outputs, list):
+        raise ValueError("A notebook's cell outputs must be a valid list."
+                         " Found %s instead." % type(outputs))
+    html_body = ""
+    # run through the list of outputs
+    for o in outputs:
+        # the only rich outputs should come from `display_data` and
+        # `execution_result` messages. The latter are identical to
+        # `display_data` messages, with the addition of an execution_count key.
+        output_type = o.get('output_type', None)
+        if not output_type:
+            raise ValueError("Cell output dict has not `output_type` field."
+                             " Output: %s" % o)
+        if o['output_type'] in ['display_data', 'execute_result']:
+            # check mime-type of content
+            # Currently supported MIME types:
+            # see: https://ipython.org/ipython-doc/2/api/generated/IPython.core.displaypub.html#IPython.core.displaypub.DisplayPublisher
+            # text / plain
+            # text / html
+            # text / markdown
+            # text / latex
+            # application / json
+            # application / javascript
+            # image / png
+            # image / jpeg
+            # image / svg + xml
+            data = o['data']
+            # TODO: Generalize to multiple image types (i.e. jpeg and svg+xml)
+            if 'image/png' in data:
+                title = data.get('text/plain', '')
+                html = image_html_template % (title, data['image/png'])
+                html_body += html
+
+            if 'text/html' in data:
+                html_body += data['text/html']
+
+            if 'image/png' not in data \
+                    and 'text/html' not in data \
+                    and 'text/plain' in data:
+                html_body += text_html_template % data['text/plain']
+
+            if 'application/javascript' in data:
+                html_body += javascript_html_template \
+                             % data['application/javascript']
+    return html_body
+
+
+def update_uimetadata(artifact_name,
+                      uimetadata_path='/mlpipeline-ui-metadata.json'):
+    """Update ui-metadata dictionary with a new web-app entry.
+
+    Args:
+        artifact_name: Name of the artifact
+        uimetadata_path: path to mlpipeline-ui-metadata.json
+    """
+    # Default empty ui-metadata dict
+    outputs = {"outputs": []}
+    if os.path.exists(uimetadata_path):
+        try:
+            outputs = json.loads(
+                open(uimetadata_path, 'r').read())
+            if not outputs.get('outputs', None):
+                outputs['outputs'] = []
+        except json.JSONDecodeError as e:
+            print("Failed to parse json file %s: %s\n"
+                  "This step will not be able to visualize artifacts in the"
+                  " KFP UI" % uimetadata_path, e)
+
+    pod_name = pod_utils.get_pod_name()
+    namespace = pod_utils.get_namespace()
+    workflow_name = pod_utils.get_workflow_name(pod_name, namespace)
+    html_artifact_entry = [{
+        'type': 'web-app',
+        'storage': 'minio',
+        'source': 'minio://mlpipeline/artifacts/%s/%s/%s' % (
+            workflow_name, pod_name, artifact_name + '.tgz')
+    }]
+    outputs['outputs'] += html_artifact_entry
+    with open(uimetadata_path, "w") as f:
+        json.dump(outputs, f)
+
+
+def process_outputs(cells):
+    """Process a list of cells outputs after execution."""
+    html_outputs = [generate_html_output(c.outputs)
+                    for c in cells]
+    html_outputs = '\n'.join(html_outputs).strip()
+    if html_outputs == "":
+        html_outputs = "This step did not produce any artifacts."
+    html_artifact = html_template % html_outputs
+    return html_artifact
 
 
 def capture_streams(kc, exit_on_error=False, timeout=10):
@@ -120,3 +280,6 @@ def run_code(source: tuple, kernel_name='python3'):
     except KaleKernelException:
         # exit gracefully with error
         sys.exit(-1)
+
+    result = process_outputs(notebook.cells)
+    return result

--- a/kale/utils/jupyter_utils.py
+++ b/kale/utils/jupyter_utils.py
@@ -11,6 +11,8 @@ from jupyter_client.kernelspec import get_kernel_spec
 from kale.utils.utils import remove_ansi_color_sequences
 from nbconvert.preprocessors.execute import ExecutePreprocessor
 
+from packaging import version as pkg_version
+
 html_template = '''
 <html><head>
     <style>
@@ -41,7 +43,7 @@ html_template = '''
     </style>
 </head>
 <body><div>
-{}
+%s
 </div></body>
 </html>
 '''
@@ -206,7 +208,9 @@ def capture_streams(kc, exit_on_error=False, timeout=10):
                                               " recognized: {}"
                                               .format(content['name']))
             if msg_type == 'error':  # error and exceptions
-                traceback = remove_ansi_color_sequences(content['traceback'])
+                # traceback is a list of strings (jupyter protocol spec)
+                traceback = map(remove_ansi_color_sequences,
+                                content['traceback'])
                 sys.stderr.write('\n'.join(traceback) + '\n')
                 if exit_on_error:
                     # when receiving an error from the kernel, we don't want
@@ -226,7 +230,7 @@ def run_code(source: tuple, kernel_name='python3'):
         kernel_name: name of the kernel (form the kernel spec) to be created
     """
     import IPython
-    if IPython.__version__ < '7.6.0':
+    if pkg_version.parse(IPython.__version__) < pkg_version.parse('7.6.0'):
         raise RuntimeError("IPython version {} not supported."
                            " Kale requires at least version 7.6.0."
                            .format(IPython.__version__))

--- a/kale/utils/pod_utils.py
+++ b/kale/utils/pod_utils.py
@@ -214,10 +214,7 @@ def snapshot_pipeline_step(pipeline, step, nb_path):
         json.dump(metadata, f)
 
 
-def get_run_uuid():
-    # Retrieve the pod
-    pod_name = get_pod_name()
-    namespace = get_namespace()
+def get_workflow_name(pod_name, namespace):
     v1_client = _get_k8s_v1_client()
     pod = v1_client.read_namespaced_pod(pod_name, namespace)
 
@@ -228,6 +225,14 @@ def get_run_uuid():
         msg = ("Could not retrieve workflow name from pod"
                "{}/{}".format(namespace, pod_name))
         raise RuntimeError(msg)
+    return workflow_name
+
+
+def get_run_uuid():
+    # Retrieve the pod
+    pod_name = get_pod_name()
+    namespace = get_namespace()
+    workflow_name = get_workflow_name(pod_name, namespace)
 
     # Retrieve the Argo workflow
     api_group = "argoproj.io"

--- a/kale/utils/utils.py
+++ b/kale/utils/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import random
 import string
 
@@ -11,3 +12,9 @@ def random_string(size=5, chars=string.ascii_lowercase + string.digits):
 def get_abs_working_dir(path):
     """Get absolute path to parent dir."""
     return os.path.dirname(os.path.abspath(path))
+
+
+def remove_ansi_color_sequences(text):
+    """Remove ANSI color sequences from text."""
+    ansi_color_escape = re.compile(r'\x1B\[[0-9;]*m')
+    return ansi_color_escape.sub('', text)

--- a/kale/utils/utils.py
+++ b/kale/utils/utils.py
@@ -18,3 +18,9 @@ def remove_ansi_color_sequences(text):
     """Remove ANSI color sequences from text."""
     ansi_color_escape = re.compile(r'\x1B\[[0-9;]*m')
     return ansi_color_escape.sub('', text)
+
+
+def comment_magic_commands(code):
+    """Comment the magic commands in a code block."""
+    magic_pattern = re.compile(r'^(\s*%%?.*)$', re.MULTILINE)
+    return re.sub(magic_pattern, r'#\1', code.strip())

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
         'jinja2 >=2.10, <3.0',
         'graphviz >=0.13, <1.0',
         'pyflakes >=2.1.1',
-        'dill >=0.3, <0.4'
+        'dill >=0.3, <0.4',
+        'IPython >= 7.6.0'
     ],
     extras_require={
         'dev': [

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
               'kale.rpc'
               ],
     install_requires=[
-        'kfp >=0.1.31, <0.2',
+        'kfp >= 0.2',
         'autopep8 >=1.4, <1.5',
         'nbformat >=4.4, <5.0',
         'networkx >=2.3, <3.0',
@@ -34,7 +34,13 @@ setup(
         'graphviz >=0.13, <1.0',
         'pyflakes >=2.1.1',
         'dill >=0.3, <0.4',
-        'IPython >= 7.6.0'
+        'IPython >= 7.6.0',
+        'jupyter-client >= 5.3.4',
+        'jupyter-core >= 4.6.0',
+        'nbconvert >= 5.6.1',
+        'ipykernel >= 5.1.4',
+        'kfp-server-api == 0.1.18.3',
+        'packaging > 20'
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
This PR introduces the following changes:

1. Step's code is handles as a list of code blocks, to keep information about the original notebook code cells
2. Utils to create an ipython kernel on the fly and run some code in it, while monitoring for stdout, stderr and error and redirecting the to the main thread.
3. Utils to parse the rich outputs produced by (2) and parse them to create a single html artifact for each execution
4. Extension to the code generation module to generate a pipeline that takes advantage of (1) (2) and (3) 