### PR TITLE
backend: Add text streams to the notebook's KFP artifact

### DIFF
--- a/backend/kale/tests/unit_tests/test_jupyter_utils.py
+++ b/backend/kale/tests/unit_tests/test_jupyter_utils.py
@@ -28,15 +28,15 @@ def _output_display(data):
     ([], ""),
     # ---
     (_output_display({'image/png': "bytes"}),
-     ju.image_html_template.format("", "bytes")),
+     ju.IMAGE_HTML_TEMPLATE.format("", "bytes")),
     # ---
     (_output_display({'text/html': "bytes"}), "bytes"),
     # ---
     (_output_display({'text/plain': "bytes"}),
-     ju.text_html_template.format("bytes")),
+     ju.TEXT_HTML_TEMPLATE.format("bytes")),
     # ---
     (_output_display({'application/javascript': "bytes"}),
-     ju.javascript_html_template.format("bytes")),
+     ju.JAVASCRIPT_HTML_TEMPLATE.format("bytes")),
 ])
 def test_generate_html_output(outputs, target):
     """Tests html artifact generation from cell outputs."""

--- a/backend/kale/utils/jupyter_utils.py
+++ b/backend/kale/utils/jupyter_utils.py
@@ -26,7 +26,7 @@ from nbconvert.preprocessors.execute import ExecutePreprocessor
 
 from packaging import version as pkg_version
 
-html_template = '''
+HTML_TEMPLATE = '''
 <html><head>
     <style>
         table {
@@ -61,14 +61,14 @@ html_template = '''
 </html>
 '''
 
-image_html_template = '''
+IMAGE_HTML_TEMPLATE = '''
 <div>
   <p>{}</p>
   <img src="data:image/png;base64, {}" />
 </div>
 '''
 
-text_html_template = '''
+TEXT_HTML_TEMPLATE = '''
 <div style="margin:10px 0;">
 <pre>
 {}
@@ -76,19 +76,19 @@ text_html_template = '''
 </div>
 '''
 
-stream_html_template = '''
+STREAM_HTML_TEMPLATE = '''
 <pre style="margin:0;">
 {}
 </pre>
 '''
 
-stream_error_container_html_template = '''
+STREAM_ERROR_CONTAINER_HTML_TEMPLATE = '''
 <div style="background:#FFDDDD;">
 {}
 </div>
 '''
 
-javascript_html_template = '''
+JAVASCRIPT_HTML_TEMPLATE = '''
 <script>
 {}
 </script>
@@ -124,10 +124,10 @@ def generate_html_output(outputs):
                              " Output: {}".format(o))
         if o['output_type'] == 'stream':
             if o['name'] == 'stdout':
-                html = stream_html_template.format(o['text'])
+                html = STREAM_HTML_TEMPLATE.format(o['text'])
             if o['name'] == 'stderr':
-                html = stream_error_container_html_template.format(
-                    stream_html_template.format(o['text']))
+                html = STREAM_ERROR_CONTAINER_HTML_TEMPLATE.format(
+                    STREAM_HTML_TEMPLATE.format(o['text']))
         if o['output_type'] in ['display_data', 'execute_result']:
             # check mime-type of content
             # Currently supported MIME types:
@@ -145,7 +145,7 @@ def generate_html_output(outputs):
             # TODO: Generalize to multiple image types (i.e. jpeg and svg+xml)
             if 'image/png' in data:
                 title = data.get('text/plain', '')
-                html += image_html_template.format(title, data['image/png'])
+                html += IMAGE_HTML_TEMPLATE.format(title, data['image/png'])
 
             if 'text/html' in data:
                 html += data['text/html']
@@ -153,10 +153,10 @@ def generate_html_output(outputs):
             if ('image/png' not in data
                     and 'text/html' not in data
                     and 'text/plain' in data):
-                html += text_html_template.format(data['text/plain'])
+                html += TEXT_HTML_TEMPLATE.format(data['text/plain'])
 
             if 'application/javascript' in data:
-                html += javascript_html_template.format(
+                html += JAVASCRIPT_HTML_TEMPLATE.format(
                     data['application/javascript'])
         html_body += html
     return html_body
@@ -169,7 +169,7 @@ def process_outputs(cells):
     html_outputs = '\n'.join(html_outputs).strip()
     if html_outputs == "":
         html_outputs = "This step did not produce any artifacts."
-    html_artifact = html_template % html_outputs
+    html_artifact = HTML_TEMPLATE % html_outputs
     return html_artifact
 
 


### PR DESCRIPTION
This PR adds the text streams `stdout` and `stderr` to the notebook artifact that is generated for each pipeline step. In this way, the artifact tries to be a as close as possible replica of the original output seen in the notebook.