### PR TITLE
marshal: Support tf.keras model serialization

### DIFF
--- a/backend/kale/marshal/backends.py
+++ b/backend/kale/marshal/backends.py
@@ -133,3 +133,25 @@ def resource_keras_save(obj, path, **kwargs):
         obj.save(path + ".keras")
     except ImportError:
         fallback_save(obj, path, **kwargs)
+
+
+@resource_load.register(r'.*\.tfkeras')
+def resource_tf_load(uri, **kwargs):
+    """Load a Keras model."""
+    try:
+        from tensorflow.keras.models import load_model
+        log.info(f"Loading tf.Keras model: {uri}")
+        obj_tfkeras = load_model(uri)
+        return obj_tfkeras
+    except ImportError:
+        return fallback_load(uri, **kwargs)
+
+
+@resource_save.register(r'tensorflow.python.keras.*')
+def resource_tf_save(obj, path, **kwargs):
+    """Save a tf.Keras model."""
+    try:
+        log.info("Saving Keras model: %s", _get_obj_name(path))
+        obj.save(path + ".tfkeras")
+    except ImportError:
+        fallback_save(obj, path, **kwargs)

--- a/backend/kale/marshal/utils.py
+++ b/backend/kale/marshal/utils.py
@@ -104,16 +104,18 @@ def save(obj, obj_name):
 
 def _load(file_name):
     try:
-        _kale_load_file_name = [
-            f
-            for f in os.listdir(KALE_DATA_DIRECTORY)
-            if (os.path.isfile(os.path.join(KALE_DATA_DIRECTORY, f))
-                and os.path.splitext(f)[0] == file_name)
-        ]
+        _kale_load_file_name = _get_files(file_name)
+        _kale_load_folder_name = _get_folders(file_name)
+
         if len(_kale_load_file_name) > 1:
             raise ValueError("Found multiple files with name %s: %s"
                              % (file_name, str(_kale_load_file_name)))
-        _kale_load_file_name = _kale_load_file_name[0]
+        if len(_kale_load_folder_name) > 1:
+            raise ValueError("Found multiple folders with name %s: %s"
+                             % (file_name, str(_kale_load_folder_name)))
+
+        _names = _kale_load_file_name + _kale_load_folder_name
+        _kale_load_file_name = _names[0]
 
         return resource_load(os.path.join(KALE_DATA_DIRECTORY,
                                           _kale_load_file_name))
@@ -129,6 +131,20 @@ def _load(file_name):
             original_traceback=sys.exc_info()[EXC_INFO_TRACEBACK],
             msg=KALE_UNKNOWN_MARSHALLING_ERROR % e,
             obj_name=file_name, operation="load")
+
+
+def _get_files(file_name):
+    files = [f for f in os.listdir(KALE_DATA_DIRECTORY)
+             if (os.path.isfile(os.path.join(KALE_DATA_DIRECTORY, f))
+             and os.path.splitext(f)[0] == file_name)]
+    return files
+
+
+def _get_folders(folder_name):
+    folders = [f for f in os.listdir(KALE_DATA_DIRECTORY)
+               if (os.path.isdir(os.path.join(KALE_DATA_DIRECTORY, f))
+               and os.path.splitext(f)[0] == folder_name)]
+    return folders
 
 
 def load(file_name):


### PR DESCRIPTION
To support the tf.keras model serialization a new backend is added
to save the mode in the SavedModel format. This produces a folder
instead of a single file. Thus, utils.py file is also altered to
see folders as serialized objects in the case of TensorFlow artifacts.

The choise to proceed with SavedModel format instead of a single .h5 file
was taken because SavedModel is the new standard as of TF 2.x.
Later, we can use this format as is to deploy models as web services,
to edge devices or TensorFlow JS.

Signed-off-by: Dimitris Poulopoulos <dimpo@arrikto.com>