### PR TITLE
logging: Improve logs in the marshal module

### DIFF
--- a/backend/kale/marshal/__init__.py
+++ b/backend/kale/marshal/__init__.py
@@ -14,10 +14,13 @@
 
 from .resource_save import resource_save
 from .resource_load import resource_load
+from .utils import save, load
 
 from .backends import *
 
 
 from kale.utils import log_utils
-log_utils.get_or_create_logger(module=__name__, name="marshalling")
+log_utils.get_or_create_logger(module=__name__, name="marshalling",
+                                # XXX: Should we have this as default in `get_or_create_logger`??
+                               log_path="kale.log")
 del log_utils

--- a/backend/kale/marshal/utils.py
+++ b/backend/kale/marshal/utils.py
@@ -4,6 +4,7 @@ import logging
 
 from kale.marshal import resource_save
 from kale.marshal import resource_load
+from kale.utils import utils
 
 KALE_DATA_DIRECTORY = ""
 
@@ -98,7 +99,7 @@ def save(obj, obj_name):
     except KaleMarshalException as e:
         log.error(e)
         log.debug("Original Traceback", exc_info=e.__traceback__)
-        sys.exit(1)
+        utils.graceful_exit(1)
 
 
 def _load(file_name):
@@ -143,4 +144,4 @@ def load(file_name):
     except KaleMarshalException as e:
         log.error(e)
         log.debug("Original Traceback", exc_info=e.__traceback__)
-        sys.exit(1)
+        utils.graceful_exit(1)

--- a/backend/kale/templates/function_template.jinja2
+++ b/backend/kale/templates/function_template.jinja2
@@ -31,7 +31,6 @@ def {{ step_name }}({%- for arg in parameters_names -%}
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("{{ marshal_path }}")
-    _kale_marshal_utils.set_kale_directory_file_names()
 {%- for in_var in in_variables %}
     {{ in_var }} = _kale_marshal_utils.load("{{ in_var }}")
 {%- endfor %}

--- a/backend/kale/tests/assets/functions/func04.out.py
+++ b/backend/kale/tests/assets/functions/func04.out.py
@@ -6,7 +6,6 @@ def test():
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("")
-    _kale_marshal_utils.set_kale_directory_file_names()
     v1 = _kale_marshal_utils.load("v1")
     # -----------------------DATA LOADING END----------------------------------
     '''

--- a/backend/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
+++ b/backend/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
@@ -64,7 +64,6 @@ def sum_matrix():
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
-    _kale_marshal_utils.set_kale_directory_file_names()
     rnd_matrix = _kale_marshal_utils.load("rnd_matrix")
     # -----------------------DATA LOADING END----------------------------------
     '''

--- a/backend/kale/tests/assets/kfp_dsl/titanic.py
+++ b/backend/kale/tests/assets/kfp_dsl/titanic.py
@@ -70,7 +70,6 @@ def datapreprocessing():
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
-    _kale_marshal_utils.set_kale_directory_file_names()
     test_df = _kale_marshal_utils.load("test_df")
     train_df = _kale_marshal_utils.load("train_df")
     # -----------------------DATA LOADING END----------------------------------
@@ -198,7 +197,6 @@ def featureengineering():
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
-    _kale_marshal_utils.set_kale_directory_file_names()
     PREDICTION_LABEL = _kale_marshal_utils.load("PREDICTION_LABEL")
     test_df = _kale_marshal_utils.load("test_df")
     train_df = _kale_marshal_utils.load("train_df")
@@ -363,7 +361,6 @@ def decisiontree():
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
-    _kale_marshal_utils.set_kale_directory_file_names()
     train_df = _kale_marshal_utils.load("train_df")
     train_labels = _kale_marshal_utils.load("train_labels")
     # -----------------------DATA LOADING END----------------------------------
@@ -425,7 +422,6 @@ def svm():
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
-    _kale_marshal_utils.set_kale_directory_file_names()
     train_df = _kale_marshal_utils.load("train_df")
     train_labels = _kale_marshal_utils.load("train_labels")
     # -----------------------DATA LOADING END----------------------------------
@@ -487,7 +483,6 @@ def naivebayes():
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
-    _kale_marshal_utils.set_kale_directory_file_names()
     train_df = _kale_marshal_utils.load("train_df")
     train_labels = _kale_marshal_utils.load("train_labels")
     # -----------------------DATA LOADING END----------------------------------
@@ -549,7 +544,6 @@ def logisticregression():
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
-    _kale_marshal_utils.set_kale_directory_file_names()
     train_df = _kale_marshal_utils.load("train_df")
     train_labels = _kale_marshal_utils.load("train_labels")
     # -----------------------DATA LOADING END----------------------------------
@@ -611,7 +605,6 @@ def randomforest():
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
-    _kale_marshal_utils.set_kale_directory_file_names()
     train_df = _kale_marshal_utils.load("train_df")
     train_labels = _kale_marshal_utils.load("train_labels")
     # -----------------------DATA LOADING END----------------------------------
@@ -673,7 +666,6 @@ def results():
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
-    _kale_marshal_utils.set_kale_directory_file_names()
     acc_decision_tree = _kale_marshal_utils.load("acc_decision_tree")
     acc_gaussian = _kale_marshal_utils.load("acc_gaussian")
     acc_linear_svc = _kale_marshal_utils.load("acc_linear_svc")

--- a/backend/kale/utils/log_utils.py
+++ b/backend/kale/utils/log_utils.py
@@ -66,7 +66,9 @@ def get_or_create_logger(module, name=None, level=logging.INFO, fmt=None,
     log.addHandler(stream_handler)
 
     if log_path:
-        os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        # if log_path is just a file name, dirname will be empty
+        if os.path.dirname(log_path):
+            os.makedirs(os.path.dirname(log_path), exist_ok=True)
         file_handler = logging.FileHandler(filename=os.path.abspath(log_path),
                                            mode='a')
         _configure_handler(file_handler, file_level,


### PR DESCRIPTION
Improve the logging in the marshal module to show clean and easy to
unrstand error messages in case Kale fails to marshal an object.

The traceback of the produced error is not shows to stdout but logged in
kale.log

Signed-off-by: Stefano Fioravanzo <stefano@arrikto.com>