### PR TITLE
marshal: Set compile to False when loading the model

### DIFF
--- a/backend/kale/marshal/backends.py
+++ b/backend/kale/marshal/backends.py
@@ -141,7 +141,7 @@ def resource_tf_load(uri, **kwargs):
     try:
         from tensorflow.keras.models import load_model
         log.info(f"Loading tf.Keras model: {uri}")
-        obj_tfkeras = load_model(uri)
+        obj_tfkeras = load_model(uri, compile=False)
         return obj_tfkeras
     except ImportError:
         return fallback_load(uri, **kwargs)


### PR DESCRIPTION
The model will load in inference mode and won't be ready for further training.
If the user wants to train it further he would have to compile it again.
However, this is preferable in order to support custom loss functions and optimizers.

For example, if the user has trained a model with a custom loss function
or a custom optimizer and tries to load it with compile set to True
a `ValueError` will occur specifying that it does not recognize this loss function
or optimizer. Thus the step will fail on KFP.

Signed-off-by: Dimitris Poulopoulos <dimpo@arrikto.com>