### PR TITLE
backend: Obfuscate template var names used by Kale

### DIFF
--- a/backend/kale/codegen/generate_code.py
+++ b/backend/kale/codegen/generate_code.py
@@ -30,6 +30,7 @@ def _initialize_templating_env(templates_path=None):
     template_env = Environment(loader=loader)
     # add custom filters
     template_env.filters['add_suffix'] = lambda s, suffix: s + suffix
+    template_env.filters['add_prefix'] = lambda s, prefix: prefix + s
     return template_env
 
 
@@ -136,8 +137,7 @@ def pipeline_dependencies_tasks(g):
     """
     deps = dict()
     for step_name in nx.topological_sort(g):
-        deps[step_name] = ["{}_task".format(pred)
-                           for pred in g.predecessors(step_name)]
+        deps[step_name] = list(g.predecessors(step_name))  # copy list
     return deps
 
 

--- a/backend/kale/templates/function_template.jinja2
+++ b/backend/kale/templates/function_template.jinja2
@@ -6,7 +6,7 @@ def {{ step_name }}({%- for arg in parameters_names -%}
 {%- if not autosnapshot and in_variables|length == 0 and out_variables|length == 0 and function_body|length == 0 %}
     pass
 {%- elif parameters_names|length > 0 %}
-    pipeline_parameters_block = '''
+    _kale_pipeline_parameters_block = '''
 {%- for arg in parameters_names %}
     {% if parameters_types[loop.index-1] == 'str' %}{{ arg }} = "{}"{% else %}{{ arg }} = {}{% endif -%}
 {%- endfor %}
@@ -27,7 +27,7 @@ def {{ step_name }}({%- for arg in parameters_names -%}
 {% endif %}
 
 {%- if in_variables|length > 0 %}
-    data_loading_block = '''
+    _kale_data_loading_block = '''
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("{{ marshal_path }}")
@@ -39,12 +39,12 @@ def {{ step_name }}({%- for arg in parameters_names -%}
 {% endif %}
 
 {%- for block in function_body %}
-    block{{ loop.index }} = '''
+    _kale_block{{ loop.index }} = '''
 {{block|indent(4, True)}}
     '''
 {% endfor %}
 {%- if out_variables|length > 0 %}
-    data_saving_block = '''
+    _kale_data_saving_block = '''
     # -----------------------DATA SAVING START---------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("{{ marshal_path }}")
@@ -60,15 +60,15 @@ def {{ step_name }}({%- for arg in parameters_names -%}
     from kale.common.jputils import run_code as _kale_run_code
     from kale.common.kfputils import \
         update_uimetadata as _kale_update_uimetadata
-    blocks = ({% if parameters_names|length > 0 %}pipeline_parameters_block,{% endif -%}
-              {% if in_variables|length > 0 %}data_loading_block,{% endif -%}
+    _kale_blocks = ({% if parameters_names|length > 0 %}_kale_pipeline_parameters_block,{% endif -%}
+                    {% if in_variables|length > 0 %}_kale_data_loading_block,{% endif -%}
 {%- for block in function_body %}
-              block{{ loop.index }},
+                    _kale_block{{ loop.index }},
 {%- endfor %}
-              {% if out_variables|length > 0 %}data_saving_block{% endif %})
-    html_artifact = _kale_run_code(blocks)
+                    {% if out_variables|length > 0 %}_kale_data_saving_block{% endif %})
+    _kale_html_artifact = _kale_run_code(_kale_blocks)
     with open("/{{ step_name }}.html", "w") as f:
-        f.write(html_artifact)
+        f.write(_kale_html_artifact)
     _kale_update_uimetadata('{{ step_name }}')
 {% endif -%}
 

--- a/backend/kale/templates/pipeline_template.jinja2
+++ b/backend/kale/templates/pipeline_template.jinja2
@@ -1,5 +1,8 @@
 import json
-import kfp.components as comp
+
+import kfp.dsl as _kfp_dsl
+import kfp.components as _kfp_components
+
 from collections import OrderedDict
 from kubernetes import client as k8s_client
 
@@ -11,15 +14,14 @@ from kubernetes import client as k8s_client
 {# DEFINE PIPELINE TASKS FROM FUNCTIONS #}
 {%- for name in step_names -%}
 {% if docker_image != '' %}
-{{ name }}_op = comp.func_to_container_op({{ name }}, base_image='{{ docker_image }}')
+_kale_{{ name }}_op = _kfp_components.func_to_container_op({{ name }}, base_image='{{ docker_image }}')
 {% else %}
-{{ name }}_op = comp.func_to_container_op({{ name }})
+_kale_{{ name }}_op = _kfp_components.func_to_container_op({{ name }})
 {% endif %}
 {% endfor -%}
 
 {# DECLARE PIPELINE #}
-import kfp.dsl as dsl
-@dsl.pipeline(
+@_kfp_dsl.pipeline(
    name='{{ pipeline_name }}',
    description='{{ pipeline_description }}'
 )
@@ -28,20 +30,20 @@ def auto_generated_pipeline({%- for arg in parameters_names -%}
     {%- if loop.index < parameters_values|length -%},
     {%- endif -%}
     {%- endfor -%}):
-    pvolumes_dict = OrderedDict()
-    volume_step_names = []
-    volume_name_parameters = []
+    _kale_pvolumes_dict = OrderedDict()
+    _kale_volume_step_names = []
+    _kale_volume_name_parameters = []
 
     {% for vol in volumes -%}
     {% set name= vol['name'] %}
     {% set mountpoint = vol['mount_point'] %}
     {% set pvc_size = vol['size']|default ('') + vol['size_type']|default ('') %}
     {% set annotations = vol['annotations']|default({}) %}
-    annotations = {{ annotations }}
+    _kale_annotations = {{ annotations }}
 
     {% if vol['type'] == 'pv' %}
 
-    pvc{{ loop.index }}  = k8s_client.V1PersistentVolumeClaim(
+    _kale_pvc{{ loop.index }}  = k8s_client.V1PersistentVolumeClaim(
         api_version="v1",
         kind="PersistentVolumeClaim",
         metadata=k8s_client.V1ObjectMeta(
@@ -51,117 +53,118 @@ def auto_generated_pipeline({%- for arg in parameters_names -%}
             volume_name="{{ name }}",
             access_modes=['ReadWriteOnce'],
             resources=k8s_client.V1ResourceRequirements(
-                requests={"storage": {{ pvc_size }}}
+                requests={"storage": "{{ pvc_size }}"}
             )
         )
     )
 
-    vop{{ loop.index }} = dsl.VolumeOp(
+    _kale_vop{{ loop.index }} = _kfp_dsl.VolumeOp(
         name="pvc-data{{ loop.index }}",
-        annotations=annotations,
-        k8s_resource=pvc{{ loop.index }}
+        annotations=_kale_annotations,
+        k8s_resource=_kale_pvc{{ loop.index }}
     )
-    volume = vop{{ loop.index }}.volume
-    volume_step_names.append(vop{{ loop.index }}.name)
-    volume_name_parameters.append(vop{{ loop.index }}.outputs["name"].full_name)
+    _kale_volume = _kale_vop{{ loop.index }}.volume
+    _kale_volume_step_names.append(_kale_vop{{ loop.index }}.name)
+    _kale_volume_name_parameters.append(_kale_vop{{ loop.index }}.outputs["name"].full_name)
 
     {% elif vol['type'] == 'pvc' %}
 
-    volume = dsl.PipelineVolume(pvc=vol_{{ mountpoint.replace('/', '_').strip('_') }})
+    _kale_volume = _kfp_dsl.PipelineVolume(pvc=vol_{{ mountpoint.replace('/', '_').strip('_') }})
 
     {% elif vol['type'] == 'new_pvc' %}
     {% if annotations.get('rok/origin') %}
-    annotations['rok/origin'] = rok_{{ name.replace('-', '_') }}_url
+    _kale_annotations['rok/origin'] = rok_{{ name.replace('-', '_') }}_url
     {% endif %}
 
-    vop{{ loop.index }} = dsl.VolumeOp(
+    _kale_vop{{ loop.index }} = _kfp_dsl.VolumeOp(
         name='create-volume-{{ loop.index }}',
         resource_name='{{ name }}',
         {%- if annotations %}
-        annotations=annotations,
+        annotations=_kale_annotations,
         {% endif -%}
         size='{{ pvc_size }}'
     )
-    volume = vop{{ loop.index }}.volume
-    volume_step_names.append(vop{{ loop.index }}.name)
-    volume_name_parameters.append(vop{{ loop.index }}.outputs["name"].full_name)
+    _kale_volume = _kale_vop{{ loop.index }}.volume
+    _kale_volume_step_names.append(_kale_vop{{ loop.index }}.name)
+    _kale_volume_name_parameters.append(_kale_vop{{ loop.index }}.outputs["name"].full_name)
 
     {% endif %}
 
-    pvolumes_dict['{{ mountpoint }}'] = volume
+    _kale_pvolumes_dict['{{ mountpoint }}'] = _kale_volume
 
     {% endfor %}
 
     {% if marshal_volume %}
-    marshal_vop = dsl.VolumeOp(
+    _kale_marshal_vop = _kfp_dsl.VolumeOp(
         name="kale-marshal-volume",
         resource_name="kale-marshal-pvc",
-        modes=dsl.VOLUME_MODE_RWM,
+        modes=_kfp_dsl.VOLUME_MODE_RWM,
         size="1Gi"
     )
-    volume_step_names.append(marshal_vop.name)
-    volume_name_parameters.append(marshal_vop.outputs["name"].full_name)
-    pvolumes_dict['{{ marshal_path }}'] = marshal_vop.volume
+    _kale_volume_step_names.append(_kale_marshal_vop.name)
+    _kale_volume_name_parameters.append(_kale_marshal_vop.outputs["name"].full_name)
+    _kale_pvolumes_dict['{{ marshal_path }}'] = _kale_marshal_vop.volume
     {% endif %}
 
-    volume_step_names.sort()
-    volume_name_parameters.sort()
+    _kale_volume_step_names.sort()
+    _kale_volume_name_parameters.sort()
 
     {% for name in step_names %}
-    {{ name }}_task = {{ name }}_op({{ all_step_parameters[name]|join(', ') }})\
-                            .add_pvolumes(pvolumes_dict)\
-                            .after({{ step_prevs[ name ]|join(', ') }})
+    _kale_{{ name }}_task = _kale_{{ name }}_op({{ all_step_parameters[name]|join(', ') }})\
+                            .add_pvolumes(_kale_pvolumes_dict)\
+                            .after({{ step_prevs[ name ]| map('add_prefix', '_kale_') | map('add_suffix', '_task') |join(', ') }})
     {%- if nb_graph.nodes(data=True)[name].get("annotations") %}
-    step_annotations = {{ nb_graph.nodes(data=True)[name].get("annotations", {}) }}
-    for k, v in step_annotations.items():
-        {{ name }}_task.add_pod_annotation(k, v)
+    _kale_step_annotations = {{ nb_graph.nodes(data=True)[name].get("annotations", {}) }}
+    for _kale_k, _kale_v in _kale_step_annotations.items():
+        {{ name }}_task.add_pod_annotation(_kale_k, _kale_v)
     {%- endif %}
     {%- if nb_graph.nodes(data=True)[name].get("annotations") %}
-    step_annotations = {{ nb_graph.nodes(data=True)[name].get("annotations", {}) }}
-    for k, v in step_annotations.items():
-      {{ name }}_task.add_pod_annotation(k, v)
+    _kale_step_annotations = {{ nb_graph.nodes(data=True)[name].get("annotations", {}) }}
+    for _kale_k, _kale_v in _kale_step_annotations.items():
+      _kale_{{ name }}_task.add_pod_annotation(_kale_k, _kale_v)
     {%- endif %}
     {%- if nb_graph.nodes(data=True)[name].get("labels") %}
-    step_labels = {{ nb_graph.nodes(data=True)[name].get("labels", {}) }}
-    for k, v in step_labels.items():
-      {{ name }}_task.add_pod_label(k, v)
+    _kale_step_labels = {{ nb_graph.nodes(data=True)[name].get("labels", {}) }}
+    for _kale_k, _kale_v in _kale_step_labels.items():
+      _kale_{{ name }}_task.add_pod_label(_kale_k, _kale_v)
     {%- endif %}
     {%- if nb_graph.nodes(data=True)[name].get("limits") %}
-    step_limits = {{ nb_graph.nodes(data=True)[name].get("limits", {}) }}
-    for k, v in step_limits.items():
-      {{ name }}_task.container.add_resource_limit(k, v)
+    _kale_step_limits = {{ nb_graph.nodes(data=True)[name].get("limits", {}) }}
+    for _kale_k, _kale_v in _kale_step_limits.items():
+      _kale_{{ name }}_task.container.add_resource_limit(_kale_k, _kale_v)
     {%- endif %}
-    {{ name }}_task.container.working_dir = "{{ abs_working_dir }}"
-    {{ name }}_task.container.set_security_context(k8s_client.V1SecurityContext(run_as_user=0))
-    output_artifacts = {}
+    _kale_{{ name }}_task.container.working_dir = "{{ abs_working_dir }}"
+    _kale_{{ name }}_task.container.set_security_context(k8s_client.V1SecurityContext(run_as_user=0))
+    _kale_output_artifacts = {}
     {%- if autosnapshot %}
-    output_artifacts.update({'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
+    _kale_output_artifacts.update({'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
     {%- endif %}
     {%- if nb_graph.nodes(data=True)[name].get("metrics") %}
-    output_artifacts.update({'mlpipeline-metrics': '/mlpipeline-metrics.json'})
+    _kale_output_artifacts.update({'mlpipeline-metrics': '/mlpipeline-metrics.json'})
     {%- endif %}
     {%- if name != "final_auto_snapshot" and name != "pipeline_metrics" %}
-    output_artifacts.update({'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
-    output_artifacts.update({'{{ name }}': '/{{ name }}.html'})
+    _kale_output_artifacts.update({'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
+    _kale_output_artifacts.update({'{{ name }}': '/{{ name }}.html'})
     {%- endif %}
-    {{ name }}_task.output_artifact_paths.update(output_artifacts)
-    {{ name }}_task.add_pod_label("pipelines.kubeflow.org/metadata_written", "true")
-    dep_names = {{ name }}_task.dependent_names + volume_step_names
-    {{ name }}_task.add_pod_annotation(
-        "kubeflow-kale.org/dependent-templates", json.dumps(dep_names))
-    if volume_name_parameters:
-        {{ name }}_task.add_pod_annotation(
+    _kale_{{ name }}_task.output_artifact_paths.update(_kale_output_artifacts)
+    _kale_{{ name }}_task.add_pod_label("pipelines.kubeflow.org/metadata_written", "true")
+    _kale_dep_names = (_kale_{{ name }}_task.dependent_names +
+                        _kale_volume_step_names)
+    _kale_{{ name }}_task.add_pod_annotation(
+        "kubeflow-kale.org/dependent-templates", json.dumps(_kale_dep_names))
+    if _kale_volume_name_parameters:
+        _kale_{{ name }}_task.add_pod_annotation(
             "kubeflow-kale.org/volume-name-parameters",
-            json.dumps(volume_name_parameters))
+            json.dumps(_kale_volume_name_parameters))
     {% endfor %}
 
     {# Snaphosts #}
     {% for vol in volumes -%}
     {% if vol['snapshot'] %}
-    snapshot{{ loop.index }} = dsl.VolumeSnapshotOp(
+    _kale_snapshot{{ loop.index }} = _kfp_dsl.VolumeSnapshotOp(
         name='snapshot-volume-{{ loop.index }}',
         resource_name='{{ vol['snapshot_name'] }}',
-        volume=vop{{ loop.index }}.volume.after({{ leaf_steps| map('add_suffix', '_task') | join(', ') }})
+        volume=_kale_vop{{ loop.index }}.volume.after({{ leaf_steps| map('add_prefix', '_kale_') | map('add_suffix', '_task') | join(', ') }})
     )
     {% endif %}
     {% endfor %}

--- a/backend/kale/tests/assets/functions/func04.out.py
+++ b/backend/kale/tests/assets/functions/func04.out.py
@@ -2,7 +2,7 @@ def test():
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    data_loading_block = '''
+    _kale_data_loading_block = '''
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("")
@@ -14,11 +14,11 @@ def test():
     from kale.common.jputils import run_code as _kale_run_code
     from kale.common.kfputils import \
         update_uimetadata as _kale_update_uimetadata
-    blocks = (data_loading_block,
-              )
-    html_artifact = _kale_run_code(blocks)
+    _kale_blocks = (_kale_data_loading_block,
+                    )
+    _kale_html_artifact = _kale_run_code(_kale_blocks)
     with open("/test.html", "w") as f:
-        f.write(html_artifact)
+        f.write(_kale_html_artifact)
     _kale_update_uimetadata('test')
 
     _kale_mlmdutils.call("mark_execution_complete")

--- a/backend/kale/tests/assets/functions/func05.out.py
+++ b/backend/kale/tests/assets/functions/func05.out.py
@@ -2,15 +2,15 @@ def test():
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    block1 = '''
+    _kale_block1 = '''
     v1 = "Hello"
     '''
 
-    block2 = '''
+    _kale_block2 = '''
     print(v1)
     '''
 
-    data_saving_block = '''
+    _kale_data_saving_block = '''
     # -----------------------DATA SAVING START---------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("")
@@ -22,13 +22,13 @@ def test():
     from kale.common.jputils import run_code as _kale_run_code
     from kale.common.kfputils import \
         update_uimetadata as _kale_update_uimetadata
-    blocks = (
-        block1,
-        block2,
-        data_saving_block)
-    html_artifact = _kale_run_code(blocks)
+    _kale_blocks = (
+        _kale_block1,
+        _kale_block2,
+        _kale_data_saving_block)
+    _kale_html_artifact = _kale_run_code(_kale_blocks)
     with open("/test.html", "w") as f:
-        f.write(html_artifact)
+        f.write(_kale_html_artifact)
     _kale_update_uimetadata('test')
 
     _kale_mlmdutils.call("mark_execution_complete")

--- a/backend/kale/tests/assets/functions/func06.out.py
+++ b/backend/kale/tests/assets/functions/func06.out.py
@@ -2,7 +2,7 @@ def test():
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    block1 = '''
+    _kale_block1 = '''
     print("hello")
     '''
 
@@ -10,12 +10,12 @@ def test():
     from kale.common.jputils import run_code as _kale_run_code
     from kale.common.kfputils import \
         update_uimetadata as _kale_update_uimetadata
-    blocks = (
-        block1,
+    _kale_blocks = (
+        _kale_block1,
     )
-    html_artifact = _kale_run_code(blocks)
+    _kale_html_artifact = _kale_run_code(_kale_blocks)
     with open("/test.html", "w") as f:
-        f.write(html_artifact)
+        f.write(_kale_html_artifact)
     _kale_update_uimetadata('test')
 
     _kale_mlmdutils.call("mark_execution_complete")

--- a/backend/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
+++ b/backend/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
@@ -1,12 +1,14 @@
-import kfp.dsl as dsl
 import json
-import kfp.components as comp
+
+import kfp.dsl as _kfp_dsl
+import kfp.components as _kfp_components
+
 from collections import OrderedDict
 from kubernetes import client as k8s_client
 
 
 def create_matrix(d1: int, d2: int):
-    pipeline_parameters_block = '''
+    _kale_pipeline_parameters_block = '''
     d1 = {}
     d2 = {}
     '''.format(d1, d2)
@@ -14,15 +16,15 @@ def create_matrix(d1: int, d2: int):
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    block1 = '''
+    _kale_block1 = '''
     import numpy as np
     '''
 
-    block2 = '''
+    _kale_block2 = '''
     rnd_matrix = np.random.rand(d1, d2)
     '''
 
-    block3 = '''
+    _kale_block3 = '''
     from kale.common import kfputils as _kale_kfputils
     _kale_kfp_metrics = {
         "d1": d1,
@@ -31,7 +33,7 @@ def create_matrix(d1: int, d2: int):
     _kale_kfputils.generate_mlpipeline_metrics(_kale_kfp_metrics)
     '''
 
-    data_saving_block = '''
+    _kale_data_saving_block = '''
     # -----------------------DATA SAVING START---------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -43,14 +45,14 @@ def create_matrix(d1: int, d2: int):
     from kale.common.jputils import run_code as _kale_run_code
     from kale.common.kfputils import \
         update_uimetadata as _kale_update_uimetadata
-    blocks = (pipeline_parameters_block,
-              block1,
-              block2,
-              block3,
-              data_saving_block)
-    html_artifact = _kale_run_code(blocks)
+    _kale_blocks = (_kale_pipeline_parameters_block,
+                    _kale_block1,
+                    _kale_block2,
+                    _kale_block3,
+                    _kale_data_saving_block)
+    _kale_html_artifact = _kale_run_code(_kale_blocks)
     with open("/create_matrix.html", "w") as f:
-        f.write(html_artifact)
+        f.write(_kale_html_artifact)
     _kale_update_uimetadata('create_matrix')
 
     _kale_mlmdutils.call("mark_execution_complete")
@@ -60,7 +62,7 @@ def sum_matrix():
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    data_loading_block = '''
+    _kale_data_loading_block = '''
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -68,15 +70,15 @@ def sum_matrix():
     # -----------------------DATA LOADING END----------------------------------
     '''
 
-    block1 = '''
+    _kale_block1 = '''
     import numpy as np
     '''
 
-    block2 = '''
+    _kale_block2 = '''
     sum_result = rnd_matrix.sum()
     '''
 
-    block3 = '''
+    _kale_block3 = '''
     from kale.common import kfputils as _kale_kfputils
     _kale_kfp_metrics = {
         "sum-result": sum_result
@@ -88,93 +90,99 @@ def sum_matrix():
     from kale.common.jputils import run_code as _kale_run_code
     from kale.common.kfputils import \
         update_uimetadata as _kale_update_uimetadata
-    blocks = (data_loading_block,
-              block1,
-              block2,
-              block3,
-              )
-    html_artifact = _kale_run_code(blocks)
+    _kale_blocks = (_kale_data_loading_block,
+                    _kale_block1,
+                    _kale_block2,
+                    _kale_block3,
+                    )
+    _kale_html_artifact = _kale_run_code(_kale_blocks)
     with open("/sum_matrix.html", "w") as f:
-        f.write(html_artifact)
+        f.write(_kale_html_artifact)
     _kale_update_uimetadata('sum_matrix')
 
     _kale_mlmdutils.call("mark_execution_complete")
 
 
-create_matrix_op = comp.func_to_container_op(create_matrix)
+_kale_create_matrix_op = _kfp_components.func_to_container_op(create_matrix)
 
 
-sum_matrix_op = comp.func_to_container_op(sum_matrix)
+_kale_sum_matrix_op = _kfp_components.func_to_container_op(sum_matrix)
 
 
-@dsl.pipeline(
+@_kfp_dsl.pipeline(
     name='hp-test-rnd',
     description=''
 )
 def auto_generated_pipeline(booltest='True', d1='5', d2='6', strtest='test'):
-    pvolumes_dict = OrderedDict()
-    volume_step_names = []
-    volume_name_parameters = []
+    _kale_pvolumes_dict = OrderedDict()
+    _kale_volume_step_names = []
+    _kale_volume_name_parameters = []
 
-    marshal_vop = dsl.VolumeOp(
+    _kale_marshal_vop = _kfp_dsl.VolumeOp(
         name="kale-marshal-volume",
         resource_name="kale-marshal-pvc",
-        modes=dsl.VOLUME_MODE_RWM,
+        modes=_kfp_dsl.VOLUME_MODE_RWM,
         size="1Gi"
     )
-    volume_step_names.append(marshal_vop.name)
-    volume_name_parameters.append(marshal_vop.outputs["name"].full_name)
-    pvolumes_dict['/marshal'] = marshal_vop.volume
+    _kale_volume_step_names.append(_kale_marshal_vop.name)
+    _kale_volume_name_parameters.append(
+        _kale_marshal_vop.outputs["name"].full_name)
+    _kale_pvolumes_dict['/marshal'] = _kale_marshal_vop.volume
 
-    volume_step_names.sort()
-    volume_name_parameters.sort()
+    _kale_volume_step_names.sort()
+    _kale_volume_name_parameters.sort()
 
-    create_matrix_task = create_matrix_op(d1, d2)\
-        .add_pvolumes(pvolumes_dict)\
+    _kale_create_matrix_task = _kale_create_matrix_op(d1, d2)\
+        .add_pvolumes(_kale_pvolumes_dict)\
         .after()
-    step_limits = {'nvidia.com/gpu': '2'}
-    for k, v in step_limits.items():
-        create_matrix_task.container.add_resource_limit(k, v)
-    create_matrix_task.container.working_dir = "/kale"
-    create_matrix_task.container.set_security_context(
+    _kale_step_limits = {'nvidia.com/gpu': '2'}
+    for _kale_k, _kale_v in _kale_step_limits.items():
+        _kale_create_matrix_task.container.add_resource_limit(_kale_k, _kale_v)
+    _kale_create_matrix_task.container.working_dir = "/kale"
+    _kale_create_matrix_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
-    output_artifacts = {}
-    output_artifacts.update({'mlpipeline-metrics': '/mlpipeline-metrics.json'})
-    output_artifacts.update(
+    _kale_output_artifacts = {}
+    _kale_output_artifacts.update(
+        {'mlpipeline-metrics': '/mlpipeline-metrics.json'})
+    _kale_output_artifacts.update(
         {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
-    output_artifacts.update({'create_matrix': '/create_matrix.html'})
-    create_matrix_task.output_artifact_paths.update(output_artifacts)
-    create_matrix_task.add_pod_label(
+    _kale_output_artifacts.update({'create_matrix': '/create_matrix.html'})
+    _kale_create_matrix_task.output_artifact_paths.update(
+        _kale_output_artifacts)
+    _kale_create_matrix_task.add_pod_label(
         "pipelines.kubeflow.org/metadata_written", "true")
-    dep_names = create_matrix_task.dependent_names + volume_step_names
-    create_matrix_task.add_pod_annotation(
-        "kubeflow-kale.org/dependent-templates", json.dumps(dep_names))
-    if volume_name_parameters:
-        create_matrix_task.add_pod_annotation(
+    _kale_dep_names = (_kale_create_matrix_task.dependent_names +
+                       _kale_volume_step_names)
+    _kale_create_matrix_task.add_pod_annotation(
+        "kubeflow-kale.org/dependent-templates", json.dumps(_kale_dep_names))
+    if _kale_volume_name_parameters:
+        _kale_create_matrix_task.add_pod_annotation(
             "kubeflow-kale.org/volume-name-parameters",
-            json.dumps(volume_name_parameters))
+            json.dumps(_kale_volume_name_parameters))
 
-    sum_matrix_task = sum_matrix_op()\
-        .add_pvolumes(pvolumes_dict)\
-        .after(create_matrix_task)
-    sum_matrix_task.container.working_dir = "/kale"
-    sum_matrix_task.container.set_security_context(
+    _kale_sum_matrix_task = _kale_sum_matrix_op()\
+        .add_pvolumes(_kale_pvolumes_dict)\
+        .after(_kale_create_matrix_task)
+    _kale_sum_matrix_task.container.working_dir = "/kale"
+    _kale_sum_matrix_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
-    output_artifacts = {}
-    output_artifacts.update({'mlpipeline-metrics': '/mlpipeline-metrics.json'})
-    output_artifacts.update(
+    _kale_output_artifacts = {}
+    _kale_output_artifacts.update(
+        {'mlpipeline-metrics': '/mlpipeline-metrics.json'})
+    _kale_output_artifacts.update(
         {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
-    output_artifacts.update({'sum_matrix': '/sum_matrix.html'})
-    sum_matrix_task.output_artifact_paths.update(output_artifacts)
-    sum_matrix_task.add_pod_label(
+    _kale_output_artifacts.update({'sum_matrix': '/sum_matrix.html'})
+    _kale_sum_matrix_task.output_artifact_paths.update(_kale_output_artifacts)
+    _kale_sum_matrix_task.add_pod_label(
         "pipelines.kubeflow.org/metadata_written", "true")
-    dep_names = sum_matrix_task.dependent_names + volume_step_names
-    sum_matrix_task.add_pod_annotation(
-        "kubeflow-kale.org/dependent-templates", json.dumps(dep_names))
-    if volume_name_parameters:
-        sum_matrix_task.add_pod_annotation(
+    _kale_dep_names = (_kale_sum_matrix_task.dependent_names +
+                       _kale_volume_step_names)
+    _kale_sum_matrix_task.add_pod_annotation(
+        "kubeflow-kale.org/dependent-templates", json.dumps(_kale_dep_names))
+    if _kale_volume_name_parameters:
+        _kale_sum_matrix_task.add_pod_annotation(
             "kubeflow-kale.org/volume-name-parameters",
-            json.dumps(volume_name_parameters))
+            json.dumps(_kale_volume_name_parameters))
 
 
 if __name__ == "__main__":

--- a/backend/kale/tests/assets/kfp_dsl/titanic.py
+++ b/backend/kale/tests/assets/kfp_dsl/titanic.py
@@ -1,6 +1,8 @@
-import kfp.dsl as dsl
 import json
-import kfp.components as comp
+
+import kfp.dsl as _kfp_dsl
+import kfp.components as _kfp_components
+
 from collections import OrderedDict
 from kubernetes import client as k8s_client
 
@@ -9,7 +11,7 @@ def loaddata():
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    block1 = '''
+    _kale_block1 = '''
     import numpy as np
     import pandas as pd
     import seaborn as sns
@@ -27,7 +29,7 @@ def loaddata():
     from sklearn.naive_bayes import GaussianNB
     '''
 
-    block2 = '''
+    _kale_block2 = '''
     path = "data/"
 
     PREDICTION_LABEL = 'Survived'
@@ -36,7 +38,7 @@ def loaddata():
     train_df = pd.read_csv(path + "train.csv")
     '''
 
-    data_saving_block = '''
+    _kale_data_saving_block = '''
     # -----------------------DATA SAVING START---------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -50,13 +52,13 @@ def loaddata():
     from kale.common.jputils import run_code as _kale_run_code
     from kale.common.kfputils import \
         update_uimetadata as _kale_update_uimetadata
-    blocks = (
-        block1,
-        block2,
-        data_saving_block)
-    html_artifact = _kale_run_code(blocks)
+    _kale_blocks = (
+        _kale_block1,
+        _kale_block2,
+        _kale_data_saving_block)
+    _kale_html_artifact = _kale_run_code(_kale_blocks)
     with open("/loaddata.html", "w") as f:
-        f.write(html_artifact)
+        f.write(_kale_html_artifact)
     _kale_update_uimetadata('loaddata')
 
     _kale_mlmdutils.call("mark_execution_complete")
@@ -66,7 +68,7 @@ def datapreprocessing():
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    data_loading_block = '''
+    _kale_data_loading_block = '''
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -75,7 +77,7 @@ def datapreprocessing():
     # -----------------------DATA LOADING END----------------------------------
     '''
 
-    block1 = '''
+    _kale_block1 = '''
     import numpy as np
     import pandas as pd
     import seaborn as sns
@@ -93,7 +95,7 @@ def datapreprocessing():
     from sklearn.naive_bayes import GaussianNB
     '''
 
-    block2 = '''
+    _kale_block2 = '''
     data = [train_df, test_df]
     for dataset in data:
         dataset['relatives'] = dataset['SibSp'] + dataset['Parch']
@@ -103,12 +105,12 @@ def datapreprocessing():
     train_df['not_alone'].value_counts()
     '''
 
-    block3 = '''
+    _kale_block3 = '''
     # This does not contribute to a person survival probability
     train_df = train_df.drop(['PassengerId'], axis=1)
     '''
 
-    block4 = '''
+    _kale_block4 = '''
     import re
     deck = {"A": 1, "B": 2, "C": 3, "D": 4, "E": 5, "F": 6, "G": 7, "U": 8}
     data = [train_df, test_df]
@@ -124,7 +126,7 @@ def datapreprocessing():
     test_df = test_df.drop(['Cabin'], axis=1)
     '''
 
-    block5 = '''
+    _kale_block5 = '''
     data = [train_df, test_df]
 
     for dataset in data:
@@ -141,11 +143,11 @@ def datapreprocessing():
     train_df["Age"].isnull().sum()
     '''
 
-    block6 = '''
+    _kale_block6 = '''
     train_df['Embarked'].describe()
     '''
 
-    block7 = '''
+    _kale_block7 = '''
     # fill with most common value
     common_value = 'S'
     data = [train_df, test_df]
@@ -154,11 +156,11 @@ def datapreprocessing():
         dataset['Embarked'] = dataset['Embarked'].fillna(common_value)
     '''
 
-    block8 = '''
+    _kale_block8 = '''
     train_df.info()
     '''
 
-    data_saving_block = '''
+    _kale_data_saving_block = '''
     # -----------------------DATA SAVING START---------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -171,19 +173,19 @@ def datapreprocessing():
     from kale.common.jputils import run_code as _kale_run_code
     from kale.common.kfputils import \
         update_uimetadata as _kale_update_uimetadata
-    blocks = (data_loading_block,
-              block1,
-              block2,
-              block3,
-              block4,
-              block5,
-              block6,
-              block7,
-              block8,
-              data_saving_block)
-    html_artifact = _kale_run_code(blocks)
+    _kale_blocks = (_kale_data_loading_block,
+                    _kale_block1,
+                    _kale_block2,
+                    _kale_block3,
+                    _kale_block4,
+                    _kale_block5,
+                    _kale_block6,
+                    _kale_block7,
+                    _kale_block8,
+                    _kale_data_saving_block)
+    _kale_html_artifact = _kale_run_code(_kale_blocks)
     with open("/datapreprocessing.html", "w") as f:
-        f.write(html_artifact)
+        f.write(_kale_html_artifact)
     _kale_update_uimetadata('datapreprocessing')
 
     _kale_mlmdutils.call("mark_execution_complete")
@@ -193,7 +195,7 @@ def featureengineering():
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    data_loading_block = '''
+    _kale_data_loading_block = '''
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -203,7 +205,7 @@ def featureengineering():
     # -----------------------DATA LOADING END----------------------------------
     '''
 
-    block1 = '''
+    _kale_block1 = '''
     import numpy as np
     import pandas as pd
     import seaborn as sns
@@ -221,7 +223,7 @@ def featureengineering():
     from sklearn.naive_bayes import GaussianNB
     '''
 
-    block2 = '''
+    _kale_block2 = '''
     data = [train_df, test_df]
 
     for dataset in data:
@@ -229,7 +231,7 @@ def featureengineering():
         dataset['Fare'] = dataset['Fare'].astype(int)
     '''
 
-    block3 = '''
+    _kale_block3 = '''
     data = [train_df, test_df]
     titles = {"Mr": 1, "Miss": 2, "Mrs": 3, "Master": 4, "Rare": 5}
 
@@ -250,7 +252,7 @@ def featureengineering():
     test_df = test_df.drop(['Name'], axis=1)
     '''
 
-    block4 = '''
+    _kale_block4 = '''
     genders = {"male": 0, "female": 1}
     data = [train_df, test_df]
 
@@ -258,12 +260,12 @@ def featureengineering():
         dataset['Sex'] = dataset['Sex'].map(genders)
     '''
 
-    block5 = '''
+    _kale_block5 = '''
     train_df = train_df.drop(['Ticket'], axis=1)
     test_df = test_df.drop(['Ticket'], axis=1)
     '''
 
-    block6 = '''
+    _kale_block6 = '''
     ports = {"S": 0, "C": 1, "Q": 2}
     data = [train_df, test_df]
 
@@ -271,7 +273,7 @@ def featureengineering():
         dataset['Embarked'] = dataset['Embarked'].map(ports)
     '''
 
-    block7 = '''
+    _kale_block7 = '''
     data = [train_df, test_df]
     for dataset in data:
         dataset['Age'] = dataset['Age'].astype(int)
@@ -287,7 +289,7 @@ def featureengineering():
     # let's see how it's distributed train_df['Age'].value_counts()
     '''
 
-    block8 = '''
+    _kale_block8 = '''
     data = [train_df, test_df]
 
     for dataset in data:
@@ -300,13 +302,13 @@ def featureengineering():
         dataset['Fare'] = dataset['Fare'].astype(int)
     '''
 
-    block9 = '''
+    _kale_block9 = '''
     data = [train_df, test_df]
     for dataset in data:
         dataset['Age_Class']= dataset['Age']* dataset['Pclass']
     '''
 
-    block10 = '''
+    _kale_block10 = '''
     for dataset in data:
         dataset['Fare_Per_Person'] = dataset['Fare']/(dataset['relatives']+1)
         dataset['Fare_Per_Person'] = dataset['Fare_Per_Person'].astype(int)
@@ -314,12 +316,12 @@ def featureengineering():
     train_df.head(10)
     '''
 
-    block11 = '''
+    _kale_block11 = '''
     train_labels = train_df[PREDICTION_LABEL]
     train_df = train_df.drop(PREDICTION_LABEL, axis=1)
     '''
 
-    data_saving_block = '''
+    _kale_data_saving_block = '''
     # -----------------------DATA SAVING START---------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -332,22 +334,22 @@ def featureengineering():
     from kale.common.jputils import run_code as _kale_run_code
     from kale.common.kfputils import \
         update_uimetadata as _kale_update_uimetadata
-    blocks = (data_loading_block,
-              block1,
-              block2,
-              block3,
-              block4,
-              block5,
-              block6,
-              block7,
-              block8,
-              block9,
-              block10,
-              block11,
-              data_saving_block)
-    html_artifact = _kale_run_code(blocks)
+    _kale_blocks = (_kale_data_loading_block,
+                    _kale_block1,
+                    _kale_block2,
+                    _kale_block3,
+                    _kale_block4,
+                    _kale_block5,
+                    _kale_block6,
+                    _kale_block7,
+                    _kale_block8,
+                    _kale_block9,
+                    _kale_block10,
+                    _kale_block11,
+                    _kale_data_saving_block)
+    _kale_html_artifact = _kale_run_code(_kale_blocks)
     with open("/featureengineering.html", "w") as f:
-        f.write(html_artifact)
+        f.write(_kale_html_artifact)
     _kale_update_uimetadata('featureengineering')
 
     _kale_mlmdutils.call("mark_execution_complete")
@@ -357,7 +359,7 @@ def decisiontree():
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    data_loading_block = '''
+    _kale_data_loading_block = '''
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -366,7 +368,7 @@ def decisiontree():
     # -----------------------DATA LOADING END----------------------------------
     '''
 
-    block1 = '''
+    _kale_block1 = '''
     import numpy as np
     import pandas as pd
     import seaborn as sns
@@ -384,13 +386,13 @@ def decisiontree():
     from sklearn.naive_bayes import GaussianNB
     '''
 
-    block2 = '''
+    _kale_block2 = '''
     decision_tree = DecisionTreeClassifier()
     decision_tree.fit(train_df, train_labels)
     acc_decision_tree = round(decision_tree.score(train_df, train_labels) * 100, 2)
     '''
 
-    data_saving_block = '''
+    _kale_data_saving_block = '''
     # -----------------------DATA SAVING START---------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -402,13 +404,13 @@ def decisiontree():
     from kale.common.jputils import run_code as _kale_run_code
     from kale.common.kfputils import \
         update_uimetadata as _kale_update_uimetadata
-    blocks = (data_loading_block,
-              block1,
-              block2,
-              data_saving_block)
-    html_artifact = _kale_run_code(blocks)
+    _kale_blocks = (_kale_data_loading_block,
+                    _kale_block1,
+                    _kale_block2,
+                    _kale_data_saving_block)
+    _kale_html_artifact = _kale_run_code(_kale_blocks)
     with open("/decisiontree.html", "w") as f:
-        f.write(html_artifact)
+        f.write(_kale_html_artifact)
     _kale_update_uimetadata('decisiontree')
 
     _kale_mlmdutils.call("mark_execution_complete")
@@ -418,7 +420,7 @@ def svm():
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    data_loading_block = '''
+    _kale_data_loading_block = '''
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -427,7 +429,7 @@ def svm():
     # -----------------------DATA LOADING END----------------------------------
     '''
 
-    block1 = '''
+    _kale_block1 = '''
     import numpy as np
     import pandas as pd
     import seaborn as sns
@@ -445,13 +447,13 @@ def svm():
     from sklearn.naive_bayes import GaussianNB
     '''
 
-    block2 = '''
+    _kale_block2 = '''
     linear_svc = SVC(gamma='auto')
     linear_svc.fit(train_df, train_labels)
     acc_linear_svc = round(linear_svc.score(train_df, train_labels) * 100, 2)
     '''
 
-    data_saving_block = '''
+    _kale_data_saving_block = '''
     # -----------------------DATA SAVING START---------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -463,13 +465,13 @@ def svm():
     from kale.common.jputils import run_code as _kale_run_code
     from kale.common.kfputils import \
         update_uimetadata as _kale_update_uimetadata
-    blocks = (data_loading_block,
-              block1,
-              block2,
-              data_saving_block)
-    html_artifact = _kale_run_code(blocks)
+    _kale_blocks = (_kale_data_loading_block,
+                    _kale_block1,
+                    _kale_block2,
+                    _kale_data_saving_block)
+    _kale_html_artifact = _kale_run_code(_kale_blocks)
     with open("/svm.html", "w") as f:
-        f.write(html_artifact)
+        f.write(_kale_html_artifact)
     _kale_update_uimetadata('svm')
 
     _kale_mlmdutils.call("mark_execution_complete")
@@ -479,7 +481,7 @@ def naivebayes():
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    data_loading_block = '''
+    _kale_data_loading_block = '''
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -488,7 +490,7 @@ def naivebayes():
     # -----------------------DATA LOADING END----------------------------------
     '''
 
-    block1 = '''
+    _kale_block1 = '''
     import numpy as np
     import pandas as pd
     import seaborn as sns
@@ -506,13 +508,13 @@ def naivebayes():
     from sklearn.naive_bayes import GaussianNB
     '''
 
-    block2 = '''
+    _kale_block2 = '''
     gaussian = GaussianNB()
     gaussian.fit(train_df, train_labels)
     acc_gaussian = round(gaussian.score(train_df, train_labels) * 100, 2)
     '''
 
-    data_saving_block = '''
+    _kale_data_saving_block = '''
     # -----------------------DATA SAVING START---------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -524,13 +526,13 @@ def naivebayes():
     from kale.common.jputils import run_code as _kale_run_code
     from kale.common.kfputils import \
         update_uimetadata as _kale_update_uimetadata
-    blocks = (data_loading_block,
-              block1,
-              block2,
-              data_saving_block)
-    html_artifact = _kale_run_code(blocks)
+    _kale_blocks = (_kale_data_loading_block,
+                    _kale_block1,
+                    _kale_block2,
+                    _kale_data_saving_block)
+    _kale_html_artifact = _kale_run_code(_kale_blocks)
     with open("/naivebayes.html", "w") as f:
-        f.write(html_artifact)
+        f.write(_kale_html_artifact)
     _kale_update_uimetadata('naivebayes')
 
     _kale_mlmdutils.call("mark_execution_complete")
@@ -540,7 +542,7 @@ def logisticregression():
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    data_loading_block = '''
+    _kale_data_loading_block = '''
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -549,7 +551,7 @@ def logisticregression():
     # -----------------------DATA LOADING END----------------------------------
     '''
 
-    block1 = '''
+    _kale_block1 = '''
     import numpy as np
     import pandas as pd
     import seaborn as sns
@@ -567,13 +569,13 @@ def logisticregression():
     from sklearn.naive_bayes import GaussianNB
     '''
 
-    block2 = '''
+    _kale_block2 = '''
     logreg = LogisticRegression(solver='lbfgs', max_iter=110)
     logreg.fit(train_df, train_labels)
     acc_log = round(logreg.score(train_df, train_labels) * 100, 2)
     '''
 
-    data_saving_block = '''
+    _kale_data_saving_block = '''
     # -----------------------DATA SAVING START---------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -585,13 +587,13 @@ def logisticregression():
     from kale.common.jputils import run_code as _kale_run_code
     from kale.common.kfputils import \
         update_uimetadata as _kale_update_uimetadata
-    blocks = (data_loading_block,
-              block1,
-              block2,
-              data_saving_block)
-    html_artifact = _kale_run_code(blocks)
+    _kale_blocks = (_kale_data_loading_block,
+                    _kale_block1,
+                    _kale_block2,
+                    _kale_data_saving_block)
+    _kale_html_artifact = _kale_run_code(_kale_blocks)
     with open("/logisticregression.html", "w") as f:
-        f.write(html_artifact)
+        f.write(_kale_html_artifact)
     _kale_update_uimetadata('logisticregression')
 
     _kale_mlmdutils.call("mark_execution_complete")
@@ -601,7 +603,7 @@ def randomforest():
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    data_loading_block = '''
+    _kale_data_loading_block = '''
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -610,7 +612,7 @@ def randomforest():
     # -----------------------DATA LOADING END----------------------------------
     '''
 
-    block1 = '''
+    _kale_block1 = '''
     import numpy as np
     import pandas as pd
     import seaborn as sns
@@ -628,13 +630,13 @@ def randomforest():
     from sklearn.naive_bayes import GaussianNB
     '''
 
-    block2 = '''
+    _kale_block2 = '''
     random_forest = RandomForestClassifier(n_estimators=100)
     random_forest.fit(train_df, train_labels)
     acc_random_forest = round(random_forest.score(train_df, train_labels) * 100, 2)
     '''
 
-    data_saving_block = '''
+    _kale_data_saving_block = '''
     # -----------------------DATA SAVING START---------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -646,13 +648,13 @@ def randomforest():
     from kale.common.jputils import run_code as _kale_run_code
     from kale.common.kfputils import \
         update_uimetadata as _kale_update_uimetadata
-    blocks = (data_loading_block,
-              block1,
-              block2,
-              data_saving_block)
-    html_artifact = _kale_run_code(blocks)
+    _kale_blocks = (_kale_data_loading_block,
+                    _kale_block1,
+                    _kale_block2,
+                    _kale_data_saving_block)
+    _kale_html_artifact = _kale_run_code(_kale_blocks)
     with open("/randomforest.html", "w") as f:
-        f.write(html_artifact)
+        f.write(_kale_html_artifact)
     _kale_update_uimetadata('randomforest')
 
     _kale_mlmdutils.call("mark_execution_complete")
@@ -662,7 +664,7 @@ def results():
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    data_loading_block = '''
+    _kale_data_loading_block = '''
     # -----------------------DATA LOADING START--------------------------------
     from kale.marshal import utils as _kale_marshal_utils
     _kale_marshal_utils.set_kale_data_directory("/marshal")
@@ -674,7 +676,7 @@ def results():
     # -----------------------DATA LOADING END----------------------------------
     '''
 
-    block1 = '''
+    _kale_block1 = '''
     import numpy as np
     import pandas as pd
     import seaborn as sns
@@ -692,7 +694,7 @@ def results():
     from sklearn.naive_bayes import GaussianNB
     '''
 
-    block2 = '''
+    _kale_block2 = '''
     results = pd.DataFrame({
         'Model': ['Support Vector Machines', 'logistic Regression',
                   'Random Forest', 'Naive Bayes', 'Decision Tree'],
@@ -707,254 +709,276 @@ def results():
     from kale.common.jputils import run_code as _kale_run_code
     from kale.common.kfputils import \
         update_uimetadata as _kale_update_uimetadata
-    blocks = (data_loading_block,
-              block1,
-              block2,
-              )
-    html_artifact = _kale_run_code(blocks)
+    _kale_blocks = (_kale_data_loading_block,
+                    _kale_block1,
+                    _kale_block2,
+                    )
+    _kale_html_artifact = _kale_run_code(_kale_blocks)
     with open("/results.html", "w") as f:
-        f.write(html_artifact)
+        f.write(_kale_html_artifact)
     _kale_update_uimetadata('results')
 
     _kale_mlmdutils.call("mark_execution_complete")
 
 
-loaddata_op = comp.func_to_container_op(loaddata)
+_kale_loaddata_op = _kfp_components.func_to_container_op(loaddata)
 
 
-datapreprocessing_op = comp.func_to_container_op(datapreprocessing)
+_kale_datapreprocessing_op = _kfp_components.func_to_container_op(
+    datapreprocessing)
 
 
-featureengineering_op = comp.func_to_container_op(featureengineering)
+_kale_featureengineering_op = _kfp_components.func_to_container_op(
+    featureengineering)
 
 
-decisiontree_op = comp.func_to_container_op(decisiontree)
+_kale_decisiontree_op = _kfp_components.func_to_container_op(decisiontree)
 
 
-svm_op = comp.func_to_container_op(svm)
+_kale_svm_op = _kfp_components.func_to_container_op(svm)
 
 
-naivebayes_op = comp.func_to_container_op(naivebayes)
+_kale_naivebayes_op = _kfp_components.func_to_container_op(naivebayes)
 
 
-logisticregression_op = comp.func_to_container_op(logisticregression)
+_kale_logisticregression_op = _kfp_components.func_to_container_op(
+    logisticregression)
 
 
-randomforest_op = comp.func_to_container_op(randomforest)
+_kale_randomforest_op = _kfp_components.func_to_container_op(randomforest)
 
 
-results_op = comp.func_to_container_op(results)
+_kale_results_op = _kfp_components.func_to_container_op(results)
 
 
-@dsl.pipeline(
+@_kfp_dsl.pipeline(
     name='titanic-ml-rnd',
     description='Predict which passengers survived the Titanic shipwreck'
 )
 def auto_generated_pipeline():
-    pvolumes_dict = OrderedDict()
-    volume_step_names = []
-    volume_name_parameters = []
+    _kale_pvolumes_dict = OrderedDict()
+    _kale_volume_step_names = []
+    _kale_volume_name_parameters = []
 
-    marshal_vop = dsl.VolumeOp(
+    _kale_marshal_vop = _kfp_dsl.VolumeOp(
         name="kale-marshal-volume",
         resource_name="kale-marshal-pvc",
-        modes=dsl.VOLUME_MODE_RWM,
+        modes=_kfp_dsl.VOLUME_MODE_RWM,
         size="1Gi"
     )
-    volume_step_names.append(marshal_vop.name)
-    volume_name_parameters.append(marshal_vop.outputs["name"].full_name)
-    pvolumes_dict['/marshal'] = marshal_vop.volume
+    _kale_volume_step_names.append(_kale_marshal_vop.name)
+    _kale_volume_name_parameters.append(
+        _kale_marshal_vop.outputs["name"].full_name)
+    _kale_pvolumes_dict['/marshal'] = _kale_marshal_vop.volume
 
-    volume_step_names.sort()
-    volume_name_parameters.sort()
+    _kale_volume_step_names.sort()
+    _kale_volume_name_parameters.sort()
 
-    loaddata_task = loaddata_op()\
-        .add_pvolumes(pvolumes_dict)\
+    _kale_loaddata_task = _kale_loaddata_op()\
+        .add_pvolumes(_kale_pvolumes_dict)\
         .after()
-    loaddata_task.container.working_dir = "/kale"
-    loaddata_task.container.set_security_context(
+    _kale_loaddata_task.container.working_dir = "/kale"
+    _kale_loaddata_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
-    output_artifacts = {}
-    output_artifacts.update(
+    _kale_output_artifacts = {}
+    _kale_output_artifacts.update(
         {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
-    output_artifacts.update({'loaddata': '/loaddata.html'})
-    loaddata_task.output_artifact_paths.update(output_artifacts)
-    loaddata_task.add_pod_label(
+    _kale_output_artifacts.update({'loaddata': '/loaddata.html'})
+    _kale_loaddata_task.output_artifact_paths.update(_kale_output_artifacts)
+    _kale_loaddata_task.add_pod_label(
         "pipelines.kubeflow.org/metadata_written", "true")
-    dep_names = loaddata_task.dependent_names + volume_step_names
-    loaddata_task.add_pod_annotation(
-        "kubeflow-kale.org/dependent-templates", json.dumps(dep_names))
-    if volume_name_parameters:
-        loaddata_task.add_pod_annotation(
+    _kale_dep_names = (_kale_loaddata_task.dependent_names +
+                       _kale_volume_step_names)
+    _kale_loaddata_task.add_pod_annotation(
+        "kubeflow-kale.org/dependent-templates", json.dumps(_kale_dep_names))
+    if _kale_volume_name_parameters:
+        _kale_loaddata_task.add_pod_annotation(
             "kubeflow-kale.org/volume-name-parameters",
-            json.dumps(volume_name_parameters))
+            json.dumps(_kale_volume_name_parameters))
 
-    datapreprocessing_task = datapreprocessing_op()\
-        .add_pvolumes(pvolumes_dict)\
-        .after(loaddata_task)
-    datapreprocessing_task.container.working_dir = "/kale"
-    datapreprocessing_task.container.set_security_context(
+    _kale_datapreprocessing_task = _kale_datapreprocessing_op()\
+        .add_pvolumes(_kale_pvolumes_dict)\
+        .after(_kale_loaddata_task)
+    _kale_datapreprocessing_task.container.working_dir = "/kale"
+    _kale_datapreprocessing_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
-    output_artifacts = {}
-    output_artifacts.update(
+    _kale_output_artifacts = {}
+    _kale_output_artifacts.update(
         {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
-    output_artifacts.update({'datapreprocessing': '/datapreprocessing.html'})
-    datapreprocessing_task.output_artifact_paths.update(output_artifacts)
-    datapreprocessing_task.add_pod_label(
+    _kale_output_artifacts.update(
+        {'datapreprocessing': '/datapreprocessing.html'})
+    _kale_datapreprocessing_task.output_artifact_paths.update(
+        _kale_output_artifacts)
+    _kale_datapreprocessing_task.add_pod_label(
         "pipelines.kubeflow.org/metadata_written", "true")
-    dep_names = datapreprocessing_task.dependent_names + volume_step_names
-    datapreprocessing_task.add_pod_annotation(
-        "kubeflow-kale.org/dependent-templates", json.dumps(dep_names))
-    if volume_name_parameters:
-        datapreprocessing_task.add_pod_annotation(
+    _kale_dep_names = (_kale_datapreprocessing_task.dependent_names +
+                       _kale_volume_step_names)
+    _kale_datapreprocessing_task.add_pod_annotation(
+        "kubeflow-kale.org/dependent-templates", json.dumps(_kale_dep_names))
+    if _kale_volume_name_parameters:
+        _kale_datapreprocessing_task.add_pod_annotation(
             "kubeflow-kale.org/volume-name-parameters",
-            json.dumps(volume_name_parameters))
+            json.dumps(_kale_volume_name_parameters))
 
-    featureengineering_task = featureengineering_op()\
-        .add_pvolumes(pvolumes_dict)\
-        .after(datapreprocessing_task)
-    featureengineering_task.container.working_dir = "/kale"
-    featureengineering_task.container.set_security_context(
+    _kale_featureengineering_task = _kale_featureengineering_op()\
+        .add_pvolumes(_kale_pvolumes_dict)\
+        .after(_kale_datapreprocessing_task)
+    _kale_featureengineering_task.container.working_dir = "/kale"
+    _kale_featureengineering_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
-    output_artifacts = {}
-    output_artifacts.update(
+    _kale_output_artifacts = {}
+    _kale_output_artifacts.update(
         {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
-    output_artifacts.update({'featureengineering': '/featureengineering.html'})
-    featureengineering_task.output_artifact_paths.update(output_artifacts)
-    featureengineering_task.add_pod_label(
+    _kale_output_artifacts.update(
+        {'featureengineering': '/featureengineering.html'})
+    _kale_featureengineering_task.output_artifact_paths.update(
+        _kale_output_artifacts)
+    _kale_featureengineering_task.add_pod_label(
         "pipelines.kubeflow.org/metadata_written", "true")
-    dep_names = featureengineering_task.dependent_names + volume_step_names
-    featureengineering_task.add_pod_annotation(
-        "kubeflow-kale.org/dependent-templates", json.dumps(dep_names))
-    if volume_name_parameters:
-        featureengineering_task.add_pod_annotation(
+    _kale_dep_names = (_kale_featureengineering_task.dependent_names +
+                       _kale_volume_step_names)
+    _kale_featureengineering_task.add_pod_annotation(
+        "kubeflow-kale.org/dependent-templates", json.dumps(_kale_dep_names))
+    if _kale_volume_name_parameters:
+        _kale_featureengineering_task.add_pod_annotation(
             "kubeflow-kale.org/volume-name-parameters",
-            json.dumps(volume_name_parameters))
+            json.dumps(_kale_volume_name_parameters))
 
-    decisiontree_task = decisiontree_op()\
-        .add_pvolumes(pvolumes_dict)\
-        .after(featureengineering_task)
-    decisiontree_task.container.working_dir = "/kale"
-    decisiontree_task.container.set_security_context(
+    _kale_decisiontree_task = _kale_decisiontree_op()\
+        .add_pvolumes(_kale_pvolumes_dict)\
+        .after(_kale_featureengineering_task)
+    _kale_decisiontree_task.container.working_dir = "/kale"
+    _kale_decisiontree_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
-    output_artifacts = {}
-    output_artifacts.update(
+    _kale_output_artifacts = {}
+    _kale_output_artifacts.update(
         {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
-    output_artifacts.update({'decisiontree': '/decisiontree.html'})
-    decisiontree_task.output_artifact_paths.update(output_artifacts)
-    decisiontree_task.add_pod_label(
+    _kale_output_artifacts.update({'decisiontree': '/decisiontree.html'})
+    _kale_decisiontree_task.output_artifact_paths.update(
+        _kale_output_artifacts)
+    _kale_decisiontree_task.add_pod_label(
         "pipelines.kubeflow.org/metadata_written", "true")
-    dep_names = decisiontree_task.dependent_names + volume_step_names
-    decisiontree_task.add_pod_annotation(
-        "kubeflow-kale.org/dependent-templates", json.dumps(dep_names))
-    if volume_name_parameters:
-        decisiontree_task.add_pod_annotation(
+    _kale_dep_names = (_kale_decisiontree_task.dependent_names +
+                       _kale_volume_step_names)
+    _kale_decisiontree_task.add_pod_annotation(
+        "kubeflow-kale.org/dependent-templates", json.dumps(_kale_dep_names))
+    if _kale_volume_name_parameters:
+        _kale_decisiontree_task.add_pod_annotation(
             "kubeflow-kale.org/volume-name-parameters",
-            json.dumps(volume_name_parameters))
+            json.dumps(_kale_volume_name_parameters))
 
-    svm_task = svm_op()\
-        .add_pvolumes(pvolumes_dict)\
-        .after(featureengineering_task)
-    svm_task.container.working_dir = "/kale"
-    svm_task.container.set_security_context(
+    _kale_svm_task = _kale_svm_op()\
+        .add_pvolumes(_kale_pvolumes_dict)\
+        .after(_kale_featureengineering_task)
+    _kale_svm_task.container.working_dir = "/kale"
+    _kale_svm_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
-    output_artifacts = {}
-    output_artifacts.update(
+    _kale_output_artifacts = {}
+    _kale_output_artifacts.update(
         {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
-    output_artifacts.update({'svm': '/svm.html'})
-    svm_task.output_artifact_paths.update(output_artifacts)
-    svm_task.add_pod_label("pipelines.kubeflow.org/metadata_written", "true")
-    dep_names = svm_task.dependent_names + volume_step_names
-    svm_task.add_pod_annotation(
-        "kubeflow-kale.org/dependent-templates", json.dumps(dep_names))
-    if volume_name_parameters:
-        svm_task.add_pod_annotation(
-            "kubeflow-kale.org/volume-name-parameters",
-            json.dumps(volume_name_parameters))
-
-    naivebayes_task = naivebayes_op()\
-        .add_pvolumes(pvolumes_dict)\
-        .after(featureengineering_task)
-    naivebayes_task.container.working_dir = "/kale"
-    naivebayes_task.container.set_security_context(
-        k8s_client.V1SecurityContext(run_as_user=0))
-    output_artifacts = {}
-    output_artifacts.update(
-        {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
-    output_artifacts.update({'naivebayes': '/naivebayes.html'})
-    naivebayes_task.output_artifact_paths.update(output_artifacts)
-    naivebayes_task.add_pod_label(
+    _kale_output_artifacts.update({'svm': '/svm.html'})
+    _kale_svm_task.output_artifact_paths.update(_kale_output_artifacts)
+    _kale_svm_task.add_pod_label(
         "pipelines.kubeflow.org/metadata_written", "true")
-    dep_names = naivebayes_task.dependent_names + volume_step_names
-    naivebayes_task.add_pod_annotation(
-        "kubeflow-kale.org/dependent-templates", json.dumps(dep_names))
-    if volume_name_parameters:
-        naivebayes_task.add_pod_annotation(
+    _kale_dep_names = (_kale_svm_task.dependent_names +
+                       _kale_volume_step_names)
+    _kale_svm_task.add_pod_annotation(
+        "kubeflow-kale.org/dependent-templates", json.dumps(_kale_dep_names))
+    if _kale_volume_name_parameters:
+        _kale_svm_task.add_pod_annotation(
             "kubeflow-kale.org/volume-name-parameters",
-            json.dumps(volume_name_parameters))
+            json.dumps(_kale_volume_name_parameters))
 
-    logisticregression_task = logisticregression_op()\
-        .add_pvolumes(pvolumes_dict)\
-        .after(featureengineering_task)
-    logisticregression_task.container.working_dir = "/kale"
-    logisticregression_task.container.set_security_context(
+    _kale_naivebayes_task = _kale_naivebayes_op()\
+        .add_pvolumes(_kale_pvolumes_dict)\
+        .after(_kale_featureengineering_task)
+    _kale_naivebayes_task.container.working_dir = "/kale"
+    _kale_naivebayes_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
-    output_artifacts = {}
-    output_artifacts.update(
+    _kale_output_artifacts = {}
+    _kale_output_artifacts.update(
         {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
-    output_artifacts.update({'logisticregression': '/logisticregression.html'})
-    logisticregression_task.output_artifact_paths.update(output_artifacts)
-    logisticregression_task.add_pod_label(
+    _kale_output_artifacts.update({'naivebayes': '/naivebayes.html'})
+    _kale_naivebayes_task.output_artifact_paths.update(_kale_output_artifacts)
+    _kale_naivebayes_task.add_pod_label(
         "pipelines.kubeflow.org/metadata_written", "true")
-    dep_names = logisticregression_task.dependent_names + volume_step_names
-    logisticregression_task.add_pod_annotation(
-        "kubeflow-kale.org/dependent-templates", json.dumps(dep_names))
-    if volume_name_parameters:
-        logisticregression_task.add_pod_annotation(
+    _kale_dep_names = (_kale_naivebayes_task.dependent_names +
+                       _kale_volume_step_names)
+    _kale_naivebayes_task.add_pod_annotation(
+        "kubeflow-kale.org/dependent-templates", json.dumps(_kale_dep_names))
+    if _kale_volume_name_parameters:
+        _kale_naivebayes_task.add_pod_annotation(
             "kubeflow-kale.org/volume-name-parameters",
-            json.dumps(volume_name_parameters))
+            json.dumps(_kale_volume_name_parameters))
 
-    randomforest_task = randomforest_op()\
-        .add_pvolumes(pvolumes_dict)\
-        .after(featureengineering_task)
-    randomforest_task.container.working_dir = "/kale"
-    randomforest_task.container.set_security_context(
+    _kale_logisticregression_task = _kale_logisticregression_op()\
+        .add_pvolumes(_kale_pvolumes_dict)\
+        .after(_kale_featureengineering_task)
+    _kale_logisticregression_task.container.working_dir = "/kale"
+    _kale_logisticregression_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
-    output_artifacts = {}
-    output_artifacts.update(
+    _kale_output_artifacts = {}
+    _kale_output_artifacts.update(
         {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
-    output_artifacts.update({'randomforest': '/randomforest.html'})
-    randomforest_task.output_artifact_paths.update(output_artifacts)
-    randomforest_task.add_pod_label(
+    _kale_output_artifacts.update(
+        {'logisticregression': '/logisticregression.html'})
+    _kale_logisticregression_task.output_artifact_paths.update(
+        _kale_output_artifacts)
+    _kale_logisticregression_task.add_pod_label(
         "pipelines.kubeflow.org/metadata_written", "true")
-    dep_names = randomforest_task.dependent_names + volume_step_names
-    randomforest_task.add_pod_annotation(
-        "kubeflow-kale.org/dependent-templates", json.dumps(dep_names))
-    if volume_name_parameters:
-        randomforest_task.add_pod_annotation(
+    _kale_dep_names = (_kale_logisticregression_task.dependent_names +
+                       _kale_volume_step_names)
+    _kale_logisticregression_task.add_pod_annotation(
+        "kubeflow-kale.org/dependent-templates", json.dumps(_kale_dep_names))
+    if _kale_volume_name_parameters:
+        _kale_logisticregression_task.add_pod_annotation(
             "kubeflow-kale.org/volume-name-parameters",
-            json.dumps(volume_name_parameters))
+            json.dumps(_kale_volume_name_parameters))
 
-    results_task = results_op()\
-        .add_pvolumes(pvolumes_dict)\
-        .after(randomforest_task, logisticregression_task, naivebayes_task, svm_task, decisiontree_task)
-    results_task.container.working_dir = "/kale"
-    results_task.container.set_security_context(
+    _kale_randomforest_task = _kale_randomforest_op()\
+        .add_pvolumes(_kale_pvolumes_dict)\
+        .after(_kale_featureengineering_task)
+    _kale_randomforest_task.container.working_dir = "/kale"
+    _kale_randomforest_task.container.set_security_context(
         k8s_client.V1SecurityContext(run_as_user=0))
-    output_artifacts = {}
-    output_artifacts.update(
+    _kale_output_artifacts = {}
+    _kale_output_artifacts.update(
         {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
-    output_artifacts.update({'results': '/results.html'})
-    results_task.output_artifact_paths.update(output_artifacts)
-    results_task.add_pod_label(
+    _kale_output_artifacts.update({'randomforest': '/randomforest.html'})
+    _kale_randomforest_task.output_artifact_paths.update(
+        _kale_output_artifacts)
+    _kale_randomforest_task.add_pod_label(
         "pipelines.kubeflow.org/metadata_written", "true")
-    dep_names = results_task.dependent_names + volume_step_names
-    results_task.add_pod_annotation(
-        "kubeflow-kale.org/dependent-templates", json.dumps(dep_names))
-    if volume_name_parameters:
-        results_task.add_pod_annotation(
+    _kale_dep_names = (_kale_randomforest_task.dependent_names +
+                       _kale_volume_step_names)
+    _kale_randomforest_task.add_pod_annotation(
+        "kubeflow-kale.org/dependent-templates", json.dumps(_kale_dep_names))
+    if _kale_volume_name_parameters:
+        _kale_randomforest_task.add_pod_annotation(
             "kubeflow-kale.org/volume-name-parameters",
-            json.dumps(volume_name_parameters))
+            json.dumps(_kale_volume_name_parameters))
+
+    _kale_results_task = _kale_results_op()\
+        .add_pvolumes(_kale_pvolumes_dict)\
+        .after(_kale_randomforest_task, _kale_logisticregression_task, _kale_naivebayes_task, _kale_svm_task, _kale_decisiontree_task)
+    _kale_results_task.container.working_dir = "/kale"
+    _kale_results_task.container.set_security_context(
+        k8s_client.V1SecurityContext(run_as_user=0))
+    _kale_output_artifacts = {}
+    _kale_output_artifacts.update(
+        {'mlpipeline-ui-metadata': '/mlpipeline-ui-metadata.json'})
+    _kale_output_artifacts.update({'results': '/results.html'})
+    _kale_results_task.output_artifact_paths.update(_kale_output_artifacts)
+    _kale_results_task.add_pod_label(
+        "pipelines.kubeflow.org/metadata_written", "true")
+    _kale_dep_names = (_kale_results_task.dependent_names +
+                       _kale_volume_step_names)
+    _kale_results_task.add_pod_annotation(
+        "kubeflow-kale.org/dependent-templates", json.dumps(_kale_dep_names))
+    if _kale_volume_name_parameters:
+        _kale_results_task.add_pod_annotation(
+            "kubeflow-kale.org/volume-name-parameters",
+            json.dumps(_kale_volume_name_parameters))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In case a pipeline parameter had the same name as one of the variables
used by Kale in the `dsl.pipeline` decorated function, the value of the
pipeline parameter would be overwritten.
This commit prevents this by obfuscating all the local variables
assigned and used by Kale.

Signed-off-by: Stefano Fioravanzo <stefano@arrikto.com>