### PR TITLE
Support pipeline metrics

### DIFF
--- a/kale/core.py
+++ b/kale/core.py
@@ -190,6 +190,10 @@ class Kale:
         pipeline_parameters_dict = ast.parse_assignments_expressions(
             pipeline_parameters_source)
 
+        # get a list of variables that need to be logged as pipeline metrics
+        pipeline_metrics = ast.parse_metrics_print_statements(
+            pipeline_metrics_source)
+
         # run static analysis over the source code
         to_ignore = set(pipeline_parameters_dict.keys())
         dependencies.dependencies_detection(pipeline_graph,

--- a/kale/core.py
+++ b/kale/core.py
@@ -182,8 +182,9 @@ class Kale:
 
     def notebook_to_graph(self):
         # convert notebook to nx graph
-        pipeline_graph, pipeline_parameters_source = parser.parse_notebook(
-            self.notebook)
+        (pipeline_graph,
+         pipeline_parameters_source,
+         pipeline_metrics_source) = parser.parse_notebook(self.notebook)
 
         # get a dict from the 'pipeline parameters' cell source code
         pipeline_parameters_dict = ast.parse_assignments_expressions(

--- a/kale/nbparser/parser.py
+++ b/kale/nbparser/parser.py
@@ -233,8 +233,8 @@ def parse_notebook(notebook):
             # in this branch we are sure that we are reading a code cell with
             # a step tag, so we must not allow for pipeline-metrics
             if prev_step_name == 'pipeline-metrics':
-                raise ValueError("Tag pipeline-metrics must be placed on a "
-                                 "cell at the end of the Notebook."
+                raise ValueError("Tag pipeline-metrics must be placed on a"
+                                 " cell at the end of the Notebook."
                                  " Pipeline metrics should be considered as a"
                                  " result of the pipeline execution and not of"
                                  " single steps.")

--- a/kale/nbparser/parser.py
+++ b/kale/nbparser/parser.py
@@ -22,6 +22,7 @@ _TAGS_LANGUAGE = [SKIP_TAG,
                   FUNCTIONS_TAG,
                   PREV_TAG,
                   BLOCK_TAG,
+                  STEP_TAG,
                   PIPELINE_PARAMETERS_TAG,
                   PIPELINE_METRICS_TAG]
 
@@ -118,22 +119,20 @@ def get_pipeline_parameters_source(notebook):
     """
     detected = False
     pipeline_parameters = ''
+
+    language = _TAGS_LANGUAGE[:]
+    language.remove(PIPELINE_PARAMETERS_TAG)
+
     for c in notebook.cells:
         # parse only source code cells
         if c.cell_type != "code":
             continue
         # in case the previous cell was a pipeline-parameter cell and this
-        # cell either:
-        #  - does not have tags
-        #  - does not have any `block` or `step` tags
-        #  - is not a skip tag
+        # cell is not any other tag of the tag language:
         if ((('tags' not in c.metadata
               or len(c.metadata['tags']) == 0)
-             or (not any(re.match(BLOCK_TAG, t) for t in c.metadata['tags'])
-                 and not any(re.match(STEP_TAG, t)
-                             for t in c.metadata['tags'])
-                 and not any(re.match(SKIP_TAG, t)
-                             for t in c.metadata['tags'])))
+             or all([not any(re.match(tag, t) for t in c.metadata['tags'])
+                     for tag in language]))
                 and detected):
             pipeline_parameters += '\n' + c.source
         elif (('tags' in c.metadata

--- a/kale/templates/pipeline_metrics_template.jinja2
+++ b/kale/templates/pipeline_metrics_template.jinja2
@@ -1,0 +1,28 @@
+import json
+
+metrics_metadata = list()
+metrics = {
+{% for metric in pipeline_metrics -%}
+    "{{ metric }}": {{ pipeline_metrics[metric] }},
+{% endfor -%}
+}
+
+for k in metrics:
+    if isinstance(metrics[k], (int, float)):
+        metric = metrics[k]
+    else:
+        try:
+            metric = float(metrics[k])
+        except ValueError:
+            print("Variable {} with type {} not supported as pipeline"
+                  " metric. Can only write `int` or `float` types as"
+                  " pipeline metrics".format(k, type(k)))
+            continue
+    metrics_metadata.append({
+                'name': k,
+                'numberValue': metric,
+                'format': "RAW",
+            })
+
+with open('/mlpipeline-metrics.json', 'w') as f:
+    json.dump({'metrics': metrics_metadata}, f)

--- a/kale/templates/pipeline_template.jinja2
+++ b/kale/templates/pipeline_template.jinja2
@@ -102,7 +102,9 @@ def auto_generated_pipeline({{ pipeline_args }}):
     mlpipeline_ui_metadata = {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'}
     {{ name }}_task.output_artifact_paths.update(mlpipeline_ui_metadata)
     {% endif -%}
-
+    {% if name == "pipeline_metrics" -%}
+    {{ name }}_task.output_artifact_paths.update({'mlpipeline-metrics': '/mlpipeline-metrics.json'})
+    {% endif -%}
     {% endfor %}
 
     {# Snaphosts #}

--- a/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
+++ b/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
@@ -1,0 +1,198 @@
+import kfp.dsl as dsl
+import kfp.components as comp
+from collections import OrderedDict
+from kubernetes import client as k8s_client
+
+
+def create_matrix(d1: int, d2: int):
+    import os
+    import shutil
+    from kale.utils import pod_utils as _kale_pod_utils
+    from kale.marshal import resource_save as _kale_resource_save
+    from kale.marshal import resource_load as _kale_resource_load
+
+    _kale_data_directory = "/marshal"
+    if not os.path.isdir(_kale_data_directory):
+        os.makedirs(_kale_data_directory, exist_ok=True)
+
+    import numpy as np
+    rnd_matrix = np.random.rand(d1, d2)
+
+    # -----------------------DATA SAVING START---------------------------------
+    if "rnd_matrix" in locals():
+        _kale_resource_save(
+            rnd_matrix, os.path.join(_kale_data_directory, "rnd_matrix"))
+    else:
+        print("_kale_resource_save: `rnd_matrix` not found.")
+    # -----------------------DATA SAVING END-----------------------------------
+
+
+def sum_matrix(d1: int, d2: int):
+    import os
+    import shutil
+    from kale.utils import pod_utils as _kale_pod_utils
+    from kale.marshal import resource_save as _kale_resource_save
+    from kale.marshal import resource_load as _kale_resource_load
+
+    _kale_data_directory = "/marshal"
+    if not os.path.isdir(_kale_data_directory):
+        os.makedirs(_kale_data_directory, exist_ok=True)
+
+    # -----------------------DATA LOADING START--------------------------------
+    _kale_directory_file_names = [
+        os.path.splitext(f)[0]
+        for f in os.listdir(_kale_data_directory)
+        if os.path.isfile(os.path.join(_kale_data_directory, f))
+    ]
+    if "rnd_matrix" not in _kale_directory_file_names:
+        raise ValueError("rnd_matrix" + " does not exists in directory")
+    _kale_load_file_name = [
+        f
+        for f in os.listdir(_kale_data_directory)
+        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
+            os.path.splitext(f)[0] == "rnd_matrix")
+    ]
+    if len(_kale_load_file_name) > 1:
+        raise ValueError("Found multiple files with name %s: %s"
+                         % ("rnd_matrix", str(_kale_load_file_name)))
+    _kale_load_file_name = _kale_load_file_name[0]
+    rnd_matrix = _kale_resource_load(
+        os.path.join(_kale_data_directory, _kale_load_file_name))
+    # -----------------------DATA LOADING END----------------------------------
+    import numpy as np
+    result = rnd_matrix.sum()
+
+    # -----------------------DATA SAVING START---------------------------------
+    if "result" in locals():
+        _kale_resource_save(
+            result, os.path.join(_kale_data_directory, "result"))
+    else:
+        print("_kale_resource_save: `result` not found.")
+    # -----------------------DATA SAVING END-----------------------------------
+
+
+def pipeline_metrics(d1: int, d2: int):
+    import os
+    import shutil
+    from kale.utils import pod_utils as _kale_pod_utils
+    from kale.marshal import resource_save as _kale_resource_save
+    from kale.marshal import resource_load as _kale_resource_load
+
+    _kale_data_directory = "/marshal"
+    if not os.path.isdir(_kale_data_directory):
+        os.makedirs(_kale_data_directory, exist_ok=True)
+
+    # -----------------------DATA LOADING START--------------------------------
+    _kale_directory_file_names = [
+        os.path.splitext(f)[0]
+        for f in os.listdir(_kale_data_directory)
+        if os.path.isfile(os.path.join(_kale_data_directory, f))
+    ]
+    if "result" not in _kale_directory_file_names:
+        raise ValueError("result" + " does not exists in directory")
+    _kale_load_file_name = [
+        f
+        for f in os.listdir(_kale_data_directory)
+        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
+            os.path.splitext(f)[0] == "result")
+    ]
+    if len(_kale_load_file_name) > 1:
+        raise ValueError("Found multiple files with name %s: %s"
+                         % ("result", str(_kale_load_file_name)))
+    _kale_load_file_name = _kale_load_file_name[0]
+    result = _kale_resource_load(
+        os.path.join(_kale_data_directory, _kale_load_file_name))
+    # -----------------------DATA LOADING END----------------------------------
+    import json
+
+    metrics_metadata = list()
+    metrics = {
+        "d1": d1,
+        "d2": d2,
+        "result": result,
+    }
+
+    for k in metrics:
+        if isinstance(metrics[k], (int, float)):
+            metric = metrics[k]
+        else:
+            try:
+                metric = float(metrics[k])
+            except ValueError:
+                print("Variable {} with type {} not supported as pipeline"
+                      " metric. Can only write `int` or `float` types as"
+                      " pipeline metrics".format(k, type(k)))
+                continue
+        metrics_metadata.append({
+            'name': k,
+            'numberValue': metric,
+            'format': "RAW",
+        })
+
+    with open('/mlpipeline-metrics.json', 'w') as f:
+        json.dump({'metrics': metrics_metadata}, f)
+
+
+create_matrix_op = comp.func_to_container_op(create_matrix)
+
+
+sum_matrix_op = comp.func_to_container_op(sum_matrix)
+
+
+pipeline_metrics_op = comp.func_to_container_op(pipeline_metrics)
+
+
+@dsl.pipeline(
+    name='hp-test-rnd',
+    description=''
+)
+def auto_generated_pipeline(d1='5', d2='6'):
+    pvolumes_dict = OrderedDict()
+
+    marshal_vop = dsl.VolumeOp(
+        name="kale_marshal_volume",
+        resource_name="kale-marshal-pvc",
+        modes=dsl.VOLUME_MODE_RWM,
+        size="1Gi"
+    )
+    pvolumes_dict['/marshal'] = marshal_vop.volume
+
+    create_matrix_task = create_matrix_op(d1, d2)\
+        .add_pvolumes(pvolumes_dict)\
+        .after()
+    create_matrix_task.container.working_dir = "/kale"
+    create_matrix_task.container.set_security_context(
+        k8s_client.V1SecurityContext(run_as_user=0))
+
+    sum_matrix_task = sum_matrix_op(d1, d2)\
+        .add_pvolumes(pvolumes_dict)\
+        .after(create_matrix_task)
+    sum_matrix_task.container.working_dir = "/kale"
+    sum_matrix_task.container.set_security_context(
+        k8s_client.V1SecurityContext(run_as_user=0))
+
+    pipeline_metrics_task = pipeline_metrics_op(d1, d2)\
+        .add_pvolumes(pvolumes_dict)\
+        .after(sum_matrix_task)
+    pipeline_metrics_task.container.working_dir = "/kale"
+    pipeline_metrics_task.container.set_security_context(
+        k8s_client.V1SecurityContext(run_as_user=0))
+    pipeline_metrics_task.output_artifact_paths.update(
+        {'mlpipeline-metrics': '/mlpipeline-metrics.json'})
+
+
+if __name__ == "__main__":
+    pipeline_func = auto_generated_pipeline
+    pipeline_filename = pipeline_func.__name__ + '.pipeline.tar.gz'
+    import kfp.compiler as compiler
+    compiler.Compiler().compile(pipeline_func, pipeline_filename)
+
+    # Get or create an experiment and submit a pipeline run
+    import kfp
+    client = kfp.Client()
+    experiment = client.create_experiment('hp tuning')
+
+    # Submit a pipeline run
+    run_name = 'hp-test-rnd_run'
+    run_result = client.run_pipeline(
+        experiment.id, run_name, pipeline_filename, {})

--- a/kale/tests/assets/notebooks/pipeline_parameters_and_metrics.ipynb
+++ b/kale/tests/assets/notebooks/pipeline_parameters_and_metrics.ipynb
@@ -1,0 +1,105 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "tags": [
+     "imports"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "tags": [
+     "pipeline-parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "d1 = 5\n",
+    "d2 = 6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "tags": [
+     "block:create_matrix"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "rnd_matrix = np.random.rand(d1, d2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "tags": [
+     "block:sum_matrix",
+     "prev:create_matrix"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "result = rnd_matrix.sum()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "pipeline-metrics"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "print(d1)\n",
+    "print(d2)\n",
+    "print(result)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "kubeflow_notebook": {
+   "docker_image": "",
+   "experiment": {
+    "id": "new",
+    "name": "hp tuning"
+   },
+   "experiment_name": "hp tuning",
+   "pipeline_description": "",
+   "pipeline_name": "hp-test",
+   "volumes": []
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/kale/tests/e2e/test_e2e.py
+++ b/kale/tests/e2e/test_e2e.py
@@ -33,3 +33,28 @@ def test_pipeline_generation_from_gtihub(random_string, abs_working_dir):
     expected_result = open(target_asset).read()
     result = open(script_path).read()
     assert result == expected_result
+
+
+@mock.patch('kale.core.utils.get_abs_working_dir')
+@mock.patch('kale.utils.metadata_utils.random_string')
+def test_pipeline_generation_from_local(random_string, abs_working_dir):
+    """Test code generation end to end from notebook to DSL."""
+    abs_working_dir.return_value = '/kale'
+    random_string.return_value = 'rnd'
+    notebook_path = "../assets/notebooks/pipeline_parameters_and_metrics.ipynb"
+    notebook_path = os.path.join(THIS_DIR, notebook_path)
+
+    kale = Kale(source_notebook_path=notebook_path)
+    pipeline_graph, pipeline_parameters = kale.notebook_to_graph()
+    script_path = kale.generate_kfp_executable(pipeline_graph,
+                                               pipeline_parameters,
+                                               save_to_tmp=True)
+    # TODO: Need to suppress log generation when running tests
+    os.remove(os.path.join(os.getcwd(), 'kale.log'))
+
+    target_asset = os.path.join(THIS_DIR,
+                                '../assets/kfp_dsl/',
+                                'pipeline_parameters_and_metrics.py')
+    expected_result = open(target_asset).read()
+    result = open(script_path).read()
+    assert result == expected_result

--- a/kale/tests/unit_tests/test_ast.py
+++ b/kale/tests/unit_tests/test_ast.py
@@ -2,8 +2,7 @@ import ast
 import pytest
 from testfixtures import compare
 
-from kale.static_analysis.ast import get_all_names, get_list_tuple_names, \
-    get_function_and_class_names, parse_assignments_expressions
+from kale.static_analysis import ast as kale_ast
 
 
 _numpy_snippet = '''
@@ -59,14 +58,14 @@ def fun()
 ])
 def test_get_all_names(code, target):
     """Tests get_all_names function."""
-    res = get_all_names(code)
+    res = kale_ast.get_all_names(code)
     assert sorted(res) == sorted(target)
 
 
 def test_get_all_names_exc():
     """Tests exception when passing a wrong code snippet to get_all_names."""
     with pytest.raises(SyntaxError):
-        get_all_names(_wrong_code_snippet)
+        kale_ast.get_all_names(_wrong_code_snippet)
 
 
 @pytest.mark.parametrize("code,target", [
@@ -80,7 +79,7 @@ def test_get_all_names_exc():
 def test_get_list_tuple_names(code, target):
     """Test list_tuple_names function."""
     tree = ast.parse(code)
-    res = get_list_tuple_names(tree.body[0].value)
+    res = kale_ast.get_list_tuple_names(tree.body[0].value)
     assert sorted(res) == sorted(target)
 
 
@@ -91,7 +90,7 @@ def test_get_list_tuple_names(code, target):
 ])
 def test_get_function_and_class_names(code, target):
     """Test get_function_and_class_names function."""
-    res = get_function_and_class_names(code)
+    res = kale_ast.get_function_and_class_names(code)
     assert sorted(res) == sorted(target)
 
 
@@ -104,7 +103,7 @@ def test_get_function_and_class_names(code, target):
 ])
 def test_parse_assignments_expressions(code, target):
     """Test parse_assignments_expressions function."""
-    res = parse_assignments_expressions(code)
+    res = kale_ast.parse_assignments_expressions(code)
     compare(res, target)
 
 
@@ -119,4 +118,31 @@ def test_parse_assignments_expressions(code, target):
 def test_parse_assignments_expressions_exc(code):
     """Test parse_assignments_expressions function."""
     with pytest.raises(ValueError):
-        parse_assignments_expressions(code)
+        kale_ast.parse_assignments_expressions(code)
+
+
+@pytest.mark.parametrize("code, target", [
+    ('', {}),
+    ('   ', {}),
+    ('print(a)', {'a': 'a'}),
+    ('print(a)\nprint(var)\nprint(test_var)', {'a': 'a',
+                                               'var': 'var',
+                                               'test-var': 'test_var'}),
+])
+def test_parse_metrics_print_statements(code, target):
+    """Tests parse_metrics_print_statements function."""
+    res = kale_ast.parse_metrics_print_statements(code)
+    assert res == target
+
+
+@pytest.mark.parametrize("code", [
+    'print(foo())',
+    'def',
+    'variable',
+    'print(var)\nname',
+    '_variable'
+])
+def test_parse_metrics_print_statements_exc(code):
+    """Tests a exception cases for parse_metrics_print_statements function."""
+    with pytest.raises(ValueError):
+        kale_ast.parse_metrics_print_statements(code)

--- a/kale/tests/unit_tests/test_rpc_nb.py
+++ b/kale/tests/unit_tests/test_rpc_nb.py
@@ -58,3 +58,20 @@ def test_get_pipeline_parameters_source_skip(tmpdir, rpc_request):
     nbformat.write(notebook, notebook_path, nbformat.NO_CONVERT)
     target = [['a', 'int', 1], ['b', 'int', 2], ['c', 'int', 3]]
     assert nb.get_pipeline_parameters(rpc_request, notebook_path) == target
+
+
+def test_get_pipeline_metrics(tmpdir, rpc_request):
+    """Test that the function gets the correct pipeline metrics source."""
+    notebook = nbformat.v4.new_notebook()
+    cells = [
+        ("0", {}),
+        ("0", {"tags": []}),
+        ("print(metric_1)", {"tags": ["pipeline-metrics"]}),
+        ("print(metric_2)", {}),
+    ]
+    notebook.cells = [nbformat.v4.new_code_cell(source=s, metadata=m)
+                      for (s, m) in cells]
+    notebook_path = os.path.join(tmpdir, 'test1.ipynb')
+    nbformat.write(notebook, notebook_path, nbformat.NO_CONVERT)
+    target = {"metric-1": "metric_1", "metric-2": "metric_2"}
+    assert nb.get_pipeline_metrics(rpc_request, notebook_path) == target


### PR DESCRIPTION
This PR add the following functionalities:

- Parse `pipeline-metrics` tag
- Parse and validate code blocks belonging to `pipeline-metrics` tag
- Generate code to run pipeline with pipeline metrics
- RPC to let the UI get the current pipeline metrics