### PR TITLE
Apply notebook server's PodDefaults on pipeline steps

### DIFF
--- a/backend/kale/common/kfutils.py
+++ b/backend/kale/common/kfutils.py
@@ -1,0 +1,61 @@
+# Copyright 2020 The Kale Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, List
+from kubernetes.client.models import V1Pod
+
+from kale.common import podutils
+
+
+def list_poddefaults(namespace: str = None):
+    """List PodDefaults in requested namespace.
+
+    If namespace is not provided, list PodDefaults in pod's namespace.
+    """
+    if not namespace:
+        try:
+            namespace = podutils.get_namespace()
+        except Exception:
+            raise ValueError("'namespace' cannot be empty when not inside a"
+                             " pod")
+    api_group = "kubeflow.org"
+    api_version = "v1alpha1"
+    co_name = "poddefaults"
+    co_client = podutils._get_k8s_custom_objects_client()
+    return co_client.list_namespaced_custom_object(api_group, api_version,
+                                                   namespace, co_name)["items"]
+
+
+def find_applied_poddefaults(pod: V1Pod, poddefaults: List[Dict]):
+    """Find out which poddefaults from the list are applied to a pod."""
+    applied_poddefaults = list()
+    for pd in poddefaults:
+        labels_required = pd["spec"]["selector"].get("matchLabels", {})
+        for k, v in labels_required.items():
+            if pod.metadata.labels.get(k) == v:
+                applied_poddefaults.append(pd)
+    return applied_poddefaults
+
+
+def get_poddefault_labels(poddefaults: List[Dict]):
+    """Get all labels a pod requires to get a list of PodDefaults applied."""
+    labels = dict()
+    for pd in poddefaults:
+        for k, v in pd["spec"]["selector"].get("matchLabels", {}).items():
+            if k in labels and labels[k] != v:
+                raise ValueError("Conflicting label: %s. Found 2 poddefaults"
+                                 " using the same label but different values:"
+                                 " %s, %s" % (k, labels[k], v))
+            labels[k] = v
+    return labels

--- a/backend/kale/common/metadatautils.py
+++ b/backend/kale/common/metadatautils.py
@@ -31,6 +31,7 @@ DEFAULT_METADATA = {
     'marshal_path': '',
     'snapshot_volumes': False,
     'autosnapshot': False,
+    'steps_defaults': [],
 }
 
 METADATA_REQUIRED_KEYS = (

--- a/backend/kale/core.py
+++ b/backend/kale/core.py
@@ -98,7 +98,8 @@ class Kale:
         (pipeline_graph,
          pipeline_parameters_source,
          pipeline_metrics_source,
-         imports_and_functions) = parser.parse_notebook(self.notebook)
+         imports_and_functions) = parser.parse_notebook(self.notebook,
+                                                        self.pipeline_metadata)
 
         # get a dict from the 'pipeline parameters' cell source code
         pipeline_parameters_dict = ast.parse_assignments_expressions(

--- a/backend/kale/nbparser/parser.py
+++ b/backend/kale/nbparser/parser.py
@@ -300,7 +300,8 @@ def parse_notebook(notebook, metadata):
         if c.cell_type != "code":
             continue
 
-        steps_defaults = parse_steps_defaults(metadata.get("steps_defaults", []))
+        steps_defaults = metadata.get("steps_defaults", [])
+        parsed_step_defaults = parse_steps_defaults(steps_defaults)
         tags = parse_metadata(c.metadata)
 
         if len(tags['step_names']) > 1:
@@ -336,11 +337,11 @@ def parse_notebook(notebook, metadata):
 
         # if none of the above apply, then we are parsing a code cell with
         # a block names and (possibly) some dependencies
-        cell_annotations = dict(**steps_defaults.get("annotations", {}),
+        cell_annotations = dict(**parsed_step_defaults.get("annotations", {}),
                                 **tags.get("annotations", {}))
-        cell_labels = dict(**steps_defaults.get("labels", {}),
+        cell_labels = dict(**parsed_step_defaults.get("labels", {}),
                            **tags.get("labels", {}))
-        cell_limits = dict(**steps_defaults.get("limits", {}),
+        cell_limits = dict(**parsed_step_defaults.get("limits", {}),
                            **tags.get("limits", {}))
 
         # if the cell was not tagged with a step name,

--- a/backend/kale/templates/pipeline_template.jinja2
+++ b/backend/kale/templates/pipeline_template.jinja2
@@ -116,6 +116,16 @@ def auto_generated_pipeline({%- for arg in parameters_names -%}
     for k, v in step_annotations.items():
         {{ name }}_task.add_pod_annotation(k, v)
     {%- endif %}
+    {%- if nb_graph.nodes(data=True)[name].get("annotations") %}
+    step_annotations = {{ nb_graph.nodes(data=True)[name].get("annotations", {}) }}
+    for k, v in step_annotations.items():
+      {{ name }}_task.add_pod_annotation(k, v)
+    {%- endif %}
+    {%- if nb_graph.nodes(data=True)[name].get("labels") %}
+    step_labels = {{ nb_graph.nodes(data=True)[name].get("labels", {}) }}
+    for k, v in step_labels.items():
+      {{ name }}_task.add_pod_label(k, v)
+    {%- endif %}
     {%- if nb_graph.nodes(data=True)[name].get("limits") %}
     step_limits = {{ nb_graph.nodes(data=True)[name].get("limits", {}) }}
     for k, v in step_limits.items():

--- a/labextension/src/lib/Commands.ts
+++ b/labextension/src/lib/Commands.ts
@@ -573,4 +573,22 @@ export default class Commands {
       },
     );
   };
+
+  findPodDefaultLabelsOnServer = async (): Promise<{
+    [key: string]: string;
+  }> => {
+    let labels: {
+      [key: string]: string;
+    } = {};
+    try {
+      return await _legacy_executeRpc(
+        this._notebook,
+        this._kernel,
+        'nb.find_poddefault_labels_on_server',
+      );
+    } catch (error) {
+      console.error('Failed to retrieve PodDefaults applied on server', error);
+      return labels;
+    }
+  };
 }


### PR DESCRIPTION
In this PR the main focus is to retrieve PodDefaults applied on the notebook server and pass them on to pipeline steps.

To achieve this we:
* first add support to add labels on steps via cell tags,
* then we introduce a new field in metadata allowing global configurations for steps (currently annotations, labels, limits)
  [these configurations may be overwritten by cell-specific tags],
* then we add utils and an RPC to list and filter PodDefaults (according to our needs aka PodDefaults applied on pod) as well as fetch the labels required for these PodDefaults to be applied,
* and, finally, we let the lab extension orchestrate all the above