### PR TITLE
Fix pipeline-metrics to not include html in ui-metadata

### DIFF
--- a/kale/templates/function_template.jinja2
+++ b/kale/templates/function_template.jinja2
@@ -60,8 +60,12 @@ def {{ step_name }}({%- for arg in parameters_names -%}
               block{{ loop.index }},
 {%- endfor %}
               {% if out_variables|length > 0 %}data_saving_block{% endif %})
+{%- if step_name == "pipeline_metrics" %}
+    _kale_run_code(blocks)
+{% else %}
     html_artifact = _kale_run_code(blocks)
     with open("/{{ step_name }}.html", "w") as f:
         f.write(html_artifact)
     _kale_update_uimetadata('{{ step_name }}')
+{% endif -%}
 {% endif -%}

--- a/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
+++ b/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
@@ -130,10 +130,7 @@ def pipeline_metrics(d1: int, d2: int):
     blocks = (pipeline_parameters_block, data_loading_block,
               block1,
               )
-    html_artifact = _kale_run_code(blocks)
-    with open("/pipeline_metrics.html", "w") as f:
-        f.write(html_artifact)
-    _kale_update_uimetadata('pipeline_metrics')
+    _kale_run_code(blocks)
 
 
 create_matrix_op = comp.func_to_container_op(create_matrix)


### PR DESCRIPTION
Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>

---

The problem is that `pipeline_metrics` special step is adding the HTML output (empty) in `mlpipeline-ui-metadata` but in the same time it is not set as an output artifact (so it's not uploaded in artifact store). Thus, KFP UI produces an error when trying to fetch it.

I'm not sure if that's the best way to write the template, without it being complex. Feel free to propose a different format!