### PR TITLE
labextension: Show just tag name for reserved tags

### DIFF
--- a/labextension/src/components/cell-metadata/InlineMetadata.tsx
+++ b/labextension/src/components/cell-metadata/InlineMetadata.tsx
@@ -252,6 +252,20 @@ export class InlineMetadata extends React.Component<IProps, IState> {
   }
 
   render() {
+    const details = RESERVED_CELL_NAMES.includes(
+      this.props.blockName,
+    ) ? null : (
+      <>
+        {/* Add a `depends on: ` string before the deps dots in case there are some*/}
+        {this.state.dependencies.length > 0 ? (
+          <p style={{ fontStyle: 'italic', margin: '0 5px' }}>depends on: </p>
+        ) : null}
+        {this.state.dependencies}
+
+        {this.createLimitsText()}
+      </>
+    );
+
     return (
       <div>
         <div ref={this.wrapperRef}>
@@ -286,17 +300,7 @@ export class InlineMetadata extends React.Component<IProps, IState> {
               />
             </Tooltip>
 
-            {/* Add a `depends on: ` string before the deps dots in case there are some*/}
-            {this.state.dependencies.length > 0 ? (
-              <p style={{ fontStyle: 'italic', margin: '0 5px' }}>
-                depends on:{' '}
-              </p>
-            ) : (
-              ''
-            )}
-            {this.state.dependencies}
-
-            {this.createLimitsText()}
+            {details}
           </div>
 
           <div


### PR DESCRIPTION
Since special tags are treated as block names, when setting a special
tag to a cell that already has some metadata (e.g. `prev` tags) the only
one that is removed is the previous `block:***` tag.

This commit prevents cells tagged with reserved tags to show inline
metadata information coming from other tags. This is just a workaround
for now, as the end goal will be to treat differently step names from
special tags.

Signed-off-by: Stefano Fioravanzo <stefano@arrikto.com>