### PR TITLE
backend: Fix pip 20.3 dependency resolution

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -20,7 +20,7 @@ jobs:
       working-directory: ${{env.working-directory}}
       run: |
         python -m pip install --upgrade pip
-        pip install .[dev] --use-deprecated=legacy-resolver
+        pip install .[dev]
     - name: Test with pytest
       working-directory: ${{env.working-directory}}
       run: |

--- a/backend/kale/common/k8sutils.py
+++ b/backend/kale/common/k8sutils.py
@@ -25,7 +25,15 @@ def _load_config():
     try:
         kubernetes.config.load_incluster_config()
     except kubernetes.config.ConfigException:  # Not in a notebook server
-        kubernetes.config.load_kube_config()
+        try:
+            kubernetes.config.load_kube_config()
+        # FIXME: `kubernetes` raises a TypeError when a `config` file is not
+        #  found. This is fixed starting from version `11.0.0`, which raises
+        #  the correct `ConfigException`. We cannot yet upgrade the package
+        #  because `kfserving` relies on `kubernetes==10.0.1`
+        except TypeError:
+            raise kubernetes.config.ConfigException("Invalid kube-config file."
+                                                    " No configuration found.")
 
 
 def get_v1_client():

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -50,8 +50,8 @@ setup(
         'packaging > 20',
         'ml_metadata == 0.24.0',
         'progress >= 1.5',
-        'kfserving >= 0.4.0',
-        'kubernetes >= 11.0.0',
+        'kfserving >= 0.4.0, < 0.5.0',
+        'kubernetes < 12.0.0',
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
With the new dependency resolver introduced in pip 20.3, dependency
resolution would get stuck because of the following conflicts:

1. `kfserving` requires `kubernetes==10.0.1`
2. Kale's `setup.py` specifies `kubernetes>=11.0.0`

We introduced (2) in [1]. This commit reverts that change and manually
catches the `TypeError` exception.

`kfserving` version 0.5.0 changes the `kubernetes` requirement to
install versions >=12.0.0. However, this is incompatible with KFP
requirement (<12.0.0).
This is also incompatible with our code, since in version 12.0.0 there
are breaking changes on code we import (e.g., Exceptions).

As a result, we change the restrictions as follows:
* `kfserving >= 0.4.0, < 0.5.0`
* `kubernetes < 12.0.0`

Closes https://github.com/kubeflow-kale/kale/issues/273
Closes https://github.com/kubeflow-kale/kale/issues/275

[1] https://github.com/kubeflow-kale/kale/commit/e3bc079a6e971e42b02aa04fcfaceb4ea28faf31

Signed-off-by: Stefano Fioravanzo <stefano@arrikto.com>