### PR TITLE
examples: Limit parallel HPT runs in OpenVaccine

### DIFF
--- a/examples/openvaccine-kaggle-competition/open-vaccine.ipynb
+++ b/examples/openvaccine-kaggle-competition/open-vaccine.ipynb
@@ -725,7 +725,7 @@
      "objectiveMetricName": "validation-loss",
      "type": "minimize"
     },
-    "parallelTrialCount": 3,
+    "parallelTrialCount": 1,
     "parameters": [
      {
       "feasibleSpace": {


### PR DESCRIPTION
Running more that one pipeline concurrently in MiniKF considerably slows
down the VM.

Signed-off-by: Stefano Fioravanzo <stefano@arrikto.com>