### PR TITLE
labextension: Reorganise RPC commands

### DIFF
--- a/labextension/src/components/AnnotationInput.tsx
+++ b/labextension/src/components/AnnotationInput.tsx
@@ -20,6 +20,11 @@ import { RokInput } from './RokInput';
 import { Button } from '@material-ui/core';
 import DeleteIcon from '@material-ui/icons/Delete';
 
+export interface IAnnotation {
+  key: string;
+  value: string;
+}
+
 interface AnnotationInputProps {
   label: string;
   volumeIdx: number;

--- a/labextension/src/components/ExperimentInput.tsx
+++ b/labextension/src/components/ExperimentInput.tsx
@@ -16,12 +16,8 @@
 
 import * as React from 'react';
 import { Input } from './Input';
-import { Select } from './Select';
-import {
-  ISelectOption,
-  IExperiment,
-  NEW_EXPERIMENT,
-} from '../widgets/LeftPanelWidget';
+import { Select, ISelectOption } from './Select';
+import { IExperiment, NEW_EXPERIMENT } from '../widgets/LeftPanelWidget';
 
 const regex: string = '^[a-z]([-a-z0-9]*[a-z0-9])?$';
 const regexErrorMsg: string =

--- a/labextension/src/components/Select.tsx
+++ b/labextension/src/components/Select.tsx
@@ -20,6 +20,13 @@ import { MenuItem, Zoom } from '@material-ui/core';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import { LightTooltip } from './LightTooltip';
 
+export interface ISelectOption {
+  label: string;
+  value: string;
+  tooltip?: any;
+  invalid?: boolean;
+}
+
 const useStyles = makeStyles(() =>
   createStyles({
     label: {
@@ -44,7 +51,7 @@ const useStyles = makeStyles(() =>
 
 interface SelectProps extends BaseTextFieldProps {
   index: number;
-  values: { value: string; label: string; tooltip?: string }[];
+  values: ISelectOption[];
   variant?: 'filled' | 'standard' | 'outlined';
   updateValue: Function;
 }

--- a/labextension/src/lib/Commands.ts
+++ b/labextension/src/lib/Commands.ts
@@ -16,7 +16,11 @@
 
 import { Kernel } from '@jupyterlab/services';
 import { NotebookPanel } from '@jupyterlab/notebook';
-import { _legacy_executeRpcAndShowRPCError } from './RPCUtils';
+import {
+  _legacy_executeRpc,
+  _legacy_executeRpcAndShowRPCError,
+  RPCError,
+} from './RPCUtils';
 import { wait } from './Utils';
 import { IVolumeMetadata } from '../widgets/LeftPanelWidget';
 
@@ -95,5 +99,23 @@ export default class Commands {
         volumes,
       },
     );
+  };
+
+  getBaseImage = async () => {
+    let baseImage: string = null;
+    try {
+      baseImage = await _legacy_executeRpc(
+        this._notebook,
+        this._kernel,
+        'nb.get_base_image',
+      );
+    } catch (error) {
+      if (error instanceof RPCError) {
+        console.warn('Kale is not running in a Notebook Server', error.error);
+      } else {
+        throw error;
+      }
+    }
+    return baseImage;
   };
 }

--- a/labextension/src/lib/Commands.ts
+++ b/labextension/src/lib/Commands.ts
@@ -18,6 +18,7 @@ import { Kernel } from '@jupyterlab/services';
 import { NotebookPanel } from '@jupyterlab/notebook';
 import { _legacy_executeRpcAndShowRPCError } from './RPCUtils';
 import { wait } from './Utils';
+import { IVolumeMetadata } from '../widgets/LeftPanelWidget';
 
 export default class Commands {
   private readonly _notebook: NotebookPanel;
@@ -75,5 +76,24 @@ export default class Commands {
     }
 
     return null;
+  };
+
+  replaceClonedVolumes = async (
+    bucket: string,
+    obj: string,
+    version: string,
+    volumes: IVolumeMetadata[],
+  ) => {
+    return await _legacy_executeRpcAndShowRPCError(
+      this._notebook,
+      this._kernel,
+      'rok.replace_cloned_volumes',
+      {
+        bucket,
+        obj,
+        version,
+        volumes,
+      },
+    );
   };
 }

--- a/labextension/src/lib/Commands.ts
+++ b/labextension/src/lib/Commands.ts
@@ -24,6 +24,7 @@ import {
 import { wait } from './Utils';
 import {
   IExperiment,
+  IKatibExperiment,
   IVolumeMetadata,
   NEW_EXPERIMENT,
 } from '../widgets/LeftPanelWidget';
@@ -222,6 +223,29 @@ export default class Commands {
       onUpdate({ runPipeline: run });
       if (run && (run.status === 'Running' || run.status === null)) {
         setTimeout(() => this.pollRun(run, onUpdate), 2000);
+      }
+    });
+  }
+
+  pollKatib(katibExperiment: IKatibExperiment, onUpdate: Function) {
+    const getExperimentArgs: any = {
+      experiment: katibExperiment.name,
+      namespace: katibExperiment.namespace,
+    };
+    _legacy_executeRpcAndShowRPCError(
+      this._notebook,
+      this._kernel,
+      'katib.get_experiment',
+      getExperimentArgs,
+    ).then(katib => {
+      if (!katib) {
+        // could not get the experiment
+        onUpdate({ katib: { status: 'error' } });
+        return;
+      }
+      onUpdate({ katib });
+      if (katib && katib.status !== 'Succeeded' && katib.status !== 'Failed') {
+        setTimeout(() => this.pollKatib(katibExperiment, onUpdate), 5000);
       }
     });
   }

--- a/labextension/src/lib/Commands.ts
+++ b/labextension/src/lib/Commands.ts
@@ -24,6 +24,7 @@ import {
 import { wait } from './Utils';
 import {
   IExperiment,
+  IKaleNotebookMetadata,
   IKatibExperiment,
   IVolumeMetadata,
   NEW_EXPERIMENT,
@@ -249,4 +250,28 @@ export default class Commands {
       }
     });
   }
