### PR TITLE
Simplify marshal code in templates

### DIFF
--- a/kale/marshal/utils.py
+++ b/kale/marshal/utils.py
@@ -1,0 +1,66 @@
+import os
+
+from kale.marshal import resource_save
+from kale.marshal import resource_load
+
+KALE_DATA_DIRECTORY = ""
+KALE_DIRECTORY_FILE_NAMES = []
+
+
+def set_kale_data_directory(path):
+    """Set the Kale data directory path."""
+    global KALE_DATA_DIRECTORY
+    KALE_DATA_DIRECTORY = path
+    # create dir if not exists
+    if not os.path.isdir(KALE_DATA_DIRECTORY):
+        os.makedirs(KALE_DATA_DIRECTORY, exist_ok=True)
+
+
+def set_kale_directory_file_names():
+    """Set the list of filenames present in the Kale data directory path."""
+    global KALE_DIRECTORY_FILE_NAMES
+    KALE_DIRECTORY_FILE_NAMES = [
+        os.path.splitext(f)[0]
+        for f in os.listdir(KALE_DATA_DIRECTORY)
+        if os.path.isfile(os.path.join(KALE_DATA_DIRECTORY, f))
+    ]
+
+
+def save(obj, obj_name):
+    """Serialise (save) an object using Kale's marshalling backends.
+
+    Args:
+        obj: The Python object to be saved
+        obj_name: The variable name of 'obj'
+    """
+    #  resource_save will automatically add the correct extension
+    resource_save(
+        obj,
+        os.path.join(KALE_DATA_DIRECTORY, obj_name))
+
+
+def load(var_name):
+    """Load an object using Kale's marshalling backends.
+
+    Args:
+        var_name: The name of the object to be loaded
+
+    Returns: loaded object
+    """
+    # First check that the variable exists in the path
+    if var_name not in KALE_DIRECTORY_FILE_NAMES:
+        raise ValueError("Failed to load variable %s" % var_name)
+
+    # Load variable
+    _kale_load_file_name = [
+        f
+        for f in os.listdir(KALE_DATA_DIRECTORY)
+        if (os.path.isfile(os.path.join(KALE_DATA_DIRECTORY, f)) and
+            os.path.splitext(f)[0] == var_name)
+    ]
+    if len(_kale_load_file_name) > 1:
+        raise ValueError("Found multiple files with name %s: %s"
+                         % (var_name, str(_kale_load_file_name)))
+    _kale_load_file_name = _kale_load_file_name[0]
+    return resource_load(os.path.join(KALE_DATA_DIRECTORY,
+                                      _kale_load_file_name))

