### PR TITLE
Generate unique run names uniformly across repo

### DIFF
--- a/kale/command_line.py
+++ b/kale/command_line.py
@@ -106,8 +106,10 @@ def main():
         )
 
     if args.run_pipeline:
+        run_name = kfp_utils.generate_run_name(
+            kale.pipeline_metadata['pipeline_name'])
         kfp_utils.run_pipeline(
-            run_name=kale.pipeline_metadata['pipeline_name'] + '_run',
+            run_name=run_name,
             experiment_name=kale.pipeline_metadata['experiment_name'],
             pipeline_package_path=pipeline_package_path,
             host=kale.pipeline_metadata.get('kfp_host', None)

--- a/kale/rpc/kfp.py
+++ b/kale/rpc/kfp.py
@@ -15,6 +15,8 @@
 import kfp
 from kfp_server_api.rest import ApiException
 
+from kale.utils import kfp_utils
+
 _client = None
 
 
@@ -86,7 +88,7 @@ def run_pipeline(request, pipeline_metadata, pipeline_package_path=None,
     """Run a pipeline."""
     client = _get_client(pipeline_metadata.get("kfp_host", None))
     experiment = client.create_experiment(pipeline_metadata["experiment_name"])
-    run_name = pipeline_metadata["pipeline_name"] + "_run"
+    run_name = kfp_utils.generate_run_name(pipeline_metadata["pipeline_name"])
     run = client.run_pipeline(experiment.id, run_name,
                               pipeline_package_path=pipeline_package_path,
                               pipeline_id=pipeline_id)

--- a/kale/templates/pipeline_template.jinja2
+++ b/kale/templates/pipeline_template.jinja2
@@ -141,5 +141,6 @@ if __name__ == "__main__":
     experiment = client.create_experiment('{{ experiment_name }}')
 
     # Submit a pipeline run
-    run_name = '{{ pipeline_name }}_run'
+    from kale.utils.kfp_utils import generate_run_name
+    run_name = generate_run_name('{{ pipeline_name }}')
     run_result = client.run_pipeline(experiment.id, run_name, pipeline_filename, {})

--- a/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
+++ b/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
@@ -204,6 +204,7 @@ if __name__ == "__main__":
     experiment = client.create_experiment('hp tuning')
 
     # Submit a pipeline run
-    run_name = 'hp-test-rnd_run'
+    from kale.utils.kfp_utils import generate_run_name
+    run_name = generate_run_name('hp-test-rnd')
     run_result = client.run_pipeline(
         experiment.id, run_name, pipeline_filename, {})

--- a/kale/tests/assets/kfp_dsl/titanic.py
+++ b/kale/tests/assets/kfp_dsl/titanic.py
@@ -835,6 +835,7 @@ if __name__ == "__main__":
     experiment = client.create_experiment('Titanic')
 
     # Submit a pipeline run
-    run_name = 'titanic-ml-rnd_run'
+    from kale.utils.kfp_utils import generate_run_name
+    run_name = generate_run_name('titanic-ml-rnd')
     run_result = client.run_pipeline(
         experiment.id, run_name, pipeline_filename, {})

--- a/kale/utils/kfp_utils.py
+++ b/kale/utils/kfp_utils.py
@@ -22,6 +22,8 @@ from kfp.compiler import Compiler
 
 from kfp_server_api.rest import ApiException
 
+from kale.utils import utils
+
 
 def _get_kfp_client(host=None):
     return Client(host=host)
@@ -121,3 +123,8 @@ def run_pipeline(run_name, experiment_name, pipeline_package_path, host=None):
                               {})
     # return the run metadata
     return run
+
+
+def generate_run_name(pipeline_name: str):
+    """Generate a new run name based on pipeline name."""
+    return "{}_run-{}".format(pipeline_name, utils.random_string(5))


### PR DESCRIPTION
* Provide a kfp_utils.generate_run_name() function which accepts a
  pipeline name (str) and generates a _unique_ run name.
* Use that function everywhere across the repo for a uniform experience.

Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>