### PR TITLE
backend: Allow Katib trials to access KFP

### DIFF
--- a/backend/kale/rpc/katib.py
+++ b/backend/kale/rpc/katib.py
@@ -38,8 +38,11 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "false"
+      labels:
+        access-ml-pipeline: "true"
     spec:
       restartPolicy: Never
+      serviceAccountName: pipeline-runner
       containers:
         - name: {{.Trial}}
           image: {image}
@@ -169,7 +172,7 @@ def create_katib_experiment(request, pipeline_id, pipeline_metadata,
     katib_spec = _sanitize_katib_spec(request, katib_spec)
 
     trial_parameters = {
-        "image": "gcr.io/arrikto/katib-kfp-trial:acbe872",
+        "image": "gcr.io/arrikto/katib-kfp-trial:f1c9b6a",
         "pipeline_id": pipeline_id,
         "experiment_name": pipeline_metadata.get(
             "experiment_name")}

--- a/backend/kale/tests/assets/yamls/katib-experiment.yaml
+++ b/backend/kale/tests/assets/yamls/katib-experiment.yaml
@@ -38,12 +38,13 @@ spec:
     goTemplate:
       rawTemplate: "apiVersion: batch/v1\nkind: Job\nmetadata:\n  name: {{.Trial}}\n\
         \  namespace: {{.NameSpace}}\nspec:\n  backoffLimit: 0\n  template:\n    metadata:\n\
-        \      annotations:\n        sidecar.istio.io/inject: \"false\"\n    spec:\n\
-        \      restartPolicy: Never\n      containers:\n        - name: {{.Trial}}\n\
-        \          image: gcr.io/arrikto/katib-kfp-trial:acbe872\n          command:\n\
-        \            - python3 -u -c \"from kale.common.kfputils                import\
-        \ create_and_wait_kfp_run;                create_and_wait_kfp_run(       \
-        \             pipeline_id='12345',                    run_name='{{.Trial}}',\
+        \      annotations:\n        sidecar.istio.io/inject: \"false\"\n      labels:\n\
+        \        access-ml-pipeline: \"true\"\n    spec:\n      restartPolicy: Never\n\
+        \      serviceAccountName: pipeline-runner\n      containers:\n        - name:\
+        \ {{.Trial}}\n          image: gcr.io/arrikto/katib-kfp-trial:f1c9b6a\n  \
+        \        command:\n            - python3 -u -c \"from kale.common.kfputils\
+        \                import create_and_wait_kfp_run;                create_and_wait_kfp_run(\
+        \                    pipeline_id='12345',                    run_name='{{.Trial}}',\
         \                    experiment_name='katib-test',                    {{-\
         \ with .HyperParameters }} {{- range .}}\n                        {{.Name}}='{{.Value}}',\
         \                    {{- end }} {{- end }}                )\"\n"


### PR DESCRIPTION
* Add label for PodDefault to be applied
* Specify service account for the trial
* Bump image
  **TODO:** Create & use new image after merging

Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>

---

[Depends on #178]