### PR TITLE
Enable specifying the storage class and access modes of the created PVCs

### DIFF
--- a/backend/kale/cli.py
+++ b/backend/kale/cli.py
@@ -73,6 +73,9 @@ def main():
     metadata_group.add_argument('--kfp_host', type=str,
                                 help='KFP endpoint. Provide address as '
                                      '<host>:<port>.')
+    metadata_group.add_argument('--storage-class-name', type=str,
+                                help='The storage class name for the created'
+                                     ' volumes')
 
     args = parser.parse_args()
 

--- a/backend/kale/cli.py
+++ b/backend/kale/cli.py
@@ -76,6 +76,8 @@ def main():
     metadata_group.add_argument('--storage-class-name', type=str,
                                 help='The storage class name for the created'
                                      ' volumes')
+    metadata_group.add_argument('--volume-access-mode', type=str,
+                                help='The access mode for the created volumes')
 
     args = parser.parse_args()
 

--- a/backend/kale/config/config.py
+++ b/backend/kale/config/config.py
@@ -60,6 +60,11 @@ class Field:
 
     def validate(self):
         """Run the validators over the field's value."""
+        # If the Field's value is `None` don't run the validation process.
+        # Validators are *not* supposed to check if the value is set or not,
+        # we should control that by setting the `required` flag to True.
+        if self._value is None:
+            return
         for v in self.validators:
             validator = v() if inspect.isclass(v) else v
             # XXX: The validator is supposed to raise an Exception if

--- a/backend/kale/config/validators.py
+++ b/backend/kale/config/validators.py
@@ -190,3 +190,16 @@ class VolumeTypeValidator(EnumValidator):
     """Validates the type of a Volume."""
 
     enum = ('pv', 'pvc', 'new_pvc', 'clone')
+
+
+class VolumeAccessModeValidator(EnumValidator):
+    """Validates the access mode of a Volume."""
+
+    enum = ("", "rom", "rwo", "rwm")
+
+
+class IsLowerValidator(Validator):
+    """Validates if a string is all lowercase."""
+
+    def _validate(self, value: str):
+        return value == value.lower()

