### PR TITLE
rpc/kfp: Fix NoneType error in list_experiments()

### DIFF
--- a/backend/kale/rpc/kfp.py
+++ b/backend/kale/rpc/kfp.py
@@ -34,7 +34,7 @@ def list_experiments(request):
     c = _get_client()
     experiments = [{"name": e.name,
                     "id": e.id}
-                   for e in c.list_experiments().experiments]
+                   for e in c.list_experiments().experiments or []]
     return experiments
 
 


### PR DESCRIPTION
kfp_client.list_experiments() returns {..., experiments: None} when no
experiments are found, so the iteration raises an error.
This commit fixes the behavior.

Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>