### PR TITLE
Fix marshal volume creation step name

### DIFF
--- a/backend/kale/templates/pipeline_template.jinja2
+++ b/backend/kale/templates/pipeline_template.jinja2
@@ -94,7 +94,7 @@ def auto_generated_pipeline({%- for arg in parameters_names -%}
 
     {% if marshal_volume %}
     marshal_vop = dsl.VolumeOp(
-        name="kale_marshal_volume",
+        name="kale-marshal-volume",
         resource_name="kale-marshal-pvc",
         modes=dsl.VOLUME_MODE_RWM,
         size="1Gi"

--- a/backend/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
+++ b/backend/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
@@ -118,7 +118,7 @@ def auto_generated_pipeline(booltest='True', d1='5', d2='6', strtest='test'):
     volume_name_parameters = []
 
     marshal_vop = dsl.VolumeOp(
-        name="kale_marshal_volume",
+        name="kale-marshal-volume",
         resource_name="kale-marshal-pvc",
         modes=dsl.VOLUME_MODE_RWM,
         size="1Gi"

--- a/backend/kale/tests/assets/kfp_dsl/titanic.py
+++ b/backend/kale/tests/assets/kfp_dsl/titanic.py
@@ -764,7 +764,7 @@ def auto_generated_pipeline():
     volume_name_parameters = []
 
     marshal_vop = dsl.VolumeOp(
-        name="kale_marshal_volume",
+        name="kale-marshal-volume",
         resource_name="kale-marshal-pvc",
         modes=dsl.VOLUME_MODE_RWM,
         size="1Gi"


### PR DESCRIPTION
volume_name_parameters list gets the parameter names before
sanitization. However, the compiler sanitizes step names. This results in
inconsistency between the two.

This commit fixes this inconsistency.

Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>