### PR TITLE
labextension: Set min width of Kale panel to 300px

### DIFF
--- a/labextension/src/widget.tsx
+++ b/labextension/src/widget.tsx
@@ -180,6 +180,7 @@ async function activate(
     widget.id = 'kubeflow-kale/kubeflowDeployment';
     widget.title.iconClass = 'jp-kale-logo jp-SideBar-tabIcon';
     widget.title.caption = 'Kubeflow Pipelines Deployment Panel';
+    widget.node.classList.add('kale-panel');
 
     restorer.add(widget, widget.id);
   });

--- a/labextension/style/index.css
+++ b/labextension/style/index.css
@@ -78,6 +78,10 @@
 | Deploy Button
 |----------------------------------------------------------------------------*/
 
+.kale-panel {
+  min-width: 300px !important;
+}
+
 .kubeflow-widget {
   flex-direction: column;
   min-width: var(--jp-sidebar-min-width);


### PR DESCRIPTION
JupyterLab reduced the minimum with of the sidebar from to 180px; the
proper way to override this setting is to create a new theme. Since
Kale does not make use of a custom theme, the quickest way to override
the panel's setting is to add a CSS class to it from the widget object.

Signed-off-by: Stefano Fioravanzo <stefano@arrikto.com>