### PR TITLE
Add annotation and limit tags and GPU UI

### DIFF
--- a/backend/kale/templates/pipeline_template.jinja2
+++ b/backend/kale/templates/pipeline_template.jinja2
@@ -51,7 +51,7 @@ def auto_generated_pipeline({%- for arg in parameters_names -%}
                 requests={"storage": {{ pvc_size }}}
             )
         )
-    )                                                              
+    )
 
     vop{{ loop.index }} = dsl.VolumeOp(
         name="pvc-data{{ loop.index }}",
@@ -96,17 +96,26 @@ def auto_generated_pipeline({%- for arg in parameters_names -%}
     {% endif %}
 
     {% for name in step_names %}
-
     {{ name }}_task = {{ name }}_op({{ all_step_parameters[name]|join(', ') }})\
                             .add_pvolumes(pvolumes_dict)\
                             .after({{ step_prevs[ name ]|join(', ') }})
+    {%- if nb_graph.nodes(data=True)[name].get("annotations") %}
+    step_annotations = {{ nb_graph.nodes(data=True)[name].get("annotations", {}) }}
+    for k, v in step_annotations.items():
+        {{ name }}_task.container.add_pod_annotation(k, v)
+    {%- endif %}
+    {%- if nb_graph.nodes(data=True)[name].get("limits") %}
+    step_limits = {{ nb_graph.nodes(data=True)[name].get("limits", {}) }}
+    for k, v in step_limits.items():
+      {{ name }}_task.container.add_resource_limit(k, v)
+    {%- endif %}
     {{ name }}_task.container.working_dir = "{{ abs_working_dir }}"
     {{ name }}_task.container.set_security_context(k8s_client.V1SecurityContext(run_as_user=0))
     output_artifacts = {}
     {%- if auto_snapshot %}
     output_artifacts.update({'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
     {%- endif %}
-    {%- if nb_graph.nodes(data=True)[name].get("metrics", false) %}
+    {%- if nb_graph.nodes(data=True)[name].get("metrics") %}
     output_artifacts.update({'mlpipeline-metrics': '/mlpipeline-metrics.json'})
     {%- endif %}
     {%- if name != "final_auto_snapshot" and name != "pipeline_metrics" %}

--- a/backend/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
+++ b/backend/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
@@ -115,6 +115,9 @@ def auto_generated_pipeline(booltest='True', d1='5', d2='6', strtest='test'):
     create_matrix_task = create_matrix_op(d1, d2)\
         .add_pvolumes(pvolumes_dict)\
         .after()
+    step_limits = {'nvidia.com/gpu': '2'}
+    for k, v in step_limits.items():
+        create_matrix_task.container.add_resource_limit(k, v)
     create_matrix_task.container.working_dir = "/kale"
     create_matrix_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))

--- a/backend/kale/tests/assets/notebooks/pipeline_parameters_and_metrics.ipynb
+++ b/backend/kale/tests/assets/notebooks/pipeline_parameters_and_metrics.ipynb
@@ -34,7 +34,8 @@
    "execution_count": 28,
    "metadata": {
     "tags": [
-     "block:create_matrix"
+     "block:create_matrix",
+     "limit:nvidia.com/gpu:2"
     ]
    },
    "outputs": [],

--- a/labextension/src/components/cell-metadata/CellMetadataEditorDialog.tsx
+++ b/labextension/src/components/cell-metadata/CellMetadataEditorDialog.tsx
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2020 The Kale Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import { MaterialInput, MaterialSelect } from '../Components';
+import {
+  Button,
+  Chip,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  Grid,
+  Switch,
+} from '@material-ui/core';
+import ColorUtils from './ColorUtils';
+
+const GPU_TYPES = [
+  { value: 'nvidia.com/gpu', label: 'Nvidia' },
+  { value: 'amd.com/gpu', label: 'AMD' },
+];
+const DEFAULT_GPU_TYPE = GPU_TYPES[0].value;
+
+interface ICellMetadataEditorDialog {
+  open: boolean;
+  stepName: string;
+  limits: { [id: string]: string };
+  updateLimits: Function;
+  toggleDialog: Function;
+}
+
+export const CellMetadataEditorDialog: React.FunctionComponent<ICellMetadataEditorDialog> = props => {
+  const handleClose = () => {
+    props.toggleDialog();
+  };
+
+  const limitAction = (
+    action: string,
+    limitKey: string,
+    limitValue: string = null,
+  ) => {
+    return {
+      action,
+      limitKey,
+      limitValue,
+    };
+  };
+
+  // intersect the current limits and the GPU_TYPES. Assume there is at most 1.
+  const gpuType =
+    Object.keys(props.limits).filter(x =>
+      GPU_TYPES.map(t => t.value).includes(x),
+    )[0] || undefined;
+  const gpuCount = props.limits[gpuType] || undefined;
+
+  return (
+    <Dialog
+      open={props.open}
+      onClose={handleClose}
+      fullWidth={true}
+      maxWidth={'sm'}
+      scroll="paper"
+      aria-labelledby="scroll-dialog-title"
+      aria-describedby="scroll-dialog-description"
+    >
+      <DialogTitle id="scroll-dialog-title">
+        <Grid
+          container
+          direction="row"
+          justify="space-between"
+          alignItems="center"
+        >
+          <Grid item xs={9}>
+            <Grid
+              container
+              direction="row"
+              justify="flex-start"
+              alignItems="center"
+            >
+              <p>Require GPU for step </p>
+              <Chip
+                className={'kale-chip'}
+                style={{
+                  marginLeft: '10px',
+                  backgroundColor: `#${ColorUtils.getColor(props.stepName)}`,
+                }}
+                key={props.stepName}
+                label={props.stepName}
+              />
+            </Grid>
+          </Grid>
+          <Grid item xs={3}>
+            <Grid
+              container
+              direction="row"
+              justify="flex-end"
+              alignItems="center"
+            >
+              <Switch
+                checked={gpuType !== undefined}
+                onChange={c => {
+                  if (c.target.checked) {
+                    // default value
+                    props.updateLimits([
+                      limitAction('update', DEFAULT_GPU_TYPE, '1'),
+                    ]);
+                  } else {
+                    props.updateLimits([limitAction('delete', gpuType)]);
+                  }
+                }}
+                color="primary"
+                name="enableKale"
+                inputProps={{ 'aria-label': 'primary checkbox' }}
+                classes={{ root: 'material-switch' }}
+              />
+            </Grid>
+          </Grid>
+        </Grid>
+      </DialogTitle>
+      <DialogContent dividers={true} style={{ paddingTop: 0 }}>
+        <Grid container direction="column" justify="center" alignItems="center">
+          <Grid
+            container
+            direction="row"
+            justify="space-between"
+            alignItems="center"
+            style={{ marginTop: '15px' }}
+          >
+            <Grid item xs={6}>
+              <MaterialInput
+                disabled={gpuType === undefined}
+                variant="outlined"
+                label="GPU Count"
+                value={gpuCount || 1}
+                updateValue={(v: string) =>
+                  props.updateLimits([limitAction('update', gpuType, v)])
+                }
+                style={{ width: '95%' }}
+              />
+            </Grid>
+            <Grid item xs={6}>
+              <MaterialSelect
+                disabled={gpuType === undefined}
+                updateValue={(v: string) => {
+                  props.updateLimits([
+                    limitAction('delete', gpuType),
+                    limitAction('update', v, gpuCount),
+                  ]);
+                }}
+                values={GPU_TYPES}
+                value={gpuType || DEFAULT_GPU_TYPE}
+                label="GPU Type"
+                index={0}
+                variant="outlined"
+              />
+            </Grid>
+          </Grid>
+        </Grid>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleClose} color="primary">
+          Ok
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/labextension/src/components/cell-metadata/InlineCellMetadata.tsx
+++ b/labextension/src/components/cell-metadata/InlineCellMetadata.tsx
@@ -226,6 +226,7 @@ export class InlineCellsMetadata extends React.Component<IProps, IState> {
         notebook: this.props.notebook,
         stepName: tags.blockName || '',
         stepDependencies: tags.prevBlockNames || [],
+        limits: tags.annotations || {},
       };
       editors[index] = editorProps;
       metadata.push(
@@ -277,7 +278,7 @@ export class InlineCellsMetadata extends React.Component<IProps, IState> {
   render() {
     // Get the editor props of the active cell, so that just one editor is
     // rendered at any given time.
-    const editorProps = {
+    const editorProps: EditorProps = {
       ...this.state.editors[this.props.activeCellIndex],
     };
     return (
@@ -305,6 +306,7 @@ export class InlineCellsMetadata extends React.Component<IProps, IState> {
               notebook={editorProps.notebook}
               stepName={editorProps.stepName}
               stepDependencies={editorProps.stepDependencies}
+              limits={editorProps.limits}
             />
             {this.state.metadataCmp}
           </CellMetadataContext.Provider>

--- a/labextension/src/components/cell-metadata/InlineCellMetadata.tsx
+++ b/labextension/src/components/cell-metadata/InlineCellMetadata.tsx
@@ -226,7 +226,7 @@ export class InlineCellsMetadata extends React.Component<IProps, IState> {
         notebook: this.props.notebook,
         stepName: tags.blockName || '',
         stepDependencies: tags.prevBlockNames || [],
-        limits: tags.annotations || {},
+        limits: tags.limits || {},
       };
       editors[index] = editorProps;
       metadata.push(
@@ -235,6 +235,7 @@ export class InlineCellsMetadata extends React.Component<IProps, IState> {
           cellElement={this.props.notebook.content.node.childNodes[index]}
           blockName={tags.blockName}
           stepDependencies={tags.prevBlockNames}
+          limits={tags.limits || {}}
           previousBlockName={previousBlockName}
           cellIndex={index}
         />,

--- a/labextension/src/components/cell-metadata/InlineMetadata.tsx
+++ b/labextension/src/components/cell-metadata/InlineMetadata.tsx
@@ -28,6 +28,7 @@ interface IProps {
   blockName: string;
   previousBlockName: string;
   stepDependencies: string[];
+  limits: { [id: string]: string };
   cellElement: any;
   cellIndex: number;
 }
@@ -204,6 +205,25 @@ export class InlineMetadata extends React.Component<IProps, IState> {
     return ColorUtils.getColor(name);
   }
 
+  createLimitsText() {
+    const gpuType = Object.keys(this.props.limits).includes('nvidia.com/gpu')
+      ? 'nvidia.com/gpu'
+      : Object.keys(this.props.limits).includes('amd.com/gpu')
+      ? 'amd.com/gpu'
+      : undefined;
+
+    return gpuType !== undefined ? (
+      <React.Fragment>
+        <p style={{ fontStyle: 'italic', marginLeft: '10px' }}>
+          GPU request: {gpuType + ' - '}
+          {this.props.limits[gpuType]}
+        </p>
+      </React.Fragment>
+    ) : (
+      ''
+    );
+  }
+
   /**
    * Create a list of div dots that represent the dependencies of the current
    * block
@@ -275,6 +295,8 @@ export class InlineMetadata extends React.Component<IProps, IState> {
               ''
             )}
             {this.state.dependencies}
+
+            {this.createLimitsText()}
           </div>
 
           <div


### PR DESCRIPTION
This PR adds two new tags to the backend: `annotation` and `limit`. These tags are parsed in `step` cells and are added respectively as pod annotations and K8s resource limits using the KFP SDK.

On the UI side, the PR adds a new Dialog to request the use of GPU for a specific pipeline step.