### PR TITLE
(Backend): Check if snapshots are available for notebook pvcs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "python.linting.flake8Enabled": true,
-    "python.linting.enabled": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.linting.flake8Enabled": true,
+    "python.linting.enabled": true
+}

--- a/backend/kale/common/podutils.py
+++ b/backend/kale/common/podutils.py
@@ -317,13 +317,13 @@ def get_snapshotclasses(label_selector=""):
         version="v1beta1",
         plural="volumesnapshotclasses",
         label_selector=label_selector)
-    return snapshotclasses
+    return snapshotclasses.get("items")
 
 
 def list_snapshotclass_storage_provisioners(label_selector=""):
     """List the storage provisioners of the snapshotclasses."""
-    snapshotclasses = get_snapshotclasses(label_selector)["items"]
-    return [snap_prov["dirver"] for snap_prov in snapshotclasses]
+    return [snap_prov["driver"] for
+            snap_prov in get_snapshotclasses(label_selector)]
 
 
 def check_snapshot_availability():


### PR DESCRIPTION
Part of https://github.com/kubeflow-kale/kale/pull/217/files

This code adds the functionality to check if a snapshot provisioner exists in the cluster, and if the storage provider of the PVCs for the notebook have a snapshot class associated with them. Additionally, the check that restricted using snapshots to `ROK_CSI_STORAGE_CLASS` has been expanded for the previously mentioned checks. 