### PR TITLE
marshal: Restrict types for Keras backend

### DIFF
--- a/backend/kale/marshal/backends.py
+++ b/backend/kale/marshal/backends.py
@@ -125,7 +125,7 @@ def resource_keras_load(uri, **kwargs):
         return fallback_load(uri, **kwargs)
 
 
-@resource_save.register(r'keras.*')
+@resource_save.register(r'keras\..*')
 def resource_keras_save(obj, path, **kwargs):
     """Save a Keras model."""
     try:


### PR DESCRIPTION
Change the type marching from `keras*` to `keras.*` for the Keras
backend to use stand pickling for objects likes
`keras_preprocessing.text.Tokenizers`.

Signed-off-by: Stefano Fioravanzo <stefano@arrikto.com>