### PR TITLE
Run PyTest workflows on default PR events

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,6 @@
 name: PyTest
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Apparently, the `push` trigger refers just to pushes to local branches, not PRs coming from external repositories. Adding `pull_request` will trigger the workflow on `opened`, `synchronize ` and `reopened` events.

Ref: https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request