### PR TITLE
Add a new RPC to validate notebook metadata

### DIFF
--- a/kale/rpc/nb.py
+++ b/kale/rpc/nb.py
@@ -91,6 +91,14 @@ def compile_notebook(request, source_notebook_path,
             "pipeline_metadata": instance.pipeline_metadata}
 
 
+def validate_notebook(request, source_notebook_path,
+                      notebook_metadata_overrides=None):
+    """Validate notebook metadata."""
+    # Notebook metadata is validated at class instantiation
+    Kale(source_notebook_path, notebook_metadata_overrides)
+    return True
+
+
 def get_pipeline_parameters(request, source_notebook_path):
     """Get the pipeline parameters tagged in the notebook."""
     # read notebook


### PR DESCRIPTION
Alongside adding a simple function to `rpc/nb.py` to perform validation of the notebook before taking the volume stapshots, this PR includes:

- Refactoring of the logging logic, by moving the initialisation of the main Kale logger from `Kale.__init__()` to `kale/__init__.py`.
- Remove the snapshot procedure at the end of `Kale.__init__()`. Since now we always take snapshots from the UI, using the rpcs defined in `rpc/rok.py` we were execution code with no effect. It makes sense to remove the snapshotting logic from `__init__` anyway and, in case we would like to be able to take snapshots by running Kale from CLI in the future, then we will probably repurpose the functions defined in `rpc/rok.py`.

@elikatsis one note: by moving the initialisation of the logger to `__init__.py` and getting it using `__name__` in `core.py` I don't get the right logger. That is why the e2e test fails, because the `kale.log` file is not created. It looks to me that we are doing the same thing we are doing for the marshal module, but it doesn't work the same way. WDYT?