### PR TITLE
logging: custom logger for printing empty lines

### DIFF
--- a/backend/kale/utils/jupyter_utils.py
+++ b/backend/kale/utils/jupyter_utils.py
@@ -238,7 +238,8 @@ def run_code(source: tuple, kernel_name='python3'):
         source (tuple): source code blocks
         kernel_name: name of the kernel (form the kernel spec) to be created
     """
-    log.info("Running user code...")
+    log.info("%s Running user code... %s", "-" * 10, "-" * 10)
+    log.newline(lines=3)
     import IPython
     if pkg_version.parse(IPython.__version__) < pkg_version.parse('7.6.0'):
         raise RuntimeError("IPython version {} not supported."
@@ -293,7 +294,8 @@ def run_code(source: tuple, kernel_name='python3'):
         # start preprocessor: run each code cell and capture the output
         ep.preprocess(notebook, resources, km=km)
     except KaleKernelException:
-        log.error("Failed to run user code")
+        log.newline(lines=3)
+        log.error("%s Failed to run user code %s", "-" * 10, "-" * 10)
         # exit gracefully with error
         sys.exit(-1)
     # Give some time to the stream watcher thread to receive all messages from
@@ -302,5 +304,6 @@ def run_code(source: tuple, kernel_name='python3'):
     km.shutdown_kernel()
 
     result = process_outputs(notebook.cells)
-    log.info("Successfully ran user code")
+    log.newline(lines=3)
+    log.info("%s Successfully ran user code %s", "-" * 10, "-" * 10)
     return result

--- a/backend/kale/utils/jupyter_utils.py
+++ b/backend/kale/utils/jupyter_utils.py
@@ -294,6 +294,7 @@ def run_code(source: tuple, kernel_name='python3'):
         # start preprocessor: run each code cell and capture the output
         ep.preprocess(notebook, resources, km=km)
     except KaleKernelException:
+        sys.stdout.flush()
         log.newline(lines=3)
         log.error("%s Failed to run user code %s", "-" * 10, "-" * 10)
         # exit gracefully with error
@@ -304,6 +305,7 @@ def run_code(source: tuple, kernel_name='python3'):
     km.shutdown_kernel()
 
     result = process_outputs(notebook.cells)
+    sys.stdout.flush()
     log.newline(lines=3)
     log.info("%s Successfully ran user code %s", "-" * 10, "-" * 10)
     return result


### PR DESCRIPTION
Using a standard logger it's not possible to just print empty lines
without having to print the Formatter prefix as well. This can be a
limitation when we want to use just the logger for user-facing outputs,
but we also want to be able to space out some section, producing empty
lines.

This commit extends the base Logger class with a funtion that, when
called, temporarily suppress all the handlers' formatters with the empty
string, logs empty lines, and then restored the original formatters.

NOTE: This function is not thread safe. If multiple processes are using
the same logger concurrently, there might be cases when one thread uses
the logger while its formatters are being suppressed by another thread.
Current Kale is not multithreaded, so this is not an issue.

Signed-off-by: Stefano Fioravanzo <stefano@arrikto.com>