+
+  validateMetadata = async (
+    notebookPath: string,
+    metadata: IKaleNotebookMetadata,
+    onUpdate: Function,
+  ): Promise<boolean> => {
+    onUpdate({ showValidationProgress: true });
+    const validateNotebookArgs = {
+      source_notebook_path: notebookPath,
+      notebook_metadata_overrides: metadata,
+    };
+    const validateNotebook = await _legacy_executeRpcAndShowRPCError(
+      this._notebook,
+      this._kernel,
+      'nb.validate_notebook',
+      validateNotebookArgs,
+    );
+    if (!validateNotebook) {
+      onUpdate({ notebookValidation: false });
+      return false;
+    }
+    onUpdate({ notebookValidation: true });
+    return true;
+  };
 }

--- a/labextension/src/lib/Commands.ts
+++ b/labextension/src/lib/Commands.ts
@@ -23,6 +23,7 @@ import {
 } from './RPCUtils';
 import { wait } from './Utils';
 import { IVolumeMetadata } from '../widgets/LeftPanelWidget';
+import NotebookUtils from './NotebookUtils';
 
 export default class Commands {
   private readonly _notebook: NotebookPanel;
@@ -99,6 +100,14 @@ export default class Commands {
         volumes,
       },
     );
+  };
+
+  unmarshalData = async (nbFileName: string) => {
+    const cmd: string =
+      `from kale.rpc.nb import unmarshal_data as __kale_rpc_unmarshal_data\n` +
+      `locals().update(__kale_rpc_unmarshal_data("${nbFileName}"))`;
+    console.log('Executing command: ' + cmd);
+    await NotebookUtils.sendKernelRequestFromNotebook(this._notebook, cmd, {});
   };
 
   getBaseImage = async () => {

--- a/labextension/src/lib/Commands.ts
+++ b/labextension/src/lib/Commands.ts
@@ -209,4 +209,20 @@ export default class Commands {
       experiment_name: newExperiment.name,
     };
   };
+
+  pollRun(runPipeline: any, onUpdate: Function) {
+    _legacy_executeRpcAndShowRPCError(
+      this._notebook,
+      this._kernel,
+      'kfp.get_run',
+      {
+        run_id: runPipeline.id,
+      },
+    ).then(run => {
+      onUpdate({ runPipeline: run });
+      if (run && (run.status === 'Running' || run.status === null)) {
+        setTimeout(() => this.pollRun(run, onUpdate), 2000);
+      }
+    });
+  }
 }

