### PR TITLE
create dependabot config script

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+updates:
+- directory: docker/jupyterlab
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  schedule:
+    interval: daily
+- directory: docker/katib
+  open-pull-requests-limit: 10
+  package-ecosystem: docker
+  schedule:
+    interval: daily
+- directory: labextension
+  open-pull-requests-limit: 10
+  package-ecosystem: npm
+  schedule:
+    interval: daily
+- directory: examples/dog-breed-classification/requirements
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  schedule:
+    interval: daily
+- directory: examples/openvaccine-kaggle-competition
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  schedule:
+    interval: daily
+- directory: examples/serving/sklearn
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  schedule:
+    interval: daily
+- directory: examples/serving/xgboost
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  schedule:
+    interval: daily
+- directory: examples/titanic-ml-dataset
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  schedule:
+    interval: daily
+- directory: examples/taxi-cab-classification
+  open-pull-requests-limit: 10
+  package-ecosystem: pip
+  schedule:
+    interval: daily
+version: 2

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+build-dependabot:
+	python3 hack/create_dependabot.py

--- a/hack/create_dependabot.py
+++ b/hack/create_dependabot.py
@@ -1,0 +1,82 @@
+import yaml
+import collections
+from pathlib import Path
+
+dependabot = {}
+dependabot['version'] = 2
+dependabot['updates'] = []
+ignored_folders = ['node_modules', 'dist', '.git', 'deprecated']
+
+def get_docker_paths():
+    dockerfile_list = list(repo_path.glob('**/*ockerfile*'))
+    docker_clean_list = []
+    for dockerfile in dockerfile_list:
+        if all(x not in str(dockerfile) for x in ignored_folders):
+            if dockerfile.parents[0] not in docker_clean_list:
+                docker_clean_list.append(dockerfile.parents[0])
+    return docker_clean_list
+
+def get_npm_paths():
+    npm_list = list(repo_path.glob('**/package*.json'))
+    npm_clean_list = []
+    for npm_file in npm_list:
+        if all(x not in str(npm_file) for x in ignored_folders):
+            if npm_file.parents[0] not in npm_clean_list:
+                npm_clean_list.append(npm_file.parents[0])
+    return npm_clean_list
+
+def get_pip_paths():
+    pip_list = list(repo_path.glob('**/*requirements.txt'))
+    pip_clean_list = []
+    for pip_file in pip_list:
+        if all(x not in str(pip_file) for x in ignored_folders):
+            if pip_file.parents[0] not in pip_clean_list:
+                pip_clean_list.append(pip_file.parents[0])
+    return pip_clean_list
+
+def get_go_paths():
+    go_list = list(repo_path.glob('**/go.*'))
+    go_clean_list = []
+    for go_file in go_list:
+        if all(x not in str(go_file) for x in ignored_folders):
+            if go_file.parents[0] not in go_clean_list:
+                go_clean_list.append(go_file.parents[0])
+    return go_clean_list
+
+def append_updates(ecosystem, directory):
+    config = {}
+    config['package-ecosystem'] = ecosystem
+    config['directory'] = directory
+    config['schedule']= {}
+    config['schedule']['interval'] = 'daily'
+    config['open-pull-requests-limit'] = 10
+    dependabot['updates'].append(config)
+
+def main():
+    for docker_path in get_docker_paths():
+        string_path = str(docker_path)
+        append_updates('docker', string_path)
+
+    for npm_path in get_npm_paths():
+        string_path = str(npm_path)
+        append_updates('npm', string_path)
+
+    for pip_path in get_pip_paths():
+        string_path = str(pip_path)
+        append_updates('pip', string_path)
+
+    for go_path in get_go_paths():
+        string_path = str(go_path)
+        append_updates('gomod', string_path)
+
+    with open('.github/dependabot.yml', 'w') as outfile:
+        yaml.dump(dependabot, outfile, default_flow_style=False)
+
+    print(get_docker_paths())
+    print(get_npm_paths())
+    print(get_pip_paths())
+    print(get_go_paths())
+
+if __name__ == "__main__":
+    repo_path = Path(__file__).parents[1]
+    main()


### PR DESCRIPTION
Inspired by kubeflow/pipelines#4682 I created a script that will create a config file for depandabot so that it knows what directories to scan. It will scan the repository for files named *ockerfile*, package*.json, *requirements.txt and go.*. It is setup for dockerfiles, npm, gomod and python at the moment, and I believe this should cover almost all the code in the repo. It is trivial to further customize what folders are selected if further customization is needed. It also parses the closest OWNERS file for a given directory and assigns the approvers and adds the reviewers to the PRs it creates.