--- a/kale/templates/function_template.jinja2
+++ b/kale/templates/function_template.jinja2
@@ -32,7 +32,7 @@ def {{ step_name }}({%- for arg in parameters_names -%}
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_directory_file_names()
 {%- for in_var in in_variables %}
-    _kale_marshal_utils.load("{{ in_var }}", locals())
+    {{ in_var }} = _kale_marshal_utils.load("{{ in_var }}")
 {%- endfor %}
     # -----------------------DATA LOADING END----------------------------------
     '''
@@ -46,9 +46,9 @@ def {{ step_name }}({%- for arg in parameters_names -%}
 {%- if out_variables|length > 0 %}
     data_saving_block = '''
     # -----------------------DATA SAVING START---------------------------------
-{%- for out_var in out_variables %}
     from kale.marshal import utils as _kale_marshal_utils
-    _kale_marshal_utils.save({{ out_var }}, "{{ out_var }}", locals())
+{%- for out_var in out_variables %}
+    _kale_marshal_utils.save({{ out_var }}, "{{ out_var }}")
 {%- endfor %}
     # -----------------------DATA SAVING END-----------------------------------
     '''

--- a/kale/templates/function_template.jinja2
+++ b/kale/templates/function_template.jinja2
@@ -20,16 +20,11 @@ def {{ step_name }}({%- for arg in parameters_names -%}
         "{{ nb_path }}")
 {% endif %}
 
-{%- if in_variables|length > 0 or out_variables|length > 0 %}
-    data_dir_block = '''
-    _kale_marshal_utils.set_kale_data_directory("{{ marshal_path }}")
-    '''
-{% endif %}
-
 {%- if in_variables|length > 0 %}
     data_loading_block = '''
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("{{ marshal_path }}")
     _kale_marshal_utils.set_kale_directory_file_names()
 {%- for in_var in in_variables %}
     {{ in_var }} = _kale_marshal_utils.load("{{ in_var }}")
@@ -47,6 +42,7 @@ def {{ step_name }}({%- for arg in parameters_names -%}
     data_saving_block = '''
     # -----------------------DATA SAVING START---------------------------------
     from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("{{ marshal_path }}")
 {%- for out_var in out_variables %}
     _kale_marshal_utils.save({{ out_var }}, "{{ out_var }}")
 {%- endfor %}
@@ -58,8 +54,7 @@ def {{ step_name }}({%- for arg in parameters_names -%}
     # run the code blocks inside a jupyter kernel
     from kale.utils.jupyter_utils import run_code as _kale_run_code
     from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
-    blocks = ({% if in_variables|length > 0 or out_variables|length > 0 %}data_dir_block,{% endif -%}
-              {% if parameters_names|length > 0 %}pipeline_parameters_block,{% endif -%}
+    blocks = ({% if parameters_names|length > 0 %}pipeline_parameters_block,{% endif -%}
               {% if in_variables|length > 0 %}data_loading_block,{% endif -%}
 {%- for block in function_body %}
               block{{ loop.index }},

--- a/kale/templates/function_template.jinja2
+++ b/kale/templates/function_template.jinja2
@@ -22,44 +22,17 @@ def {{ step_name }}({%- for arg in parameters_names -%}
 
 {%- if in_variables|length > 0 or out_variables|length > 0 %}
     data_dir_block = '''
-    import os
-    _kale_data_directory = "{{ marshal_path }}"
-    {#- Verify directory exists #}
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
+    _kale_marshal_utils.set_kale_data_directory("{{ marshal_path }}")
     '''
 {% endif %}
 
 {%- if in_variables|length > 0 %}
     data_loading_block = '''
-    import os
-    from kale.marshal import resource_load as _kale_resource_load
-
     # -----------------------DATA LOADING START--------------------------------
-    _kale_directory_file_names = [
-        os.path.splitext(f)[0]
-        for f in os.listdir(_kale_data_directory)
-        if os.path.isfile(os.path.join(_kale_data_directory, f))
-    ]
-
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_directory_file_names()
 {%- for in_var in in_variables %}
-    {#- First check that the variable exists in the path #}
-    if "{{ in_var }}" not in _kale_directory_file_names:
-        raise ValueError("{{ in_var }}" + " does not exists in directory")
-
-    {#- Load variable #}
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "{{ in_var }}")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("{{ in_var }}", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    {{ in_var }} = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
+    _kale_marshal_utils.load("{{ in_var }}", locals())
 {%- endfor %}
     # -----------------------DATA LOADING END----------------------------------
     '''
@@ -72,16 +45,10 @@ def {{ step_name }}({%- for arg in parameters_names -%}
 {% endfor %}
 {%- if out_variables|length > 0 %}
     data_saving_block = '''
-    import os
-    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
 {%- for out_var in out_variables %}
-    if "{{ out_var }}" in locals():
-        {#-  `_kale_resource_save` will automatically add the correct extension #}
-        _kale_resource_save(
-            {{ out_var }}, os.path.join(_kale_data_directory, "{{ out_var }}"))
-    else:
-        print("_kale_resource_save: `{{ out_var }}` not found.")
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.save({{ out_var }}, "{{ out_var }}", locals())
 {%- endfor %}
     # -----------------------DATA SAVING END-----------------------------------
     '''

--- a/kale/tests/assets/functions/func04.out.py
+++ b/kale/tests/assets/functions/func04.out.py
@@ -1,42 +1,17 @@
 def test():
-    data_dir_block = '''
-    import os
-    _kale_data_directory = ""
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
-    '''
-
     data_loading_block = '''
-    import os
-    from kale.marshal import resource_load as _kale_resource_load
-
     # -----------------------DATA LOADING START--------------------------------
-    _kale_directory_file_names = [
-        os.path.splitext(f)[0]
-        for f in os.listdir(_kale_data_directory)
-        if os.path.isfile(os.path.join(_kale_data_directory, f))
-    ]
-    if "v1" not in _kale_directory_file_names:
-        raise ValueError("v1" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "v1")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("v1", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    v1 = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("")
+    _kale_marshal_utils.set_kale_directory_file_names()
+    v1 = _kale_marshal_utils.load("v1")
     # -----------------------DATA LOADING END----------------------------------
     '''
 
     # run the code blocks inside a jupyter kernel
     from kale.utils.jupyter_utils import run_code as _kale_run_code
     from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
-    blocks = (data_dir_block, data_loading_block,
+    blocks = (data_loading_block,
               )
     html_artifact = _kale_run_code(blocks)
     with open("/test.html", "w") as f:

--- a/kale/tests/assets/functions/func05.out.py
+++ b/kale/tests/assets/functions/func05.out.py
@@ -1,11 +1,4 @@
 def test():
-    data_dir_block = '''
-    import os
-    _kale_data_directory = ""
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
-    '''
-
     block1 = '''
     v1 = "Hello"
     '''
@@ -15,24 +8,20 @@ def test():
     '''
 
     data_saving_block = '''
-    import os
-    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
-    if "v1" in locals():
-        _kale_resource_save(
-            v1, os.path.join(_kale_data_directory, "v1"))
-    else:
-        print("_kale_resource_save: `v1` not found.")
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("")
+    _kale_marshal_utils.save(v1, "v1")
     # -----------------------DATA SAVING END-----------------------------------
     '''
 
     # run the code blocks inside a jupyter kernel
     from kale.utils.jupyter_utils import run_code as _kale_run_code
     from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
-    blocks = (data_dir_block,
-              block1,
-              block2,
-              data_saving_block)
+    blocks = (
+        block1,
+        block2,
+        data_saving_block)
     html_artifact = _kale_run_code(blocks)
     with open("/test.html", "w") as f:
         f.write(html_artifact)

--- a/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
+++ b/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
@@ -10,13 +10,6 @@ def create_matrix(d1: int, d2: int):
     d2 = {}
     '''.format(d1, d2)
 
-    data_dir_block = '''
-    import os
-    _kale_data_directory = "/marshal"
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
-    '''
-
     block1 = '''
     import numpy as np
     '''
@@ -26,21 +19,17 @@ def create_matrix(d1: int, d2: int):
     '''
 
     data_saving_block = '''
-    import os
-    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
-    if "rnd_matrix" in locals():
-        _kale_resource_save(
-            rnd_matrix, os.path.join(_kale_data_directory, "rnd_matrix"))
-    else:
-        print("_kale_resource_save: `rnd_matrix` not found.")
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.save(rnd_matrix, "rnd_matrix")
     # -----------------------DATA SAVING END-----------------------------------
     '''
 
     # run the code blocks inside a jupyter kernel
     from kale.utils.jupyter_utils import run_code as _kale_run_code
     from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
-    blocks = (data_dir_block, pipeline_parameters_block,
+    blocks = (pipeline_parameters_block,
               block1,
               block2,
               data_saving_block)
@@ -51,37 +40,12 @@ def create_matrix(d1: int, d2: int):
 
 
 def sum_matrix():
-    data_dir_block = '''
-    import os
-    _kale_data_directory = "/marshal"
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
-    '''
-
     data_loading_block = '''
-    import os
-    from kale.marshal import resource_load as _kale_resource_load
-
     # -----------------------DATA LOADING START--------------------------------
-    _kale_directory_file_names = [
-        os.path.splitext(f)[0]
-        for f in os.listdir(_kale_data_directory)
-        if os.path.isfile(os.path.join(_kale_data_directory, f))
-    ]
-    if "rnd_matrix" not in _kale_directory_file_names:
-        raise ValueError("rnd_matrix" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "rnd_matrix")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("rnd_matrix", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    rnd_matrix = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.set_kale_directory_file_names()
+    rnd_matrix = _kale_marshal_utils.load("rnd_matrix")
     # -----------------------DATA LOADING END----------------------------------
     '''
 
@@ -94,21 +58,17 @@ def sum_matrix():
     '''
 
     data_saving_block = '''
-    import os
-    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
-    if "result" in locals():
-        _kale_resource_save(
-            result, os.path.join(_kale_data_directory, "result"))
-    else:
-        print("_kale_resource_save: `result` not found.")
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.save(result, "result")
     # -----------------------DATA SAVING END-----------------------------------
     '''
 
     # run the code blocks inside a jupyter kernel
     from kale.utils.jupyter_utils import run_code as _kale_run_code
     from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
-    blocks = (data_dir_block, data_loading_block,
+    blocks = (data_loading_block,
               block1,
               block2,
               data_saving_block)
@@ -124,37 +84,12 @@ def pipeline_metrics(d1: int, d2: int):
     d2 = {}
     '''.format(d1, d2)
 
-    data_dir_block = '''
-    import os
-    _kale_data_directory = "/marshal"
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
-    '''
-
     data_loading_block = '''
-    import os
-    from kale.marshal import resource_load as _kale_resource_load
-
     # -----------------------DATA LOADING START--------------------------------
-    _kale_directory_file_names = [
-        os.path.splitext(f)[0]
-        for f in os.listdir(_kale_data_directory)
-        if os.path.isfile(os.path.join(_kale_data_directory, f))
-    ]
-    if "result" not in _kale_directory_file_names:
-        raise ValueError("result" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "result")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("result", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    result = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.set_kale_directory_file_names()
+    result = _kale_marshal_utils.load("result")
     # -----------------------DATA LOADING END----------------------------------
     '''
 
@@ -192,7 +127,7 @@ def pipeline_metrics(d1: int, d2: int):
     # run the code blocks inside a jupyter kernel
     from kale.utils.jupyter_utils import run_code as _kale_run_code
     from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
-    blocks = (data_dir_block, pipeline_parameters_block, data_loading_block,
+    blocks = (pipeline_parameters_block, data_loading_block,
               block1,
               )
     html_artifact = _kale_run_code(blocks)

--- a/kale/tests/assets/kfp_dsl/titanic.py
+++ b/kale/tests/assets/kfp_dsl/titanic.py
@@ -5,13 +5,6 @@ from kubernetes import client as k8s_client
 
 
 def loaddata():
-    data_dir_block = '''
-    import os
-    _kale_data_directory = "/marshal"
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
-    '''
-
     block1 = '''
     import numpy as np 
     import pandas as pd 
@@ -40,34 +33,22 @@ def loaddata():
     '''
 
     data_saving_block = '''
-    import os
-    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
-    if "PREDICTION_LABEL" in locals():
-        _kale_resource_save(
-            PREDICTION_LABEL, os.path.join(_kale_data_directory, "PREDICTION_LABEL"))
-    else:
-        print("_kale_resource_save: `PREDICTION_LABEL` not found.")
-    if "test_df" in locals():
-        _kale_resource_save(
-            test_df, os.path.join(_kale_data_directory, "test_df"))
-    else:
-        print("_kale_resource_save: `test_df` not found.")
-    if "train_df" in locals():
-        _kale_resource_save(
-            train_df, os.path.join(_kale_data_directory, "train_df"))
-    else:
-        print("_kale_resource_save: `train_df` not found.")
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.save(PREDICTION_LABEL, "PREDICTION_LABEL")
+    _kale_marshal_utils.save(test_df, "test_df")
+    _kale_marshal_utils.save(train_df, "train_df")
     # -----------------------DATA SAVING END-----------------------------------
     '''
 
     # run the code blocks inside a jupyter kernel
     from kale.utils.jupyter_utils import run_code as _kale_run_code
     from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
-    blocks = (data_dir_block,
-              block1,
-              block2,
-              data_saving_block)
+    blocks = (
+        block1,
+        block2,
+        data_saving_block)
     html_artifact = _kale_run_code(blocks)
     with open("/loaddata.html", "w") as f:
         f.write(html_artifact)
@@ -75,51 +56,13 @@ def loaddata():
 
 
 def datapreprocessing():
-    data_dir_block = '''
-    import os
-    _kale_data_directory = "/marshal"
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
-    '''
-
     data_loading_block = '''
-    import os
-    from kale.marshal import resource_load as _kale_resource_load
-
     # -----------------------DATA LOADING START--------------------------------
-    _kale_directory_file_names = [
-        os.path.splitext(f)[0]
-        for f in os.listdir(_kale_data_directory)
-        if os.path.isfile(os.path.join(_kale_data_directory, f))
-    ]
-    if "test_df" not in _kale_directory_file_names:
-        raise ValueError("test_df" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "test_df")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("test_df", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    test_df = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
-    if "train_df" not in _kale_directory_file_names:
-        raise ValueError("train_df" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "train_df")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("train_df", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    train_df = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.set_kale_directory_file_names()
+    test_df = _kale_marshal_utils.load("test_df")
+    train_df = _kale_marshal_utils.load("train_df")
     # -----------------------DATA LOADING END----------------------------------
     '''
 
@@ -207,26 +150,18 @@ def datapreprocessing():
     '''
 
     data_saving_block = '''
-    import os
-    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
-    if "test_df" in locals():
-        _kale_resource_save(
-            test_df, os.path.join(_kale_data_directory, "test_df"))
-    else:
-        print("_kale_resource_save: `test_df` not found.")
-    if "train_df" in locals():
-        _kale_resource_save(
-            train_df, os.path.join(_kale_data_directory, "train_df"))
-    else:
-        print("_kale_resource_save: `train_df` not found.")
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.save(test_df, "test_df")
+    _kale_marshal_utils.save(train_df, "train_df")
     # -----------------------DATA SAVING END-----------------------------------
     '''
 
     # run the code blocks inside a jupyter kernel
     from kale.utils.jupyter_utils import run_code as _kale_run_code
     from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
-    blocks = (data_dir_block, data_loading_block,
+    blocks = (data_loading_block,
               block1,
               block2,
               block3,
@@ -243,65 +178,14 @@ def datapreprocessing():
 
 
 def featureengineering():
-    data_dir_block = '''
-    import os
-    _kale_data_directory = "/marshal"
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
-    '''
-
     data_loading_block = '''
-    import os
-    from kale.marshal import resource_load as _kale_resource_load
-
     # -----------------------DATA LOADING START--------------------------------
-    _kale_directory_file_names = [
-        os.path.splitext(f)[0]
-        for f in os.listdir(_kale_data_directory)
-        if os.path.isfile(os.path.join(_kale_data_directory, f))
-    ]
-    if "PREDICTION_LABEL" not in _kale_directory_file_names:
-        raise ValueError("PREDICTION_LABEL" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "PREDICTION_LABEL")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("PREDICTION_LABEL", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    PREDICTION_LABEL = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
-    if "test_df" not in _kale_directory_file_names:
-        raise ValueError("test_df" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "test_df")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("test_df", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    test_df = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
-    if "train_df" not in _kale_directory_file_names:
-        raise ValueError("train_df" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "train_df")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("train_df", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    train_df = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.set_kale_directory_file_names()
+    PREDICTION_LABEL = _kale_marshal_utils.load("PREDICTION_LABEL")
+    test_df = _kale_marshal_utils.load("test_df")
+    train_df = _kale_marshal_utils.load("train_df")
     # -----------------------DATA LOADING END----------------------------------
     '''
 
@@ -422,26 +306,18 @@ def featureengineering():
     '''
 
     data_saving_block = '''
-    import os
-    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
-    if "train_df" in locals():
-        _kale_resource_save(
-            train_df, os.path.join(_kale_data_directory, "train_df"))
-    else:
-        print("_kale_resource_save: `train_df` not found.")
-    if "train_labels" in locals():
-        _kale_resource_save(
-            train_labels, os.path.join(_kale_data_directory, "train_labels"))
-    else:
-        print("_kale_resource_save: `train_labels` not found.")
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.save(train_df, "train_df")
+    _kale_marshal_utils.save(train_labels, "train_labels")
     # -----------------------DATA SAVING END-----------------------------------
     '''
 
     # run the code blocks inside a jupyter kernel
     from kale.utils.jupyter_utils import run_code as _kale_run_code
     from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
-    blocks = (data_dir_block, data_loading_block,
+    blocks = (data_loading_block,
               block1,
               block2,
               block3,
@@ -461,51 +337,13 @@ def featureengineering():
 
 
 def decisiontree():
-    data_dir_block = '''
-    import os
-    _kale_data_directory = "/marshal"
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
-    '''
-
     data_loading_block = '''
-    import os
-    from kale.marshal import resource_load as _kale_resource_load
-
     # -----------------------DATA LOADING START--------------------------------
-    _kale_directory_file_names = [
-        os.path.splitext(f)[0]
-        for f in os.listdir(_kale_data_directory)
-        if os.path.isfile(os.path.join(_kale_data_directory, f))
-    ]
-    if "train_df" not in _kale_directory_file_names:
-        raise ValueError("train_df" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "train_df")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("train_df", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    train_df = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
-    if "train_labels" not in _kale_directory_file_names:
-        raise ValueError("train_labels" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "train_labels")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("train_labels", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    train_labels = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.set_kale_directory_file_names()
+    train_df = _kale_marshal_utils.load("train_df")
+    train_labels = _kale_marshal_utils.load("train_labels")
     # -----------------------DATA LOADING END----------------------------------
     '''
 
@@ -534,21 +372,17 @@ def decisiontree():
     '''
 
     data_saving_block = '''
-    import os
-    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
-    if "acc_decision_tree" in locals():
-        _kale_resource_save(
-            acc_decision_tree, os.path.join(_kale_data_directory, "acc_decision_tree"))
-    else:
-        print("_kale_resource_save: `acc_decision_tree` not found.")
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.save(acc_decision_tree, "acc_decision_tree")
     # -----------------------DATA SAVING END-----------------------------------
     '''
 
     # run the code blocks inside a jupyter kernel
     from kale.utils.jupyter_utils import run_code as _kale_run_code
     from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
-    blocks = (data_dir_block, data_loading_block,
+    blocks = (data_loading_block,
               block1,
               block2,
               data_saving_block)
@@ -559,51 +393,13 @@ def decisiontree():
 
 
 def svm():
-    data_dir_block = '''
-    import os
-    _kale_data_directory = "/marshal"
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
-    '''
-
     data_loading_block = '''
-    import os
-    from kale.marshal import resource_load as _kale_resource_load
-
     # -----------------------DATA LOADING START--------------------------------
-    _kale_directory_file_names = [
-        os.path.splitext(f)[0]
-        for f in os.listdir(_kale_data_directory)
-        if os.path.isfile(os.path.join(_kale_data_directory, f))
-    ]
-    if "train_df" not in _kale_directory_file_names:
-        raise ValueError("train_df" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "train_df")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("train_df", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    train_df = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
-    if "train_labels" not in _kale_directory_file_names:
-        raise ValueError("train_labels" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "train_labels")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("train_labels", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    train_labels = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.set_kale_directory_file_names()
+    train_df = _kale_marshal_utils.load("train_df")
+    train_labels = _kale_marshal_utils.load("train_labels")
     # -----------------------DATA LOADING END----------------------------------
     '''
 
@@ -632,21 +428,17 @@ def svm():
     '''
 
     data_saving_block = '''
-    import os
-    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
-    if "acc_linear_svc" in locals():
-        _kale_resource_save(
-            acc_linear_svc, os.path.join(_kale_data_directory, "acc_linear_svc"))
-    else:
-        print("_kale_resource_save: `acc_linear_svc` not found.")
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.save(acc_linear_svc, "acc_linear_svc")
     # -----------------------DATA SAVING END-----------------------------------
     '''
 
     # run the code blocks inside a jupyter kernel
     from kale.utils.jupyter_utils import run_code as _kale_run_code
     from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
-    blocks = (data_dir_block, data_loading_block,
+    blocks = (data_loading_block,
               block1,
               block2,
               data_saving_block)
@@ -657,51 +449,13 @@ def svm():
 
 
 def naivebayes():
-    data_dir_block = '''
-    import os
-    _kale_data_directory = "/marshal"
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
-    '''
-
     data_loading_block = '''
-    import os
-    from kale.marshal import resource_load as _kale_resource_load
-
     # -----------------------DATA LOADING START--------------------------------
-    _kale_directory_file_names = [
-        os.path.splitext(f)[0]
-        for f in os.listdir(_kale_data_directory)
-        if os.path.isfile(os.path.join(_kale_data_directory, f))
-    ]
-    if "train_df" not in _kale_directory_file_names:
-        raise ValueError("train_df" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "train_df")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("train_df", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    train_df = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
-    if "train_labels" not in _kale_directory_file_names:
-        raise ValueError("train_labels" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "train_labels")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("train_labels", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    train_labels = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.set_kale_directory_file_names()
+    train_df = _kale_marshal_utils.load("train_df")
+    train_labels = _kale_marshal_utils.load("train_labels")
     # -----------------------DATA LOADING END----------------------------------
     '''
 
@@ -730,21 +484,17 @@ def naivebayes():
     '''
 
     data_saving_block = '''
-    import os
-    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
-    if "acc_gaussian" in locals():
-        _kale_resource_save(
-            acc_gaussian, os.path.join(_kale_data_directory, "acc_gaussian"))
-    else:
-        print("_kale_resource_save: `acc_gaussian` not found.")
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.save(acc_gaussian, "acc_gaussian")
     # -----------------------DATA SAVING END-----------------------------------
     '''
 
     # run the code blocks inside a jupyter kernel
     from kale.utils.jupyter_utils import run_code as _kale_run_code
     from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
-    blocks = (data_dir_block, data_loading_block,
+    blocks = (data_loading_block,
               block1,
               block2,
               data_saving_block)
@@ -755,51 +505,13 @@ def naivebayes():
 
 
 def logisticregression():
-    data_dir_block = '''
-    import os
-    _kale_data_directory = "/marshal"
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
-    '''
-
     data_loading_block = '''
-    import os
-    from kale.marshal import resource_load as _kale_resource_load
-
     # -----------------------DATA LOADING START--------------------------------
-    _kale_directory_file_names = [
-        os.path.splitext(f)[0]
-        for f in os.listdir(_kale_data_directory)
-        if os.path.isfile(os.path.join(_kale_data_directory, f))
-    ]
-    if "train_df" not in _kale_directory_file_names:
-        raise ValueError("train_df" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "train_df")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("train_df", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    train_df = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
-    if "train_labels" not in _kale_directory_file_names:
-        raise ValueError("train_labels" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "train_labels")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("train_labels", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    train_labels = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.set_kale_directory_file_names()
+    train_df = _kale_marshal_utils.load("train_df")
+    train_labels = _kale_marshal_utils.load("train_labels")
     # -----------------------DATA LOADING END----------------------------------
     '''
 
@@ -828,21 +540,17 @@ def logisticregression():
     '''
 
     data_saving_block = '''
-    import os
-    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
-    if "acc_log" in locals():
-        _kale_resource_save(
-            acc_log, os.path.join(_kale_data_directory, "acc_log"))
-    else:
-        print("_kale_resource_save: `acc_log` not found.")
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.save(acc_log, "acc_log")
     # -----------------------DATA SAVING END-----------------------------------
     '''
 
     # run the code blocks inside a jupyter kernel
     from kale.utils.jupyter_utils import run_code as _kale_run_code
     from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
-    blocks = (data_dir_block, data_loading_block,
+    blocks = (data_loading_block,
               block1,
               block2,
               data_saving_block)
@@ -853,51 +561,13 @@ def logisticregression():
 
 
 def randomforest():
-    data_dir_block = '''
-    import os
-    _kale_data_directory = "/marshal"
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
-    '''
-
     data_loading_block = '''
-    import os
-    from kale.marshal import resource_load as _kale_resource_load
-
     # -----------------------DATA LOADING START--------------------------------
-    _kale_directory_file_names = [
-        os.path.splitext(f)[0]
-        for f in os.listdir(_kale_data_directory)
-        if os.path.isfile(os.path.join(_kale_data_directory, f))
-    ]
-    if "train_df" not in _kale_directory_file_names:
-        raise ValueError("train_df" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "train_df")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("train_df", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    train_df = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
-    if "train_labels" not in _kale_directory_file_names:
-        raise ValueError("train_labels" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "train_labels")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("train_labels", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    train_labels = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.set_kale_directory_file_names()
+    train_df = _kale_marshal_utils.load("train_df")
+    train_labels = _kale_marshal_utils.load("train_labels")
     # -----------------------DATA LOADING END----------------------------------
     '''
 
@@ -926,21 +596,17 @@ def randomforest():
     '''
 
     data_saving_block = '''
-    import os
-    from kale.marshal import resource_save as _kale_resource_save
     # -----------------------DATA SAVING START---------------------------------
-    if "acc_random_forest" in locals():
-        _kale_resource_save(
-            acc_random_forest, os.path.join(_kale_data_directory, "acc_random_forest"))
-    else:
-        print("_kale_resource_save: `acc_random_forest` not found.")
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.save(acc_random_forest, "acc_random_forest")
     # -----------------------DATA SAVING END-----------------------------------
     '''
 
     # run the code blocks inside a jupyter kernel
     from kale.utils.jupyter_utils import run_code as _kale_run_code
     from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
-    blocks = (data_dir_block, data_loading_block,
+    blocks = (data_loading_block,
               block1,
               block2,
               data_saving_block)
@@ -951,93 +617,16 @@ def randomforest():
 
 
 def results():
-    data_dir_block = '''
-    import os
-    _kale_data_directory = "/marshal"
-    if not os.path.isdir(_kale_data_directory):
-        os.makedirs(_kale_data_directory, exist_ok=True)
-    '''
-
     data_loading_block = '''
-    import os
-    from kale.marshal import resource_load as _kale_resource_load
-
     # -----------------------DATA LOADING START--------------------------------
-    _kale_directory_file_names = [
-        os.path.splitext(f)[0]
-        for f in os.listdir(_kale_data_directory)
-        if os.path.isfile(os.path.join(_kale_data_directory, f))
-    ]
-    if "acc_decision_tree" not in _kale_directory_file_names:
-        raise ValueError("acc_decision_tree" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "acc_decision_tree")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("acc_decision_tree", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    acc_decision_tree = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
-    if "acc_gaussian" not in _kale_directory_file_names:
-        raise ValueError("acc_gaussian" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "acc_gaussian")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("acc_gaussian", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    acc_gaussian = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
-    if "acc_linear_svc" not in _kale_directory_file_names:
-        raise ValueError("acc_linear_svc" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "acc_linear_svc")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("acc_linear_svc", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    acc_linear_svc = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
-    if "acc_log" not in _kale_directory_file_names:
-        raise ValueError("acc_log" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "acc_log")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("acc_log", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    acc_log = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
-    if "acc_random_forest" not in _kale_directory_file_names:
-        raise ValueError("acc_random_forest" + " does not exists in directory")
-    _kale_load_file_name = [
-        f
-        for f in os.listdir(_kale_data_directory)
-        if (os.path.isfile(os.path.join(_kale_data_directory, f)) and
-            os.path.splitext(f)[0] == "acc_random_forest")
-    ]
-    if len(_kale_load_file_name) > 1:
-        raise ValueError("Found multiple files with name %s: %s"
-                         % ("acc_random_forest", str(_kale_load_file_name)))
-    _kale_load_file_name = _kale_load_file_name[0]
-    acc_random_forest = _kale_resource_load(
-        os.path.join(_kale_data_directory, _kale_load_file_name))
+    from kale.marshal import utils as _kale_marshal_utils
+    _kale_marshal_utils.set_kale_data_directory("/marshal")
+    _kale_marshal_utils.set_kale_directory_file_names()
+    acc_decision_tree = _kale_marshal_utils.load("acc_decision_tree")
+    acc_gaussian = _kale_marshal_utils.load("acc_gaussian")
+    acc_linear_svc = _kale_marshal_utils.load("acc_linear_svc")
+    acc_log = _kale_marshal_utils.load("acc_log")
+    acc_random_forest = _kale_marshal_utils.load("acc_random_forest")
     # -----------------------DATA LOADING END----------------------------------
     '''
 
@@ -1073,7 +662,7 @@ def results():
     # run the code blocks inside a jupyter kernel
     from kale.utils.jupyter_utils import run_code as _kale_run_code
     from kale.utils.jupyter_utils import update_uimetadata as _kale_update_uimetadata
-    blocks = (data_dir_block, data_loading_block,
+    blocks = (data_loading_block,
               block1,
               block2,
               )


### PR DESCRIPTION
This PR introduces a refactoring of the code that marshals data in and out of pipeline steps.

Instead of producing a lot code using templating, the marshalling code is mode to `marshal/utils.py`, thus making the generated code much simpler.