### PR TITLE
labextension: Add lists to numeric Katib args

### DIFF
--- a/labextension/src/components/Components.tsx
+++ b/labextension/src/components/Components.tsx
@@ -113,7 +113,7 @@ export const MaterialInput: React.FunctionComponent<IMaterialInput> = props => {
     } else if (props.validation && props.validation == 'int') {
       return 'Integer value required';
     } else if (props.validation && props.validation == 'double') {
-      return 'Float value required';
+      return 'Double value required';
     } else {
       return undefined;
     }

--- a/labextension/src/components/KatibDialog.tsx
+++ b/labextension/src/components/KatibDialog.tsx
@@ -551,7 +551,7 @@ export const KatibDialog: React.FunctionComponent<KabitDialog> = props => {
                 <Button
                   variant="contained"
                   size="small"
-                  title="Add Category"
+                  title="Add Value"
                   color="primary"
                   style={{ marginRight: '52px' }}
                   onClick={() => {
@@ -562,7 +562,7 @@ export const KatibDialog: React.FunctionComponent<KabitDialog> = props => {
                   }}
                 >
                   <AddIcon />
-                  Add Category
+                  Add Value
                 </Button>
               </div>
             </Grid>

--- a/labextension/src/components/KatibDialog.tsx
+++ b/labextension/src/components/KatibDialog.tsx
@@ -515,7 +515,7 @@ export const KatibDialog: React.FunctionComponent<KabitDialog> = props => {
                         : null
                     }
                     variant={'outlined'}
-                    label={'Value' + idx}
+                    label={'Value'}
                     value={value}
                     updateValue={updateParameter(
                       metadataParameter.name,

--- a/labextension/src/components/KatibDialog.tsx
+++ b/labextension/src/components/KatibDialog.tsx
@@ -196,7 +196,13 @@ export const KatibDialog: React.FunctionComponent<KabitDialog> = props => {
         );
         return (
           existing_param.length > 0 &&
-          existing_param[0].parameterType === new_param_type
+          // in case the new parameter is numeric, don't validate its type
+          // because it could have been set to categorical by the user in a
+          // previous Dialog interaction
+          (['int', 'double'].includes(new_param_type) &&
+          existing_param[0].parameterType == 'categorical'
+            ? true
+            : existing_param[0].parameterType === new_param_type)
         );
       })
       // get the matching entries of the notebook's metadata (there might be
@@ -304,6 +310,22 @@ export const KatibDialog: React.FunctionComponent<KabitDialog> = props => {
       ...parameter.feasibleSpace,
       list: parameterList,
     };
+  };
+
+  const updateNumericParameterType = (
+    parameterName: string,
+    parameterOriginalType: 'int' | 'double',
+  ) => (parameter: IKatibParameter, value: string) => {
+    if (value === 'list') {
+      parameter.parameterType = 'categorical';
+      delete parameter.feasibleSpace.max;
+      delete parameter.feasibleSpace.min;
+      delete parameter.feasibleSpace.step;
+    } else {
+      // value === "range"
+      parameter.parameterType = parameterOriginalType;
+      delete parameter.feasibleSpace.list;
+    }
   };
 
   const updateObjectiveMetricName = (value: string) => {
@@ -485,6 +507,13 @@ export const KatibDialog: React.FunctionComponent<KabitDialog> = props => {
                   alignItems="center"
                 >
                   <MaterialInput
+                    validation={
+                      pyParameterType === 'int'
+                        ? 'int'
+                        : pyParameterType === 'float'
+                        ? 'double'
+                        : null
+                    }
                     variant={'outlined'}
                     label={'Value' + idx}
                     value={value}
@@ -576,7 +605,7 @@ export const KatibDialog: React.FunctionComponent<KabitDialog> = props => {
             </Grid>
             <Grid item xs={3}>
               <MaterialInput
-                validation="int"
+                validation={metadataParameter.parameterType}
                 variant={'outlined'}
                 label={'Step'}
                 value={metadataParameter.feasibleSpace.step || ''}
@@ -638,6 +667,37 @@ export const KatibDialog: React.FunctionComponent<KabitDialog> = props => {
                 ) : (
                   ''
                 )}
+                {metadataParameter &&
+                ['int', 'float'].includes(pyParameterType) ? (
+                  <MaterialSelect
+                    variant={'outlined'}
+                    updateValue={updateParameter(
+                      parameterName,
+                      updateNumericParameterType(
+                        parameterName,
+                        pyParameterType,
+                      ),
+                    )}
+                    values={[
+                      { label: 'Range', value: 'range' },
+                      {
+                        label: 'List',
+                        value: 'list',
+                        tooltip:
+                          'Depending on the implementation of your chosen' +
+                          ' algorithm, a list might be treated differently' +
+                          ' from a range.',
+                      },
+                    ]}
+                    value={
+                      metadataParameter.parameterType === 'categorical'
+                        ? 'list'
+                        : 'range'
+                    }
+                    label={''}
+                    index={0}
+                  />
+                ) : null}
               </Grid>
               <Grid item xs={8}>
                 {katibParameterType ? (

--- a/labextension/style/index.css
+++ b/labextension/style/index.css
@@ -465,6 +465,10 @@ a {
   width: 100%;
 }
 
+.menu-item-label {
+  width: 100%;
+}
+
 /* this class needs to be applied to every material switch we use because
   jp lab overrides the height of every input checkbox component.
 */

--- a/labextension/style/index.css
+++ b/labextension/style/index.css
@@ -48,6 +48,7 @@
 
 .kale-header.katib-headers-tooltip {
   height: 0.7em;
+  opacity: 0.75;
 }
 
 .kale-header-switch {


### PR DESCRIPTION
Katib support categorical arguments (i.e. lists of values) or numeric
arguments (int, double) defined in terms of `min`, `max` and `step`. It
is often the case that we need to run HP Tuning with a numeric arg that
has a list of choices (e.g. 0.0001, 0.001, 0.1) not expressible as a
range.

We allow changing the default range spec of numeric pipeline args to
categorical. This works because KFP converts all the pipeline args
from string to their annotated type.

There could be unintended side effects in how Katib's optimization
algorithms handle categorical differently from range. For that we
inform the user when making this choice.

Signed-off-by: Stefano Fioravanzo <stefano@arrikto.com>