### PR TITLE
Restrict experiment name to be a valid k8s name

### DIFF
--- a/backend/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
+++ b/backend/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
@@ -148,7 +148,7 @@ if __name__ == "__main__":
     # Get or create an experiment and submit a pipeline run
     import kfp
     client = kfp.Client()
-    experiment = client.create_experiment('hp tuning')
+    experiment = client.create_experiment('hp-tuning')
 
     # Submit a pipeline run
     from kale.utils.kfp_utils import generate_run_name

--- a/backend/kale/tests/assets/kfp_dsl/titanic.py
+++ b/backend/kale/tests/assets/kfp_dsl/titanic.py
@@ -6,8 +6,8 @@ from kubernetes import client as k8s_client
 
 def loaddata():
     block1 = '''
-    import numpy as np 
-    import pandas as pd 
+    import numpy as np
+    import pandas as pd
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -68,8 +68,8 @@ def datapreprocessing():
     '''
 
     block1 = '''
-    import numpy as np 
-    import pandas as pd 
+    import numpy as np
+    import pandas as pd
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -192,8 +192,8 @@ def featureengineering():
     '''
 
     block1 = '''
-    import numpy as np 
-    import pandas as pd 
+    import numpy as np
+    import pandas as pd
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -351,8 +351,8 @@ def decisiontree():
     '''
 
     block1 = '''
-    import numpy as np 
-    import pandas as pd 
+    import numpy as np
+    import pandas as pd
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -408,8 +408,8 @@ def svm():
     '''
 
     block1 = '''
-    import numpy as np 
-    import pandas as pd 
+    import numpy as np
+    import pandas as pd
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -465,8 +465,8 @@ def naivebayes():
     '''
 
     block1 = '''
-    import numpy as np 
-    import pandas as pd 
+    import numpy as np
+    import pandas as pd
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -522,8 +522,8 @@ def logisticregression():
     '''
 
     block1 = '''
-    import numpy as np 
-    import pandas as pd 
+    import numpy as np
+    import pandas as pd
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -579,8 +579,8 @@ def randomforest():
     '''
 
     block1 = '''
-    import numpy as np 
-    import pandas as pd 
+    import numpy as np
+    import pandas as pd
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -639,8 +639,8 @@ def results():
     '''
 
     block1 = '''
-    import numpy as np 
-    import pandas as pd 
+    import numpy as np
+    import pandas as pd
     import seaborn as sns
     from matplotlib import pyplot as plt
     from matplotlib import style
@@ -658,9 +658,9 @@ def results():
 
     block2 = '''
     results = pd.DataFrame({
-        'Model': ['Support Vector Machines', 'logistic Regression', 
+        'Model': ['Support Vector Machines', 'logistic Regression',
                   'Random Forest', 'Naive Bayes', 'Decision Tree'],
-        'Score': [acc_linear_svc, acc_log, 
+        'Score': [acc_linear_svc, acc_log,
                   acc_random_forest, acc_gaussian, acc_decision_tree]})
     result_df = results.sort_values(by='Score', ascending=False)
     result_df = result_df.set_index('Score')
@@ -841,7 +841,7 @@ if __name__ == "__main__":
     # Get or create an experiment and submit a pipeline run
     import kfp
     client = kfp.Client()
-    experiment = client.create_experiment('Titanic')
+    experiment = client.create_experiment('titanic')
 
     # Submit a pipeline run
     from kale.utils.kfp_utils import generate_run_name

--- a/backend/kale/tests/assets/notebooks/pipeline_parameters_and_metrics.ipynb
+++ b/backend/kale/tests/assets/notebooks/pipeline_parameters_and_metrics.ipynb
@@ -84,7 +84,7 @@
     "id": "new",
     "name": "hp tuning"
    },
-   "experiment_name": "hp tuning",
+   "experiment_name": "hp-tuning",
    "katib_run": false,
    "pipeline_description": "",
    "pipeline_name": "hp-test",

--- a/backend/kale/utils/metadata_utils.py
+++ b/backend/kale/utils/metadata_utils.py
@@ -40,9 +40,10 @@ KALE_STEP_NAME_REGEX = r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
 KALE_NAME_MSG = ("must consist of lower case alphanumeric characters"
                  " or '-', and must start and end with an alphanumeric"
                  " character.")
-K8S_VALID_NAME_REGEX = r'^[a-z]([a-z0-9-.]*[a-z0-9])?$'
-K8S_NAME_MSG = ("must consist of lower case alphanumeric characters,"
-                " '-' or '.', and must start and end with a character.")
+K8S_VALID_NAME_REGEX = r'^[a-z]([a-z0-9-]*[a-z0-9])?$'
+K8S_NAME_MSG = ("must consist of lower case alphanumeric characters or"
+                " '-', and must start with a lowercase character and end with"
+                " a lowercase alphanumeric character.")
 VOLUME_TYPES = ('pv', 'pvc', 'new_pvc', 'clone')
 VOLUME_REQUIRED_FIELDS = ('name', 'annotations', 'size', 'type', 'mount_point')
 
@@ -66,6 +67,9 @@ def parse_metadata(notebook_metadata):
 
     metadata = copy.deepcopy(DEFAULT_METADATA)
     metadata.update(validated_notebook_metadata)
+
+    if not re.match(K8S_VALID_NAME_REGEX, metadata['experiment_name']):
+        raise ValueError("Experiment name  {}".format(K8S_NAME_MSG))
 
     if not re.match(KALE_STEP_NAME_REGEX, metadata['pipeline_name']):
         raise ValueError("Pipeline name  {}".format(KALE_NAME_MSG))

--- a/labextension/src/components/ExperimentInput.tsx
+++ b/labextension/src/components/ExperimentInput.tsx
@@ -18,11 +18,11 @@ import * as React from 'react';
 import { MaterialInput, MaterialSelect } from './Components';
 import { ISelectOption, IExperiment, NEW_EXPERIMENT } from './LeftPanelWidget';
 
-const regex: string = '^[a-zA-Z][-_a-zA-z0-9\\s]*$';
+const regex: string = '^[a-z]([-a-z0-9]*[a-z0-9])?$';
 const regexErrorMsg: string =
   'Experiment name may consist of alphanumeric ' +
-  "characters, '-', '_' and white spaces, and " +
-  'must begin with letter.';
+  "characters, '-', and must start with a lowercase character and end with " +
+  'a lowercase alphanumeric character.';
 
 interface IExperimentInput {
   updateValue: Function;


### PR DESCRIPTION
Since we will use the KFP experiment name as the Katib experiment name and since Katib requires a valid K8s resource name for the experiment, we need to validate the KFP experiment name accordingly. This does not hamper much usability, as the use can still still create names that are expressive enough.