--- a/labextension/src/lib/Commands.ts
+++ b/labextension/src/lib/Commands.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 The Kale Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Kernel } from '@jupyterlab/services';
+import { NotebookPanel } from '@jupyterlab/notebook';
+import { _legacy_executeRpcAndShowRPCError } from './RPCUtils';
+import { wait } from './Utils';
+
+export default class Commands {
+  private readonly _notebook: NotebookPanel;
+  private readonly _kernel: Kernel.IKernel;
+
+  constructor(notebook: NotebookPanel, kernel: Kernel.IKernel) {
+    this._notebook = notebook;
+    this._kernel = kernel;
+  }
+
+  snapshotNotebook = async () => {
+    return await _legacy_executeRpcAndShowRPCError(
+      this._notebook,
+      this._kernel,
+      'rok.snapshot_notebook',
+    );
+  };
+
+  getSnapshotProgress = async (task_id: string, ms?: number) => {
+    const task = await _legacy_executeRpcAndShowRPCError(
+      this._notebook,
+      this._kernel,
+      'rok.get_task',
+      {
+        task_id,
+      },
+    );
+    if (ms) {
+      await wait(ms);
+    }
+    return task;
+  };
+
+  runSnapshotProcedure = async (onUpdate: Function) => {
+    const showSnapshotProgress = true;
+    const snapshot = await this.snapshotNotebook();
+    const taskId = snapshot.task.id;
+    let task = await this.getSnapshotProgress(taskId);
+    onUpdate({ task, showSnapshotProgress });
+
+    while (!['success', 'error', 'canceled'].includes(task.status)) {
+      task = await this.getSnapshotProgress(taskId, 1000);
+      onUpdate({ task });
+    }
+
+    if (task.status === 'success') {
+      console.log('Snapshotting successful!');
+      return task;
+    } else if (task.status === 'error') {
+      console.error('Snapshotting failed');
+      console.error('Stopping the deployment...');
+    } else if (task.status === 'canceled') {
+      console.error('Snapshotting canceled');
+      console.error('Stopping the deployment...');
+    }
+
+    return null;
+  };
+}

--- a/labextension/src/widgets/KatibDialog.tsx
+++ b/labextension/src/widgets/KatibDialog.tsx
@@ -16,15 +16,10 @@ import {
 import AddIcon from '@material-ui/icons/Add';
 import Help from '@material-ui/icons/Help';
 import DeleteIcon from '@material-ui/icons/Delete';
-import {
-  IKatibMetadata,
-  IKatibParameter,
-  ISelectOption,
-} from './LeftPanelWidget';
+import { IKatibMetadata, IKatibParameter } from './LeftPanelWidget';
 import { NotebookPanel } from '@jupyterlab/notebook';
 import { executeRpc, RPC_CALL_STATUS, RPCError } from '../lib/RPCUtils';
 import { Kernel } from '@jupyterlab/services';
-import NotebookUtils from '../lib/NotebookUtils';
 import { useTheme } from '@material-ui/core/styles';
 import { Input } from '../components/Input';
 import { Select } from '../components/Select';

--- a/labextension/src/widgets/LeftPanelWidget.tsx
+++ b/labextension/src/widgets/LeftPanelWidget.tsx
@@ -694,7 +694,7 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
         this.setState({ runDeployment: false });
         return;
       }
