### PR TITLE
labextension: Improve active cell tracking

### DIFF
--- a/labextension/src/lib/NotebookUtils.tsx
+++ b/labextension/src/lib/NotebookUtils.tsx
@@ -38,8 +38,6 @@ interface IRunCellResponse {
   cellIndex?: number;
   ename?: string;
   evalue?: string;
-  cell?: Cell;
-  index?: number;
 }
 
 /** Contains utility functions for manipulating/handling notebooks in the application. */
@@ -61,7 +59,7 @@ export default class NotebookUtilities {
   /**
    * Scroll the notebook to the specified cell, making it active
    * @param notebook NotebookPanel
-   * @param cell The cell to be actived
+   * @param cell The cell to be activated
    */
   public static selectAndScrollToCell(
     notebook: NotebookPanel,
@@ -305,14 +303,13 @@ export default class NotebookUtilities {
               cellIndex: i,
               ename: kernelMsg.content.ename,
               evalue: kernelMsg.content.evalue,
-              ...cell,
             };
           }
           i++;
         }
       }
     }
-    return { status: 'ok', ...cell };
+    return { status: 'ok' };
   }
 
   /**


### PR DESCRIPTION
This commits changes how the extension tracks the currently active
notebook cell. Tracking this information is needed because we are
showing just one cell metadata editor at any given time.

Since the beginning, this information was tracked in the state of the
LeftPanelWidget component and was then passed down to the InlineMetadata
component. Since the LeftPanelWidget just acted as a tracker, without
actively using this information, now the tracking is moved to
InlineMetadata so that there is no useless state passing.

In this way, many functions inside LeftPanelWidget are freed from having
to set the state, and can now be refactore more easily.

Signed-off-by: Stefano Fioravanzo <stefano@arrikto.com>