### PR TITLE
New dependencies detection algorithm

### DIFF
--- a/kale/core.py
+++ b/kale/core.py
@@ -215,7 +215,8 @@ class Kale:
         # convert notebook to nx graph
         (pipeline_graph,
          pipeline_parameters_source,
-         pipeline_metrics_source) = parser.parse_notebook(self.notebook)
+         pipeline_metrics_source,
+         imports_and_functions) = parser.parse_notebook(self.notebook)
 
         # get a dict from the 'pipeline parameters' cell source code
         pipeline_parameters_dict = ast.parse_assignments_expressions(
@@ -253,7 +254,9 @@ class Kale:
         # run static analysis over the source code
         dependencies.dependencies_detection(
             pipeline_graph,
-            pipeline_parameters=pipeline_parameters_dict)
+            pipeline_parameters=pipeline_parameters_dict,
+            imports_and_functions=imports_and_functions
+        )
 
         # add an empty step at the end of the pipeline for final snapshot
         if self.auto_snapshot:

--- a/kale/nbparser/parser.py
+++ b/kale/nbparser/parser.py
@@ -313,7 +313,7 @@ def parse_notebook(notebook):
             # add node to DAG, adding tags and source code of notebook cell
             if step_name not in nb_graph.nodes:
                 nb_graph.add_node(step_name, source=[c.source],
-                                  ins=set(), outs=set())
+                                  ins=list(), outs=list())
                 for _prev_step in tags['prev_steps']:
                     if _prev_step not in nb_graph.nodes:
                         raise ValueError("Step %s does not exist. It was "
@@ -336,4 +336,6 @@ def parse_notebook(notebook):
     # merge together pipeline metrics
     pipeline_metrics = '\n'.join(pipeline_metrics)
 
-    return nb_graph, pipeline_parameters, pipeline_metrics
+    imports_and_functions = "\n".join(imports_block + functions_block)
+    return (nb_graph, pipeline_parameters, pipeline_metrics,
+            imports_and_functions)

--- a/kale/static_analysis/ast.py
+++ b/kale/static_analysis/ast.py
@@ -18,22 +18,6 @@ import ast
 from collections import deque
 from kale.utils import utils
 
-# TODO: Get this list dynamically
-_BUILT_INS_ = ["abs", "delattr", "hash", "memoryview", "set",
-               "all", "dict", "help", "min", "setattr",
-               "any", "dir", "hex", "next", "slice",
-               "ascii", "divmod", "id", "object", "sorted",
-               "bin", "enumerate", "input", "oct", "staticmethod",
-               "bool", "eval", "int", "open", "str",
-               "breakpoint", "exec", "isinstance", "ord", "sum",
-               "bytearray", "filter", "issubclass", "pow", "super",
-               "bytes", "float", "iter", "print", "tuple",
-               "callable", "format", "len", "property", "type",
-               "chr", "frozenset", "list", "range", "vars",
-               "classmethod", "getattr", "locals", "repr", "zip",
-               "compile", "globals", "map", "reversed", "__import__",
-               "complex", "hasattr", "max", "round"]
-
 
 def walk(node, skip_nodes=tuple()):
     """Walk through the children of an ast node.

--- a/kale/static_analysis/dependencies.py
+++ b/kale/static_analysis/dependencies.py
@@ -19,7 +19,7 @@ import networkx as nx
 from pyflakes import api as pyflakes_api
 from pyflakes import reporter as pyflakes_reporter
 
-from kale.utils import utils
+from kale.utils import utils, graph_utils
 from kale.static_analysis import ast as kale_ast
 
 
@@ -79,60 +79,28 @@ def pyflakes_report(code):
     return undef_vars
 
 
-def detect_in_dependencies(nb_graph: nx.DiGraph,
+def detect_in_dependencies(source_code: str,
                            pipeline_parameters: dict = None):
-    """Detect missing names from the code blocks in the graph.
+    """Detect missing names from one pipeline step source code.
 
     Args:
-        nb_graph: nx DiGraph with pipeline code blocks
+        source_code: Multiline Python source code
         pipeline_parameters: Pipeline parameters dict
     """
-    block_names = nb_graph.nodes()
-    for block in block_names:
-        source_code = '\n'.join(nb_graph.nodes(data=True)[block]['source'])
-        commented_source_code = utils.comment_magic_commands(source_code)
-        ins = pyflakes_report(code=commented_source_code)
+    commented_source_code = utils.comment_magic_commands(source_code)
+    ins = pyflakes_report(code=commented_source_code)
 
-        # Pipeline parameters will be part of the names that are missing,
-        # but of course we don't want to marshal them in as they will be
-        # present as parameters
-        relevant_parameters = set()
-        if pipeline_parameters:
-            # Not all pipeline parameters are needed in every pipeline step,
-            # these are the parameters that are actually needed by this step.
-            relevant_parameters = ins.intersection(pipeline_parameters.keys())
-            ins.difference_update(relevant_parameters)
-        step_params = {k: pipeline_parameters[k] for k in relevant_parameters}
-        nx.set_node_attributes(nb_graph, {block: {'ins': sorted(ins),
-                                                  'parameters': step_params}})
-
-
-def detect_out_dependencies(nb_graph: nx.DiGraph):
-    """Detect the 'out' dependencies of each code block.
-
-    These deps represent the variables that each code block must marshal to
-    child steps of the pipeline. Out deps are detected by cycling though all
-    the ancestors of each block. By knowing the 'ins' deps (e.g. missing names)
-    of the current block, we can get the blocks were those names were declared.
-    If an ancestor matches the `ins` entry then it will have a matching `outs`.
-
-    Args:
-        nb_graph: nx DiGraph with pipeline code blocks
-    """
-    for block_name in reversed(list(nx.topological_sort(nb_graph))):
-        ins = nb_graph.nodes(data=True)[block_name]['ins']
-        # for _a in nb_graph.predecessors(block_name):
-        for _a in nx.ancestors(nb_graph, block_name):
-            father_data = nb_graph.nodes(data=True)[_a]
-            # Intersect the missing names of this father's child with all
-            # the father's names. The intersection is the list of variables
-            # that the father need to serialize
-            outs = set(ins).intersection(father_data['all_names'])
-            # include previous `outs` in case this father has multiple
-            # children steps
-            outs.update(father_data['outs'])
-            # add to father the new `outs` variables
-            nx.set_node_attributes(nb_graph, {_a: {'outs': sorted(outs)}})
+    # Pipeline parameters will be part of the names that are missing,
+    # but of course we don't want to marshal them in as they will be
+    # present as parameters
+    relevant_parameters = set()
+    if pipeline_parameters:
+        # Not all pipeline parameters are needed in every pipeline step,
+        # these are the parameters that are actually needed by this step.
+        relevant_parameters = ins.intersection(pipeline_parameters.keys())
+        ins.difference_update(relevant_parameters)
+    step_params = {k: pipeline_parameters[k] for k in relevant_parameters}
+    return ins, step_params
 
 
 def detect_fns_free_variables(source_code, imports_and_functions="",
@@ -189,27 +157,110 @@ def detect_fns_free_variables(source_code, imports_and_functions="",
 
 
 def dependencies_detection(nb_graph: nx.DiGraph,
-                           pipeline_parameters: dict = None):
-    """Analyze the code blocks in the graph and detect the missing names.
+                           pipeline_parameters: dict = None,
+                           imports_and_functions: str = ""):
+    """Detect the data dependencies between nodes in the graph.
 
-    in each code block, annotating the nodes with `in` and `out` dependencies
-    based in the topology of the graph.
+    The data dependencies detection algorithm roughly works as follows:
+
+    1. Traversing the graph in topological order, for every node `step` do
+    2. Detect the `ins` of current `step` by running PyFlakes on the source
+     code. During this action the pipeline parameters are taken into
+     consideration
+    3. Parse `step`'s global function definitions to get free variables
+     (i.e. variables that would need to be marshalled in other steps that call
+     these functions) - in this action pipeline parameters are taken into
+     consideration.
+    4. Get all the function that `step` calls
+    5. For every `step`'s ancestor `anc` do
+        - Get all the potential names (objects, functions, ...) of `anc` that
+         could be marshalled (saved)
+        - Intersect this with the `step`'s `ins` (from action 2) and add the
+         result to `anc`'s `outs`.
+        - for every `step`'s function call (action 4), check if this function
+         was defined in `anc` and if it has free variables (action 3). If so,
+         add to `step`'s `ins` and to `anc`'s `outs` these free variables.
 
     Args:
         nb_graph: nx DiGraph with pipeline code blocks
         pipeline_parameters: Pipeline parameters dict
+        imports_and_functions: Multiline Python source that is prepended to
+            every pipeline step
 
     Returns: annotated graph
     """
-    # First get all the names of each code block
-    for block in nb_graph:
-        block_data = nb_graph.nodes(data=True)[block]
-        all_names = kale_ast.get_all_names('\n'.join(block_data['source']))
-        nx.set_node_attributes(nb_graph, {block: {'all_names': all_names}})
+    # resolve the data dependencies between steps, looping through the graph
+    for step in nx.topological_sort(nb_graph):
+        step_data = nb_graph.nodes(data=True)[step]
 
-    # annotate the graph inplace with all the variables dependencies between
-    # graph nodes
-    detect_in_dependencies(nb_graph, pipeline_parameters)
-    detect_out_dependencies(nb_graph)
+        # detect the INS dependencies of the CURRENT node----------------------
+        step_source_code = '\n'.join(step_data['source'])
+        # get the variables that this step is missing and the pipeline
+        # parameters that it actually needs.
+        ins, parameters = detect_in_dependencies(
+            source_code=step_source_code,
+            pipeline_parameters=pipeline_parameters)
+        fns_free_variables = detect_fns_free_variables(
+            step_source_code, imports_and_functions, pipeline_parameters)
+        # will set ins later at the end of the function, as we will
+        # potentially add more ins below
+        nx.set_node_attributes(nb_graph, {step: {
+            'fns_free_variables': fns_free_variables,
+            'parameters': parameters
+        }})
 
-    return nb_graph
+        # Get all the function calls. This will be used below to check if any
+        # of the ancestors declare any of these functions. Is that is so, the
+        # free variables of those functions will have to be loaded.
+        fn_calls = kale_ast.get_function_calls(step_source_code)
+
+        # add OUT dependencies annotations in the PARENT nodes-----------------
+        # Intersect the missing names of this father's child with all
+        # the father's names. The intersection is the list of variables
+        # that the father need to serialize
+        # The ancestors are the the nodes that have a path to `step`, ordered
+        # by path length.
+        ins_left = ins.copy()
+        for anc in (graph_utils.get_ordered_ancestors(nb_graph, step)):
+            if not ins_left:
+                # if there are no more variables that need to be marshalled,
+                # stop the graph traverse
+                break
+            anc_data = nb_graph.nodes(data=True)[anc]
+            anc_source = '\n'.join(anc_data['source'])
+            # get all the marshal candidates from father's source and intersect
+            # with the required names of the current node
+            marshal_candidates = kale_ast.get_marshal_candidates(anc_source)
+            outs = ins_left.intersection(marshal_candidates)
+            # Remove the ins that have already been assigned to an ancestor.
+            ins_left.difference_update(outs)
+            # Include free variables
+            to_remove = set()
+            for fn_call in fn_calls:
+                fns_free_variables = anc_data.get("fns_free_variables", {})
+                if fn_call in fns_free_variables.keys():
+                    # the current step needs to load these variables
+                    fn_free_vars, used_params = fns_free_variables[fn_call]
+                    ins.update(fn_free_vars)
+                    # the current ancestor needs to save these variables
+                    outs.update(fn_free_vars)
+                    # add the parameters used by the function to the list
+                    # of pipeline parameters used by the step
+                    step_params = step_data.get("parameters", {})
+                    for param in used_params:
+                        if param not in step_params:
+                            step_params[param] = pipeline_parameters[param]
+                    nx.set_node_attributes(nb_graph,
+                                           {step: {'params': step_params}})
+                    # Remove this function as it has been served. We don't want
+                    # other ancestors to save free variables for this function.
+                    # Using the helper to_remove because the set can not be
+                    # resized during iteration.
+                    to_remove.add(fn_call)
+            fn_calls.difference_update(to_remove)
+            # Add to ancestor the new outs annotations. First merge the current
+            # outs present in the anc with the new ones
+            outs.update(anc_data.get('outs', []))
+            nx.set_node_attributes(nb_graph, {anc: {'outs': sorted(outs)}})
+
+        nx.set_node_attributes(nb_graph, {step: {'ins': sorted(ins)}})

--- a/kale/tests/unit_tests/test_graph_utils.py
+++ b/kale/tests/unit_tests/test_graph_utils.py
@@ -1,0 +1,41 @@
+#  Copyright 2020 The Kale Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import networkx as nx
+
+from kale.utils import graph_utils
+
+
+def test_get_ordered_ancestors():
+    """Test that the ancestors are retrieved in the expected order."""
+    g = nx.DiGraph()
+    # Layer 1
+    g.add_edge("A", "B")
+    # Layer 2
+    g.add_edge("B", "C")
+    g.add_edge("B", "D")
+    g.add_edge("B", "E")
+    # Layer 3
+    g.add_edge("C", "R")
+    g.add_edge("D", "R")
+    g.add_edge("E", "R")
+
+    ancs = ["B", "A"]
+    assert graph_utils.get_ordered_ancestors(g, "E") == ancs
+
+    ancs = ["B", "A"]
+    assert graph_utils.get_ordered_ancestors(g, "C") == ancs
+
+    ancs = ["C", "D", "E", "B", "A"]
+    assert graph_utils.get_ordered_ancestors(g, "R") == ancs

--- a/kale/utils/graph_utils.py
+++ b/kale/utils/graph_utils.py
@@ -1,0 +1,74 @@
+#  Copyright 2020 The Kale Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import networkx as nx
+
+
+def get_ordered_ancestors(g: nx.DiGraph, node):
+    """Get a list of ancestors ordered by DAG layers.
+
+    The default NetworkX ancestors function computes all the ancestors of a
+    node by returning all the nodes that have a path to it. The problem is
+    that there is not guarantee in the ordering of the result.
+
+    Example graph G:
+
+              +---+
+              | A |
+              +---+
+                |
+                v
+    +---+     +---+     +---+
+    | C | <-- | B | --> | D |
+    +---+     +---+     +---+
+      |         |         |
+      |         v         |
+      |       +---+       |
+      |       | E |       |
+      |       +---+       |
+      |         |         |
+      |         v         |
+      |       +---+       |
+      +-----> | R | <-----+
+              +---+
+
+    Running G.ancestors('R') will return a set with the correct ancestors,
+    but they are not ordered by DAG Layer. Since Kale needs to analyze the
+    nodes in reverse execution order, we need to compute the ancestors
+    as ['C', 'E', 'D', 'B', 'A'], where ['C', 'E', 'D'] is the first ancestor
+    layer, ['B'] the second and ['A'] the third.
+
+    This all comes down to performing a reversed breadth-first search, avoiding
+    duplicates in the resulting list of ancestors.
+
+    Args:
+         g (nx.DiGraph): A DAG representing a pipeline
+         node (str): The name of the node for which to compute the ancestors
+
+    Returns (list): A list of ancestors, ordered by DAG layers.
+    """
+    # list of ancestors, unique and ordered by layers
+    ancs = list()
+    # used as queue
+    q = [node]
+
+    while q:
+        cur = q.pop(0)
+        # sort ancestors for a deterministic result
+        preds = sorted(list(g.predecessors(cur)))
+        for p in preds:
+            if p not in ancs:
+                ancs.append(p)
+                q.append(p)
+    return ancs

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     install_requires=[
         'kfp >= 0.2',
         'autopep8 >=1.4, <1.5',
+        'astor >= 0.8.1',
         'nbformat >=4.4, <5.0',
         'networkx >=2.3, <3.0',
         'jinja2 >=2.10, <3.0',


### PR DESCRIPTION
The previous dependencies detection algorithm (roughly) worked as follows:

1. Get all the "names" of every pipeline step, using static analysis. This includes variable names, function names, import names.
2. Detect `ins` (objects to be loaded) for every step: run pyflakes over the source code of each step to detect which variables are missing.
3. Detect `outs` (objects to be saved) for every step: The outs of a specific step are computed as the intersection between the `ins` of all its childs and the "names" computed during 1. This was done following a reversed topological order of the graph.

The design explained above had many uncovered edge cases and could not be easily extended to future improvements.

This PR introduced a completely revamped approach that can be summarised as follows:

1. For every node `step` in the graph - traversing in a topological sort:
2. Detect the `ins` of the current `step`: This is done using pyflakes, that detects all the undefined names in the source code. During this action, pipeline parameters are also taken into consideration.
3. Detect global functions' free variables [1]: check out the helper functions implemented here https://github.com/kubeflow-kale/kale/commit/5f8078a18e862672259cf4aafabd2df506bb9256 and here https://github.com/kubeflow-kale/kale/commit/03237c78682b59f0c655f4056ba0f3e29b81a41d.
4. Get all the function calls (`fn_calls`) of the current `step`.
5. For each of the ancestors `anc` (ancestors are retrieved using the function implemented in https://github.com/kubeflow-kale/kale/commit/6cec54cb6039598eff388b2586ead14cfa68fdb2) of `step`:
	- Annotate `anc` with the variables that are to be saved, baed on what `step` needs.
	- If `step` calls any function that was parsed during action 3. , load the free variables of that function.
6. Back to action 1.

---

[1]: **Free variables and function serialization**

Free variable: _If a variable is used in a code block but not defined there, it is a free variable._

Example:

```python
x = 5

def foo():
	print(x)
```

In the example above, `x` is a free variable of function `foo`, because it is defined outside of the context of `foo`.

This can cause issues when splitting the notebook code into multiple independed steps.

Example:

Step A:

```python
x = 5

def foo():
	print(x)
```

Step B:

```python
foo()
```

By just analyzing the source code of B, Kale would require `foo` to be marshalled between A and B. But upon calling `foo()` in B, the execution would fail, as `x` would be missing.
