### PR TITLE
docker: Fix Dockerfiles (enum & KFP installation)

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -33,9 +33,11 @@ RUN echo "set background=dark" >> /etc/vim/vimrc.local
 
 # Install latest KFP SDK & Kale & JupyterLab Extension
 RUN pip3 install --upgrade pip && \
+    # XXX: Install enum34==1.1.8 because other versions lead to errors during
+    #  KFP installation
+    pip3 install --upgrade "enum34==1.1.8" && \
     pip3 install --upgrade "jupyterlab>=2.0.0,<3.0.0" && \
-    pip3 install https://storage.googleapis.com/ml-pipeline/release/latest/kfp.tar.gz --upgrade && \
-    pip3 install -U kubeflow-kale && \
+    pip3 install --upgrade kubeflow-kale && \
     jupyter labextension install kubeflow-kale-labextension
 
 RUN echo "jovyan ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/jovyan

--- a/docker/jupyterlab/Dockerfile.dev
+++ b/docker/jupyterlab/Dockerfile.dev
@@ -32,9 +32,12 @@ COPY bashrc /etc/bash.bashrc
 RUN echo "set background=dark" >> /etc/vim/vimrc.local
 
 # Install latest KFP SDK
+RUN pip3 freeze
 RUN pip3 install --upgrade pip && \
-    pip3 install --upgrade "jupyterlab>=2.0.0,<3.0.0" && \
-    pip3 install https://storage.googleapis.com/ml-pipeline/release/latest/kfp.tar.gz --upgrade
+    # XXX: Install enum34==1.1.8 because other versions lead to errors during
+    #  KFP installation
+    pip3 install --upgrade "enum34==1.1.8" && \
+    pip3 install --upgrade "jupyterlab>=2.0.0,<3.0.0"
 
 # Install Kale from KALE_BRANCH (defaults to "master")
 ARG KALE_BRANCH="master"
@@ -42,7 +45,7 @@ WORKDIR /
 RUN git clone -b ${KALE_BRANCH} https://github.com/kubeflow-kale/kale
 
 WORKDIR /kale/backend
-RUN pip3 install -U .
+RUN pip3 install --upgrade .
 
 WORKDIR /kale/labextension
 RUN jlpm install && \

--- a/docker/jupyterlab/Dockerfile.rok
+++ b/docker/jupyterlab/Dockerfile.rok
@@ -22,9 +22,11 @@ RUN echo 'alias grep="grep --color=auto' >> /etc/bash.bashrc && \
 
 # Install latest KFP SDK & Kale & JupyterLab Extension
 RUN pip3 install --upgrade pip && \
+    # XXX: Install enum34==1.1.8 because other versions lead to errors during
+    #  KFP installation
+    pip3 install --upgrade "enum34==1.1.8" && \
     pip3 install --upgrade "jupyterlab>=2.0.0,<3.0.0" && \
-    pip3 install https://storage.googleapis.com/ml-pipeline/release/latest/kfp.tar.gz --upgrade && \
-    pip3 install -U kubeflow-kale && \
+    pip3 install --upgrade kubeflow-kale && \
     jupyter labextension install kubeflow-kale-labextension
 
 RUN echo "jovyan ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers.d/jovyan

--- a/docker/jupyterlab/Dockerfile.rok.dev
+++ b/docker/jupyterlab/Dockerfile.rok.dev
@@ -22,8 +22,10 @@ RUN echo 'alias grep="grep --color=auto' >> /etc/bash.bashrc && \
 
 # Install latest KFP SDK
 RUN pip3 install --upgrade pip && \
-    pip3 install --upgrade "jupyterlab>=2.0.0,<3.0.0" && \
-    pip3 install https://storage.googleapis.com/ml-pipeline/release/latest/kfp.tar.gz --upgrade
+    # XXX: Install enum34==1.1.8 because other versions lead to errors during
+    #  KFP installation
+    pip3 install --upgrade "enum34==1.1.8" && \
+    pip3 install --upgrade "jupyterlab>=2.0.0,<3.0.0"
 
 # Install Kale from KALE_BRANCH (defaults to "master")
 ARG KALE_BRANCH="master"
@@ -32,7 +34,7 @@ RUN rm -rf /kale && \
     git clone -b ${KALE_BRANCH} https://github.com/kubeflow-kale/kale
 
 WORKDIR /kale/backend
-RUN pip3 install -U .
+RUN pip3 install --upgrade .
 
 WORKDIR /kale/labextension
 RUN jlpm install && \


### PR DESCRIPTION
* Force the installation of enum34==1.1.8. Other versions raise errors
  on KFP installation
* Do not install KFP separately, let Kale requirements do it

Closes https://github.com/kubeflow-kale/kale/issues/274

Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>