--- a/backend/kale/templates/pipeline_template.jinja2
+++ b/backend/kale/templates/pipeline_template.jinja2
@@ -35,10 +35,11 @@ def auto_generated_pipeline({%- for arg in pipeline.pps_names -%}
     _kale_volume_name_parameters = []
 
     {% for vol in volumes -%}
-    {% set name= vol['name'] %}
+    {% set name = vol['name'] %}
     {% set mountpoint = vol['mount_point'] %}
     {% set pvc_size = vol['size']|string|default ('') + vol['size_type']|default ('') %}
     {% set annotations = vol['annotations']|default({}) %}
+    {% set storage_class_name = vol['storage_class_name'] %}
     _kale_annotations = {{ annotations }}
 
     {% if vol['type'] == 'pv' %}
@@ -52,6 +53,9 @@ def auto_generated_pipeline({%- for arg in pipeline.pps_names -%}
         spec=k8s_client.V1PersistentVolumeClaimSpec(
             volume_name="{{ name }}",
             access_modes=['ReadWriteOnce'],
+            {%- if storage_class_name %}
+            storage_class_name="{{ storage_class_name }}",
+            {%- endif %}
             resources=k8s_client.V1ResourceRequirements(
                 requests={"storage": "{{ pvc_size }}"}
             )
@@ -82,6 +86,9 @@ def auto_generated_pipeline({%- for arg in pipeline.pps_names -%}
         {%- if annotations %}
         annotations=_kale_annotations,
         {% endif -%}
+        {%- if storage_class_name %}
+        storage_class="{{ storage_class_name }}",
+        {%- endif %}
         size='{{ pvc_size }}'
     )
     _kale_volume = _kale_vop{{ loop.index }}.volume
@@ -99,6 +106,9 @@ def auto_generated_pipeline({%- for arg in pipeline.pps_names -%}
         name="kale-marshal-volume",
         resource_name="kale-marshal-pvc",
         modes=_kfp_dsl.VOLUME_MODE_RWM,
+        {%- if pipeline.config.storage_class_name %}
+        storage_class="{{ pipeline.config.storage_class_name }}",
+        {%- endif %}
         size="1Gi"
     )
     _kale_volume_step_names.append(_kale_marshal_vop.name)

--- a/backend/kale/templates/pipeline_template.jinja2
+++ b/backend/kale/templates/pipeline_template.jinja2
@@ -52,7 +52,7 @@ def auto_generated_pipeline({%- for arg in pipeline.pps_names -%}
         ),
         spec=k8s_client.V1PersistentVolumeClaimSpec(
             volume_name="{{ name }}",
-            access_modes=['ReadWriteOnce'],
+            access_modes={{ vol['volume_access_mode'] }},
             {%- if storage_class_name %}
             storage_class_name="{{ storage_class_name }}",
             {%- endif %}
@@ -86,6 +86,7 @@ def auto_generated_pipeline({%- for arg in pipeline.pps_names -%}
         {%- if annotations %}
         annotations=_kale_annotations,
         {% endif -%}
+        modes={{ vol['volume_access_mode'] }},
         {%- if storage_class_name %}
         storage_class="{{ storage_class_name }}",
         {%- endif %}
@@ -105,7 +106,7 @@ def auto_generated_pipeline({%- for arg in pipeline.pps_names -%}
     _kale_marshal_vop = _kfp_dsl.VolumeOp(
         name="kale-marshal-volume",
         resource_name="kale-marshal-pvc",
-        modes=_kfp_dsl.VOLUME_MODE_RWM,
+        modes={{ pipeline.config.volume_access_mode }},
         {%- if pipeline.config.storage_class_name %}
         storage_class="{{ pipeline.config.storage_class_name }}",
         {%- endif %}

--- a/backend/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
+++ b/backend/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
@@ -121,7 +121,7 @@ def auto_generated_pipeline(booltest='True', d1='5', d2='6', strtest='test'):
     _kale_marshal_vop = _kfp_dsl.VolumeOp(
         name="kale-marshal-volume",
         resource_name="kale-marshal-pvc",
-        modes=_kfp_dsl.VOLUME_MODE_RWM,
+        modes=['ReadWriteMany'],
         size="1Gi"
     )
     _kale_volume_step_names.append(_kale_marshal_vop.name)

--- a/backend/kale/tests/assets/kfp_dsl/titanic.py
+++ b/backend/kale/tests/assets/kfp_dsl/titanic.py
@@ -763,7 +763,7 @@ def auto_generated_pipeline():
     _kale_marshal_vop = _kfp_dsl.VolumeOp(
         name="kale-marshal-volume",
         resource_name="kale-marshal-pvc",
-        modes=_kfp_dsl.VOLUME_MODE_RWM,
+        modes=['ReadWriteMany'],
         size="1Gi"
     )
     _kale_volume_step_names.append(_kale_marshal_vop.name)

--- a/labextension/src/components/Input.tsx
+++ b/labextension/src/components/Input.tsx
@@ -137,6 +137,7 @@ export const Input: React.FunctionComponent<InputProps> = props => {
       error={error}
       value={value}
       margin="dense"
+      placeholder={placeholder}
       spellCheck={false}
       helperText={error ? getRegexMessage() : helperText}
       InputProps={{

--- a/labextension/src/components/VolumeAccessModeSelect.tsx
+++ b/labextension/src/components/VolumeAccessModeSelect.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 The Kale Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import { Select, ISelectOption } from './Select';
+
+const VOLUME_ACCESS_MODE_ROM: ISelectOption = {
+  label: 'ReadOnlyMany',
+  value: 'rom',
+};
+const VOLUME_ACCESS_MODE_RWO: ISelectOption = {
+  label: 'ReadWriteOnce',
+  value: 'rwo',
+};
+const VOLUME_ACCESS_MODE_RWM: ISelectOption = {
+  label: 'ReadWriteMany',
+  value: 'rwm',
+};
+const VOLUME_ACCESS_MODES: ISelectOption[] = [
+  VOLUME_ACCESS_MODE_ROM,
+  VOLUME_ACCESS_MODE_RWO,
+  VOLUME_ACCESS_MODE_RWM,
+];
+
+interface VolumeAccessModeSelectProps {
+  value: string;
+  updateValue: Function;
+}
+
+export const VolumeAccessModeSelect: React.FunctionComponent<VolumeAccessModeSelectProps> = props => {
+  return (
+    <Select
+      variant="standard"
+      label="Volume access mode"
+      index={-1}
+      values={VOLUME_ACCESS_MODES}
+      value={props.value}
+      updateValue={props.updateValue}
+    />
+  );
+};

--- a/labextension/src/widgets/LeftPanel.tsx
+++ b/labextension/src/widgets/LeftPanel.tsx
@@ -159,6 +159,7 @@ export interface IKaleNotebookMetadata {
   katib_run: boolean;
   katib_metadata?: IKatibMetadata;
   steps_defaults?: string[];
+  storage_class_name?: string;
 }
 
 export interface IKatibExperiment {
@@ -258,6 +259,7 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
         ...prevState.metadata,
         volumes: prevState.notebookVolumes,
         snapshot_volumes: !prevState.metadata.snapshot_volumes,
+        storage_class_name: undefined,
       },
     }));
   };
@@ -290,6 +292,11 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
   changeDeployDebugMessage = () =>
     this.setState((prevState, props) => ({
       deployDebugMessage: !prevState.deployDebugMessage,
+    }));
+
+  updateStorageClassName = (storage_class_name: string) =>
+    this.setState((prevState, props) => ({
+      metadata: { ...prevState.metadata, storage_class_name },
     }));
 
   updateKatibRun = () =>
@@ -802,6 +809,8 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
         updateAutosnapshotSwitch={this.updateAutosnapshotSwitch}
         rokError={this.props.rokError}
         updateVolumes={this.updateVolumes}
+        storageClassName={this.state.metadata.storage_class_name}
+        updateStorageClassName={this.updateStorageClassName}
       />
     );
 

--- a/labextension/src/widgets/LeftPanel.tsx
+++ b/labextension/src/widgets/LeftPanel.tsx
@@ -160,6 +160,7 @@ export interface IKaleNotebookMetadata {
   katib_metadata?: IKatibMetadata;
   steps_defaults?: string[];
   storage_class_name?: string;
+  volume_access_mode?: string;
 }
 
 export interface IKatibExperiment {
@@ -192,6 +193,7 @@ export const DefaultState: IState = {
     autosnapshot: false,
     katib_run: false,
     steps_defaults: [],
+    volume_access_mode: 'rwm',
   },
   runDeployment: false,
   deploymentType: 'compile',
@@ -260,6 +262,7 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
         volumes: prevState.notebookVolumes,
         snapshot_volumes: !prevState.metadata.snapshot_volumes,
         storage_class_name: undefined,
+        volume_access_mode: undefined,
       },
     }));
   };
@@ -298,6 +301,12 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
     this.setState((prevState, props) => ({
       metadata: { ...prevState.metadata, storage_class_name },
     }));
+
+  updateVolumeAccessMode = (volume_access_mode: string) => {
+    this.setState((prevState, props) => ({
+      metadata: { ...prevState.metadata, volume_access_mode },
+    }));
+  };
 
   updateKatibRun = () =>
     this.setState((prevState, props) => ({
@@ -811,6 +820,8 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
         updateVolumes={this.updateVolumes}
         storageClassName={this.state.metadata.storage_class_name}
         updateStorageClassName={this.updateStorageClassName}
+        volumeAccessMode={this.state.metadata.volume_access_mode}
+        updateVolumeAccessMode={this.updateVolumeAccessMode}
       />
     );
 

--- a/labextension/src/widgets/LeftPanel.tsx
+++ b/labextension/src/widgets/LeftPanel.tsx
@@ -303,7 +303,7 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
     this.setState((prevState, props) => ({
       metadata: {
         ...prevState.metadata,
-        katib_run: !this.state.metadata.katib_run,
+        katib_run: !prevState.metadata.katib_run,
       },
     }));
 

--- a/labextension/src/widgets/VolumesPanel.tsx
+++ b/labextension/src/widgets/VolumesPanel.tsx
@@ -25,6 +25,7 @@ import { Select, ISelectOption } from '../components/Select';
 import { LightTooltip } from '../components/LightTooltip';
 import { AnnotationInput, IAnnotation } from '../components/AnnotationInput';
 import { removeIdxFromArray, updateIdxInArray } from '../lib/Utils';
+import { VolumeAccessModeSelect } from '../components/VolumeAccessModeSelect';
 
 const DEFAULT_EMPTY_VOLUME: IVolumeMetadata = {
   type: 'new_pvc',
@@ -97,6 +98,8 @@ interface VolumesPanelProps {
   updateAutosnapshotSwitch: Function;
   storageClassName: string;
   updateStorageClassName: Function;
+  volumeAccessMode: string;
+  updateVolumeAccessMode: Function;
 }
 
 export const VolumesPanel: React.FunctionComponent<VolumesPanelProps> = props => {
@@ -576,13 +579,18 @@ export const VolumesPanel: React.FunctionComponent<VolumesPanelProps> = props =>
   // FIXME: There is no separating bottom horizontal bar when there are no
   //  volumes
   const volumesClassNameAndMode = (
-    <div className="input-container">
+    <div className="input-container volume-container">
       <Input
         label="Storage class name"
         updateValue={props.updateStorageClassName}
         value={props.storageClassName}
         placeholder={'default'}
         variant="standard"
+      />
+
+      <VolumeAccessModeSelect
+        value={props.volumeAccessMode}
+        updateValue={props.updateVolumeAccessMode}
       />
     </div>
   );

--- a/labextension/src/widgets/VolumesPanel.tsx
+++ b/labextension/src/widgets/VolumesPanel.tsx
@@ -95,6 +95,8 @@ interface VolumesPanelProps {
   updateVolumes: Function;
   updateVolumesSwitch: Function;
   updateAutosnapshotSwitch: Function;
+  storageClassName: string;
+  updateStorageClassName: Function;
 }
 
 export const VolumesPanel: React.FunctionComponent<VolumesPanelProps> = props => {
@@ -571,10 +573,25 @@ export const VolumesPanel: React.FunctionComponent<VolumesPanelProps> = props =>
     </div>
   );
 
+  // FIXME: There is no separating bottom horizontal bar when there are no
+  //  volumes
+  const volumesClassNameAndMode = (
+    <div className="input-container">
+      <Input
+        label="Storage class name"
+        updateValue={props.updateStorageClassName}
+        value={props.storageClassName}
+        placeholder={'default'}
+        variant="standard"
+      />
+    </div>
+  );
+
   return (
     <React.Fragment>
       {useNotebookVolumesSwitch}
       {autoSnapshotSwitch}
+      {!props.useNotebookVolumes && volumesClassNameAndMode}
       {props.notebookMountPoints.length > 0 && props.useNotebookVolumes
         ? null
         : vols}


### PR DESCRIPTION
This PR adds the following two features:
* Specify storage class for the created PVCs
* Specify the access modes for the creates PVCs
It also extends the Kale CLI as well as the lab extensions to set these options.

**Note:** This PR, allows both a global and a per-PVC configuration for the above, giving priority to the per-PVC one. However, the per-PVC configuration is not available through the lab extension because it looks like it just complicates things.

Closes #51
Closes #161
Closes #207
