### PR TITLE
Change auto-snapshot behavior

### DIFF
--- a/backend/kale/core.py
+++ b/backend/kale/core.py
@@ -134,12 +134,13 @@ class Kale:
         )
         dependencies.assign_metrics(pipeline_graph, pipeline_metrics)
 
-        # add an empty step at the end of the pipeline for final snapshot
-        if self.auto_snapshot:
+        # if there are multiple DAG leaves, add an empty step at the end of the
+        # pipeline for final snapshot
+        leaf_steps = graph_utils.get_leaf_nodes(pipeline_graph)
+        if self.auto_snapshot and len(leaf_steps) > 1:
             auto_snapshot_name = 'final_auto_snapshot'
             # add a link from all the last steps of the pipeline to
             # the final auto snapshot one.
-            leaf_steps = graph_utils.get_leaf_nodes(pipeline_graph)
             for node in leaf_steps:
                 pipeline_graph.add_edge(node, auto_snapshot_name)
             data = {auto_snapshot_name: {'source': '', 'ins': [], 'outs': []}}

--- a/backend/kale/templates/function_template.jinja2
+++ b/backend/kale/templates/function_template.jinja2
@@ -17,7 +17,8 @@ def {{ step_name }}({%- for arg in parameters_names -%}
     _kale_pod_utils.snapshot_pipeline_step(
         "{{ pipeline_name }}",
         "{{ step_name }}",
-        "{{ nb_path }}")
+        "{{ nb_path }}",
+        before=True)
 {% endif %}
 
 {%- if in_variables|length > 0 %}
@@ -66,3 +67,11 @@ def {{ step_name }}({%- for arg in parameters_names -%}
         f.write(html_artifact)
     _kale_update_uimetadata('{{ step_name }}')
 {% endif -%}
+
+{%- if auto_snapshot %}
+    _kale_pod_utils.snapshot_pipeline_step(
+        "{{ pipeline_name }}",
+        "{{ step_name }}",
+        "{{ nb_path }}",
+        before=False)
+{% endif %}

--- a/backend/kale/templates/function_template.jinja2
+++ b/backend/kale/templates/function_template.jinja2
@@ -12,7 +12,7 @@ def {{ step_name }}({%- for arg in parameters_names -%}
 {%- endfor %}
     '''.format({{ parameters_names|join(', ') }})
 {% endif %}
-{%- if auto_snapshot %}
+{%- if auto_snapshot and step_name != 'final_auto_snapshot'  %}
     from kale.utils import pod_utils as _kale_pod_utils
     _kale_pod_utils.snapshot_pipeline_step(
         "{{ pipeline_name }}",
@@ -69,6 +69,9 @@ def {{ step_name }}({%- for arg in parameters_names -%}
 {% endif -%}
 
 {%- if auto_snapshot %}
+{%- if step_name == 'final_auto_snapshot' %}
+    from kale.utils import pod_utils as _kale_pod_utils
+{%- endif %}
     _kale_pod_utils.snapshot_pipeline_step(
         "{{ pipeline_name }}",
         "{{ step_name }}",

--- a/backend/kale/tests/assets/functions/func03.out.py
+++ b/backend/kale/tests/assets/functions/func03.out.py
@@ -3,4 +3,11 @@ def test():
     _kale_pod_utils.snapshot_pipeline_step(
         "T",
         "test",
-        "/path/to/nb")
+        "/path/to/nb",
+        before=True)
+
+    _kale_pod_utils.snapshot_pipeline_step(
+        "T",
+        "test",
+        "/path/to/nb",
+        before=False)

--- a/backend/kale/utils/graph_utils.py
+++ b/backend/kale/utils/graph_utils.py
@@ -85,5 +85,4 @@ def get_leaf_nodes(g: nx.DiGraph):
 
     Returns (list): A list of leaf nodes.
     """
-    return [x for x in g.nodes()
-            if g.out_degree(x) == 0 and g.in_degree(x) > 0]
+    return [x for x in g.nodes() if g.out_degree(x) == 0]


### PR DESCRIPTION
* Take Rok auto snapshot after step's execution too
* Take a single snapshot during final auto-snapshot step
* Fix get_leaf_nodes()
  get_leaf_nodes used to return all leaf nodes that have at least one
  parent. However, a node should be considered as leaf even if it is not
  dependent to any other step. This commit fixes that behavior.
* Add final snapshot step only if multiple DAG leaves