-      metadata.volumes = await this.replaceClonedVolumes(
+      metadata.volumes = await commands.replaceClonedVolumes(
         task.bucket,
         task.result.event.object,
         task.result.event.version,
@@ -1040,25 +1040,6 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
     } else {
       DefaultState.metadata.docker_image = '';
     }
-  };
-
-  replaceClonedVolumes = async (
-    bucket: string,
-    obj: string,
-    version: string,
-    volumes: IVolumeMetadata[],
-  ) => {
-    return await _legacy_executeRpcAndShowRPCError(
-      this.getActiveNotebook(),
-      this.props.kernel,
-      'rok.replace_cloned_volumes',
-      {
-        bucket,
-        obj,
-        version,
-        volumes,
-      },
-    );
   };
 
   unmarshalData = async (nbFileName: string) => {

--- a/labextension/src/widgets/LeftPanelWidget.tsx
+++ b/labextension/src/widgets/LeftPanelWidget.tsx
@@ -15,28 +15,12 @@
  */
 
 import * as React from 'react';
-import {
-  INotebookTracker,
-  Notebook,
-  NotebookPanel,
-} from '@jupyterlab/notebook';
+import { INotebookTracker, NotebookPanel } from '@jupyterlab/notebook';
 import NotebookUtils from '../lib/NotebookUtils';
-import {
-  _legacy_executeRpc,
-  _legacy_executeRpcAndShowRPCError,
-  IRPCError,
-  rokErrorTooltip,
-  RPCError,
-} from '../lib/RPCUtils';
-import CellUtils from '../lib/CellUtils';
+import { IRPCError, rokErrorTooltip } from '../lib/RPCUtils';
 import { AdvancedSettings } from '../components/AdvancedSettings';
 import { InlineCellsMetadata } from './cell-metadata/InlineCellMetadata';
-import {
-  ISelectVolumeTypes,
-  SELECT_VOLUME_SIZE_TYPES,
-  SELECT_VOLUME_TYPES,
-  VolumesPanel,
-} from './VolumesPanel';
+import { SELECT_VOLUME_TYPES, VolumesPanel } from './VolumesPanel';
 import { SplitDeployButton } from '../components/DeployButton';
 import { Kernel } from '@jupyterlab/services';
 import { ExperimentInput } from '../components/ExperimentInput';
@@ -53,13 +37,10 @@ import { KatibDialog } from './KatibDialog';
 import { Input } from '../components/Input';
 import { LightTooltip } from '../components/LightTooltip';
 import Commands from '../lib/Commands';
+import { IAnnotation } from '../components/AnnotationInput';
+import { ISelectOption } from '../components/Select';
 
 const KALE_NOTEBOOK_METADATA_KEY = 'kubeflow_notebook';
-
-export interface ISelectOption {
-  label: string;
-  value: string;
-}
 
 export interface IExperiment {
   id: string;
@@ -89,17 +70,12 @@ interface IState {
   gettingExperiments: boolean;
   notebookVolumes?: IVolumeMetadata[];
   volumes?: IVolumeMetadata[];
-  selectVolumeTypes: ISelectVolumeTypes[];
+  selectVolumeTypes: ISelectOption[];
   useNotebookVolumes: boolean;
   autosnapshot: boolean;
   deploys: { [index: number]: DeployProgressState };
   isEnabled: boolean;
   katibDialog: boolean;
-}
-
-export interface IAnnotation {
-  key: string;
-  value: string;
 }
 
 // Katib types: https://github.com/kubeflow/katib/blob/master/pkg/apis/controller/experiments/v1alpha3/experiment_types.go

--- a/labextension/src/widgets/LeftPanelWidget.tsx
+++ b/labextension/src/widgets/LeftPanelWidget.tsx
@@ -921,7 +921,7 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
         );
         if (runPipeline) {
           this.updateDeployProgress(_deployIndex, { runPipeline });
-          this.pollRun(_deployIndex, runPipeline);
+          commands.pollRun(runPipeline, updateDeployProgress);
         } else {
           this.updateDeployProgress(_deployIndex, {
             showRunProgress: false,
@@ -933,22 +933,6 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
     // stop deploy button icon spin
     this.setState({ runDeployment: false });
   };
-
-  pollRun(_deployIndex: number, runPipeline: any) {
-    _legacy_executeRpcAndShowRPCError(
-      this.getActiveNotebook(),
-      this.props.kernel,
-      'kfp.get_run',
-      {
-        run_id: runPipeline.id,
-      },
-    ).then(run => {
-      this.updateDeployProgress(_deployIndex, { runPipeline: run });
-      if (run && (run.status === 'Running' || run.status === null)) {
-        setTimeout(() => this.pollRun(_deployIndex, run), 2000);
-      }
-    });
-  }
 
   pollKatib(_deployIndex: number, katibExperiment: IKatibExperiment) {
     const getExperimentArgs: any = {

--- a/labextension/src/widgets/LeftPanelWidget.tsx
+++ b/labextension/src/widgets/LeftPanelWidget.tsx
@@ -488,7 +488,14 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
 
         if (!this.props.rokError) {
           // Get information about volumes currently mounted on the notebook server
-          await this.getMountedVolumes();
+          const {
+            notebookVolumes,
+            selectVolumeTypes,
+          } = await commands.getMountedVolumes(this.state.notebookVolumes);
+          this.setState({
+            notebookVolumes,
+            selectVolumeTypes,
+          });
         } else {
           this.setState({
             selectVolumeTypes: this.state.selectVolumeTypes.map(t => {
@@ -965,38 +972,6 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
       }
     });
   }
-
-  getMountedVolumes = async () => {
-    let notebookVolumes: IVolumeMetadata[] = await _legacy_executeRpcAndShowRPCError(
-      this.getActiveNotebook(),
-      this.props.kernel,
-      'nb.list_volumes',
-    );
-    let availableVolumeTypes = SELECT_VOLUME_TYPES.map(t => {
-      return t.value === 'snap' ? { ...t, invalid: false } : t;
-    });
-
-    if (notebookVolumes) {
-      notebookVolumes = notebookVolumes.map(volume => {
-        const sizeGroup = SELECT_VOLUME_SIZE_TYPES.filter(
-          s => volume.size >= s.base,
-        )[0];
-        volume.size = Math.ceil(volume.size / sizeGroup.base);
-        volume.size_type = sizeGroup.value;
-        volume.annotations = [];
-        return volume;
-      });
-      availableVolumeTypes = availableVolumeTypes.map(t => {
-        return t.value === 'clone' ? { ...t, invalid: false } : t;
-      });
-    } else {
-      notebookVolumes = this.state.notebookVolumes;
-    }
-    this.setState({
-      notebookVolumes: notebookVolumes,
-      selectVolumeTypes: availableVolumeTypes,
-    });
-  };
 
   onMetadataEnable = (isEnabled: boolean) => {
     this.setState({ isEnabled });

--- a/labextension/src/widgets/LeftPanelWidget.tsx
+++ b/labextension/src/widgets/LeftPanelWidget.tsx
@@ -450,7 +450,7 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
           );
           if (runCellResponse.status === RUN_CELL_STATUS.OK) {
             // unmarshalData runs in the same kernel as the .ipynb, so it requires the filename
-            await this.unmarshalData(nbFilePath.split('/').pop());
+            await commands.unmarshalData(nbFilePath.split('/').pop());
             const cell = CellUtils.getCellByStepName(
               this.getActiveNotebook(),
               exploration.step_name,
@@ -1027,18 +1027,6 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
       notebookVolumes: notebookVolumes,
       selectVolumeTypes: availableVolumeTypes,
     });
-  };
-
-  unmarshalData = async (nbFileName: string) => {
-    const cmd: string =
-      `from kale.rpc.nb import unmarshal_data as __kale_rpc_unmarshal_data\n` +
-      `locals().update(__kale_rpc_unmarshal_data("${nbFileName}"))`;
-    console.log('Executing command: ' + cmd);
-    await NotebookUtils.sendKernelRequestFromNotebook(
-      this.getActiveNotebook(),
-      cmd,
-      {},
-    );
   };
 
   onMetadataEnable = (isEnabled: boolean) => {

--- a/labextension/src/widgets/VolumesPanel.tsx
+++ b/labextension/src/widgets/VolumesPanel.tsx
@@ -18,12 +18,12 @@ import * as React from 'react';
 import { Button, Switch, Zoom } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import DeleteIcon from '@material-ui/icons/Delete';
-import { IAnnotation, ISelectOption, IVolumeMetadata } from './LeftPanelWidget';
+import { IVolumeMetadata } from './LeftPanelWidget';
 import { IRPCError, rokErrorTooltip } from '../lib/RPCUtils';
 import { Input } from '../components/Input';
-import { Select } from '../components/Select';
+import { Select, ISelectOption } from '../components/Select';
 import { LightTooltip } from '../components/LightTooltip';
-import { AnnotationInput } from '../components/AnnotationInput';
+import { AnnotationInput, IAnnotation } from '../components/AnnotationInput';
 import { removeIdxFromArray, updateIdxInArray } from '../lib/Utils';
 
 const DEFAULT_EMPTY_VOLUME: IVolumeMetadata = {
@@ -56,12 +56,7 @@ enum VOLUME_TOOLTIP {
   USE_EXISTING_VOLUME = 'Mount an existing volume on your pipeline steps',
 }
 
-export interface ISelectVolumeTypes extends ISelectOption {
-  invalid: boolean;
-  tooltip: any;
-}
-
-export const SELECT_VOLUME_TYPES: ISelectVolumeTypes[] = [
+export const SELECT_VOLUME_TYPES: ISelectOption[] = [
   {
     label: 'Create Empty Volume',
     value: 'new_pvc',
@@ -93,7 +88,7 @@ interface VolumesPanelProps {
   notebookVolumes: IVolumeMetadata[];
   metadataVolumes: IVolumeMetadata[];
   notebookMountPoints: { label: string; value: string }[];
-  selectVolumeTypes: ISelectVolumeTypes[];
+  selectVolumeTypes: ISelectOption[];
   useNotebookVolumes: boolean;
   autosnapshot: boolean;
   rokError: IRPCError;


### PR DESCRIPTION
This PR moved all the RPC commands (and their related auxiliary logics) to a separate Command class. This is just a first iteration to make the LeftPanelWidget a lighter component. In the future, further refactoring will be done on the Commands functions themselves to improve their logic and maintainability.