### PR TITLE
kfp: Work around get_experiment() issue

### DIFF
--- a/backend/kale/rpc/kfp.py
+++ b/backend/kale/rpc/kfp.py
@@ -50,6 +50,13 @@ def get_experiment(request, experiment_name):
         else:
             # Unexpected exception
             raise
+    except TypeError as e:
+        # In case the installed KFP client does not contain the following fix:
+        # https://github.com/kubeflow/pipelines/pull/4177
+        err_msg = "'NoneType' object is not iterable"
+        if err_msg in str(e):
+            return None
+        raise
     return {"id": experiment.id, "name": experiment.name}
 
 


### PR DESCRIPTION
This commit implements a minor workaround for [1] until we ship images
with KFP SDK containing its fix.

[1]: https://github.com/kubeflow/pipelines/issues/4176

Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>