### PR TITLE
labextension: Disable misconfigured Katib algorithms

### DIFF
--- a/labextension/src/widgets/KatibDialog.tsx
+++ b/labextension/src/widgets/KatibDialog.tsx
@@ -36,8 +36,10 @@ const algorithmOptions = [
   { value: 'random', label: 'Random Search' },
   { value: 'grid', label: 'Grid Search' },
   { value: 'bayesianoptimization', label: 'Bayesian Optimization' },
-  { value: 'hyperband', label: 'Hyperband' },
-  { value: 'tpe', label: 'Hyperopt TPE' },
+  // Temporarely disable the following algorithms
+  // due to bad configuration.
+  // { value: 'hyperband', label: 'Hyperband' },
+  // { value: 'tpe', label: 'Hyperopt TPE' },
 ];
 
 // https://github.com/scikit-optimize/scikit-optimize/blob/master/skopt/optimizer/optimizer.py#L55


### PR DESCRIPTION
This commit temporarily disables Hyperband and TPE due to bad configuration. We will address the issue again when upgrading to Katib `v1beta1`.

Signed-off-by: Dimitris Poulopoulos <dimpo@arrikto.com>