### PR TITLE
Support Jupyter notebook-dir CLI argument

### DIFF
--- a/backend/kale/core.py
+++ b/backend/kale/core.py
@@ -43,7 +43,7 @@ class Kale:
                  debug: bool = False,
                  auto_snapshot: bool = False):
         self.auto_snapshot = auto_snapshot
-        self.source_path = str(source_notebook_path)
+        self.source_path = os.path.expanduser(str(source_notebook_path))
         if not os.path.exists(self.source_path):
             raise ValueError("Path {} does not exist".format(self.source_path))
 

--- a/labextension/src/widget.tsx
+++ b/labextension/src/widget.tsx
@@ -46,6 +46,7 @@ import {
   RPC_CALL_STATUS,
 } from './lib/RPCUtils';
 import { Kernel } from '@jupyterlab/services';
+import { PageConfig } from '@jupyterlab/coreutils';
 
 /* tslint:disable */
 export const IKubeflowKale = new Token<IKubeflowKale>(
@@ -139,9 +140,11 @@ async function activate(
   async function loadPanel() {
     let reveal_widget = undefined;
     if (backend) {
-      // Check if NOTEBOOK_PATH env variable exists and if so load
+      // Check if KALE_NOTEBOOK_PATH env variable exists and if so load
       // that Notebook
-      const path = await executeRpc(kernel, 'nb.resume_notebook_path');
+      const path = await executeRpc(kernel, 'nb.resume_notebook_path', {
+        server_root: PageConfig.getOption('serverRoot'),
+      });
       if (path) {
         console.log('Resuming notebook ' + path);
         // open the notebook panel

--- a/labextension/src/widgets/KatibDialog.tsx
+++ b/labextension/src/widgets/KatibDialog.tsx
@@ -60,10 +60,10 @@ const acqFuncOptions = [
 
 interface KabitDialog {
   open: boolean;
+  nbFilePath: string;
   toggleDialog: Function;
   katibMetadata: IKatibMetadata;
   updateKatibMetadata: Function;
-  activeNotebook: NotebookPanel;
   kernel: Kernel.IKernelConnection;
 }
 
@@ -88,8 +88,7 @@ export const KatibDialog: React.FunctionComponent<KabitDialog> = props => {
   const onKatibShowPanel = async () => {
     // Send an RPC to Kale to get the pipeline parameters
     // that are currently defined in the notebook
-    const nbFilePath = props.activeNotebook.context.path;
-    const args = { source_notebook_path: nbFilePath };
+    const args = { source_notebook_path: props.nbFilePath };
 
     let rpcPipelineParameters = [];
     try {

--- a/labextension/src/widgets/LeftPanelWidget.tsx
+++ b/labextension/src/widgets/LeftPanelWidget.tsx
@@ -39,6 +39,7 @@ import { LightTooltip } from '../components/LightTooltip';
 import Commands from '../lib/Commands';
 import { IAnnotation } from '../components/AnnotationInput';
 import { ISelectOption } from '../components/Select';
+import { PageConfig } from '@jupyterlab/coreutils';
 
 const KALE_NOTEBOOK_METADATA_KEY = 'kubeflow_notebook';
 
@@ -209,6 +210,17 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
 
   getActiveNotebook = () => {
     return this.props.tracker.currentWidget;
+  };
+
+  getActiveNotebookPath = () => {
+    return (
+      this.getActiveNotebook() &&
+      // absolute path to the notebook's root (--notebook-dir option, if set)
+      PageConfig.getOption('serverRoot') +
+        '/' +
+        // relative path wrt to 'serverRoot'
+        this.getActiveNotebook().context.path
+    );
   };
 
   // update metadata state values: use destructure operator to update nested dict
@@ -384,7 +396,7 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
 
       if (this.props.backend) {
         // Detect whether this is an exploration, i.e., recovery from snapshot
-        const nbFilePath = this.getActiveNotebook().context.path;
+        const nbFilePath = this.getActiveNotebookPath();
         await commands.resumeStateIfExploreNotebook(nbFilePath);
 
         if (!this.props.rokError) {
@@ -561,7 +573,7 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
       metadata.docker_image = DefaultState.metadata.docker_image;
     }
 
-    const nbFilePath = this.getActiveNotebook().context.path;
+    const nbFilePath = this.getActiveNotebookPath();
 
     // VALIDATE METADATA
     const validationSucceeded = await commands.validateMetadata(
@@ -873,12 +885,12 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
 
           <KatibDialog
             open={this.state.katibDialog}
+            nbFilePath={this.getActiveNotebookPath()}
             toggleDialog={this.toggleKatibDialog}
             katibMetadata={
               this.state.metadata.katib_metadata || DefaultKatibMetadata
             }
             updateKatibMetadata={this.updateKatibMetadata}
-            activeNotebook={this.getActiveNotebook()}
             kernel={this.props.kernel}
           />
         </div>


### PR DESCRIPTION
Jupyterlab can be started with the `--notebook-dir` CLI argument. The
spceified dir will effectively become the root path visible from the JP
UI. This could be useful if one wants to start the Jupyter server in the
home folder, but wants to give access to the user just to a subfolder.

Until now Kale was assuming that the jupyter process was running in the
HOME directory, without `--notebook-dir`. When this assumption does not
hold anymore, Kale cannot find the notebook anymore, since we use a
relative path.

This commit retrieves the "server root" path (i.e. the absolute path to
`--notebook-dir`) and uses it to always point to the notebook with an
abolute path.

NOTE: `PageConfig.getOption('serverRoot')` returns a path where the HOME
prefix is `~`. We handle this in the backend by expanding the path using
`os.path.expanduser`

Signed-off-by: Stefano Fioravanzo <stefano@arrikto.com>