### PR TITLE
Fix a couple of typos

### DIFF
--- a/examples/openvaccine-kaggle-competition/open-vaccine.ipynb
+++ b/examples/openvaccine-kaggle-competition/open-vaccine.ipynb
@@ -53,7 +53,7 @@
    "source": [
     "# Imports\n",
     "\n",
-    "In this section we import the packages we need for this example. Make it a habbit to gather your imports in a single place. It will make your life easier if you are going to transform this notebook into a Kubeflow pipeline using Kale."
+    "In this section we import the packages we need for this example. Make it a habit to gather your imports in a single place. It will make your life easier if you are going to transform this notebook into a Kubeflow pipeline using Kale."
    ]
   },
   {
@@ -223,7 +223,7 @@
     "We see a lot of strange entries, so, let us try to see what they are:\n",
     "\n",
     "* `sequence`: An 107 characters long string in Train and Public Test (130 in Private Test), which describes the RNA sequence, a combination of A, G, U, and C for each sample.\n",
-    "* `structure`: An 107 characters long string in Train and Public Test (130 in Private Test), which is a compination of `(`, `)`, and `.` characters that describe whether a base is estimated to be paired or unpaired. Paired bases are denoted by opening and closing parentheses (e.g. (....) means that base 0 is paired to base 5, and bases 1-4 are unpaired).\n",
+    "* `structure`: An 107 characters long string in Train and Public Test (130 in Private Test), which is a combination of `(`, `)`, and `.` characters that describe whether a base is estimated to be paired or unpaired. Paired bases are denoted by opening and closing parentheses (e.g. (....) means that base 0 is paired to base 5, and bases 1-4 are unpaired).\n",
     "* `predicted_loop_type`: An 107 characters long string, which describes the structural context (also referred to as 'loop type') of each character in sequence. Loop types assigned by bpRNA from Vienna RNAfold 2 structure. From the bpRNA_documentation: `S`: paired \"Stem\" `M`: Multiloop `I`: Internal loop `B`: Bulge `H`: Hairpin loop `E`: dangling End `X`: eXternal loop.\n",
     "\n",
     "Then, we have `signal_to_noise`, which is quality control feature. It records the measurements relative to their errors; the higher value the more confident measurements are.\n",


### PR DESCRIPTION
Fix a couple of typos in the OpenVaccine notebook