### PR TITLE
backend: Fix auto-snapshot step wrt step defaults

### DIFF
--- a/backend/kale/core.py
+++ b/backend/kale/core.py
@@ -126,7 +126,13 @@ class Kale:
             # the final auto snapshot one.
             for node in leaf_steps:
                 pipeline_graph.add_edge(node, auto_snapshot_name)
-            data = {auto_snapshot_name: {'source': '', 'ins': [], 'outs': []}}
+            step_defaults = parser.parse_steps_defaults(
+                self.pipeline_metadata.get("steps_defaults", []))
+            data = {auto_snapshot_name: {
+                "source": "", "ins": [], "outs": [],
+                "annotations": step_defaults.get("annotations"),
+                "labels": step_defaults.get("labels"),
+                "limits": step_defaults.get("limits")}}
             nx.set_node_attributes(pipeline_graph, data)
 
         # TODO: Additional Step required:

--- a/backend/kale/nbparser/parser.py
+++ b/backend/kale/nbparser/parser.py
@@ -294,14 +294,15 @@ def parse_notebook(notebook, metadata):
     # Variables that will become pipeline metrics
     pipeline_metrics = list()
 
+    # Default step configurations
+    step_defaults = parse_steps_defaults(metadata.get("steps_defaults", []))
+
     # iterate over the notebook cells, from first to last
     for c in notebook.cells:
         # parse only source code cells
         if c.cell_type != "code":
             continue
 
-        steps_defaults = metadata.get("steps_defaults", [])
-        parsed_step_defaults = parse_steps_defaults(steps_defaults)
         tags = parse_metadata(c.metadata)
 
         if len(tags['step_names']) > 1:
@@ -337,11 +338,11 @@ def parse_notebook(notebook, metadata):
 
         # if none of the above apply, then we are parsing a code cell with
         # a block names and (possibly) some dependencies
-        cell_annotations = dict(**parsed_step_defaults.get("annotations", {}),
+        cell_annotations = dict(**step_defaults.get("annotations", {}),
                                 **tags.get("annotations", {}))
-        cell_labels = dict(**parsed_step_defaults.get("labels", {}),
+        cell_labels = dict(**step_defaults.get("labels", {}),
                            **tags.get("labels", {}))
-        cell_limits = dict(**parsed_step_defaults.get("limits", {}),
+        cell_limits = dict(**step_defaults.get("limits", {}),
                            **tags.get("limits", {}))
 
         # if the cell was not tagged with a step name,


### PR DESCRIPTION
We weren't adding the `step_defaults` configurations to the final auto-snapshot step.
This PR fixes that behavior.

The PR also contains a small performance fix: we were parsing the `step_defaults` property again and again, instead of just once.