### PR TITLE
backend: Fix wrong regex for Pandas marshalling

### DIFF
--- a/backend/kale/marshal/backends.py
+++ b/backend/kale/marshal/backends.py
@@ -76,9 +76,9 @@ def resource_pandas_load(uri, **kwargs):
         return fallback_load(uri, **kwargs)
 
 
-@resource_save.register(r'pandas\..*')
+@resource_save.register(r'pandas\..*(DataFrame|Series)')
 def resource_pandas_save(obj, path, **kwargs):
-    """Save a pandas resource."""
+    """Save a pandas DataFrame or Series."""
     try:
         import pandas as pd  # noqa: F401
         log.info("Saving pandas obj: %s", _get_obj_name(path))


### PR DESCRIPTION
The only Pandas objects that expose a `to_pickle` functions are
`pandas.core.frame.DataFrame` and `pandas.core.series.Series`. This
commit fixes the Pandas backend marshalling regex to catch just these
two type and not all `pandas.*` types. Any other Pandas object will
fallback to using `dill`.

Signed-off-by: Stefano Fioravanzo <stefano@arrikto.com>