### PR TITLE
Fix compiled artifact save paths

### DIFF
--- a/backend/kale/core.py
+++ b/backend/kale/core.py
@@ -154,7 +154,7 @@ class Kale:
             notebook_dir = os.path.dirname(self.source_path)
             filename = "{}.kale.py".format(
                 self.pipeline_metadata['pipeline_name'])
-            output_path = os.path.join(notebook_dir, filename)
+            output_path = os.path.abspath(os.path.join(notebook_dir, filename))
         # save kfp generated code
         output_path = self.save_pipeline(kfp_code, output_path)
         return output_path

--- a/backend/kale/rpc/katib.py
+++ b/backend/kale/rpc/katib.py
@@ -56,11 +56,8 @@ spec:
                 )"
 """
 
-trans_id = None
 
-
-def _get_k8s_co_client():
-    global trans_id
+def _get_k8s_co_client(trans_id):
     try:
         kubernetes.config.load_incluster_config()
     except Exception:  # Not in a notebook server
@@ -93,7 +90,7 @@ def _define_katib_experiment(name, katib_spec, trial_parameters):
 
 def _launch_katib_experiment(request, katib_experiment, namespace):
     """Launch Katib experiment."""
-    k8s_co_client = _get_k8s_co_client()
+    k8s_co_client = _get_k8s_co_client(request.trans_id)
 
     co_group = "kubeflow.org"
     co_version = "v1alpha3"
@@ -153,8 +150,6 @@ def create_katib_experiment(request, pipeline_id, pipeline_metadata,
 
     Returns (dict): a dictionary describing the status of the experiment
     """
-    global trans_id
-    trans_id = request.trans_id
     try:
         namespace = pod_utils.get_namespace()
     except Exception:
@@ -211,7 +206,7 @@ def get_experiment(request, experiment, namespace):
 
     Returns (dict): a dict describing the status of the running experiment
     """
-    k8s_co_client = _get_k8s_co_client()
+    k8s_co_client = _get_k8s_co_client(request.trans_id)
 
     co_group = "kubeflow.org"
     co_version = "v1alpha3"

--- a/backend/kale/tests/unit_tests/test_rpc_katib.py
+++ b/backend/kale/tests/unit_tests/test_rpc_katib.py
@@ -76,7 +76,7 @@ def test_create_katib_experiment():
     m = mock.mock_open()
     with mock.patch("builtins.open", m):
         katib.create_katib_experiment(_get_requets(), "12345",
-                                      pipeline_metadata)
+                                      pipeline_metadata, output_path=".")
 
     handle = m()
     target = open(os.path.join(THIS_DIR,

--- a/backend/kale/utils/kfp_utils.py
+++ b/backend/kale/utils/kfp_utils.py
@@ -97,7 +97,9 @@ def compile_pipeline(pipeline_source, pipeline_name):
 
     # path to generated pipeline package
     pipeline_package = pipeline_name + '.pipeline.tar.gz'
-    Compiler().compile(foo.auto_generated_pipeline, pipeline_package)
+    Compiler().compile(foo.auto_generated_pipeline,
+                       os.path.join(os.path.dirname(pipeline_source),
+                                    pipeline_package))
     return pipeline_package
 
 

--- a/backend/kale/utils/kfp_utils.py
+++ b/backend/kale/utils/kfp_utils.py
@@ -96,7 +96,7 @@ def compile_pipeline(pipeline_source, pipeline_name):
     spec.loader.exec_module(foo)
 
     # path to generated pipeline package
-    pipeline_package = pipeline_name + '.pipeline.tar.gz'
+    pipeline_package = pipeline_name + '.pipeline.yaml'
     Compiler().compile(foo.auto_generated_pipeline,
                        os.path.join(os.path.dirname(pipeline_source),
                                     pipeline_package))

--- a/labextension/src/components/LeftPanelWidget.tsx
+++ b/labextension/src/components/LeftPanelWidget.tsx
@@ -272,6 +272,7 @@ interface IRunPipelineArgs {
 interface IKatibRunArgs {
   pipeline_id: string;
   pipeline_metadata: any;
+  output_path: string;
 }
 
 export interface IKatibExperiment {
@@ -1250,6 +1251,7 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
             ...metadata,
             experiment_name: kfpExperiment.name,
           },
+          output_path: nbFilePath.substring(0, nbFilePath.lastIndexOf('/')),
         };
         let katibExperiment: IKatibExperiment = null;
         try {


### PR DESCRIPTION
Since (most) RPCs are called from a separate kernel, they have a base path different from the notebook (usually `$HOME`).

This PR is a fix so that all compiled artifacts (KFP DSL, Argo workflow definition and Katib experiment definition) are saved next to the `ipynb` file.

[It also changes the Argo workflow compiled file to a YAML instead of a gzipped tarball for UX purposes]