### PR TITLE
(Backend): Add ability to create a snapshot of a pod

### DIFF
--- a/backend/kale/common/snapshotutils.py
+++ b/backend/kale/common/snapshotutils.py
@@ -1,0 +1,77 @@
+# Copyright 2020 The Kale Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+
+from kale.common import podutils, k8sutils
+
+NOTEBOOK_SNAPSHOT_COMMIT_MESSAGE = """\
+This is a snapshot of notebook {} in namespace {}.
+This snapshot was created by Kale in order to clone the volumes of the notebook
+and use them to spawn a Kubeflow pipeline.\
+"""
+
+log = logging.getLogger(__name__)
+
+
+def snapshot_pvc(snapshot_name, pvc_name, labels, annotations):
+    """Perform a snapshot over a PVC."""
+    if annotations == {}:
+        annotations = {"access_mode": get_pvc_access_mode(pvc_name)}
+    snapshot_resource = {
+        "apiVersion": "snapshot.storage.k8s.io/v1beta1",
+        "kind": "VolumeSnapshot",
+        "metadata": {
+            "name": snapshot_name,
+            "annotations": annotations,
+            "labels": labels
+        },
+        "spec": {
+            "volumeSnapshotClassName": get_snapshotclass_name(pvc_name),
+            "source": {"persistentVolumeClaimName": pvc_name}
+        }
+    }
+    co_client = k8sutils.get_co_client()
+    namespace = podutils.get_namespace()
+    log.info("Taking a snapshot of PVC %s in namespace %s ...",
+             (pvc_name, namespace))
+    task_info = co_client.create_namespaced_custom_object(
+        group="snapshot.storage.k8s.io",
+        version="v1beta1",
+        namespace=namespace,
+        plural="volumesnapshots",
+        body=snapshot_resource)
+
+    return task_info
+
+
+def get_snapshotclass_name(pvc_name, label_selector=""):
+    """Get the Volume Snapshot Class Name for a PVC."""
+    client = k8sutils.get_v1_client()
+    namespace = podutils.get_namespace()
+    pvc = client.read_namespaced_persistent_volume_claim(pvc_name, namespace)
+    ann = pvc.metadata.annotations
+    provisioner = ann.get("volume.beta.kubernetes.io/storage-provisioner",
+                          None)
+    snapshotclasses = podutils.get_snapshotclasses(label_selector)
+    return [snapclass_name["metadata"]["name"] for snapclass_name in
+            snapshotclasses if snapclass_name["driver"] == provisioner][0]
+
+
+def get_pvc_access_mode(pvc_name):
+    """Get the access mode of a PVC."""
+    client = k8sutils.get_v1_client()
+    namespace = podutils.get_namespace()
+    pvc = client.read_namespaced_persistent_volume_claim(pvc_name, namespace)
+    return pvc.spec.access_modes[0]

--- a/examples/experimental-k8s-snapshots/README.md
+++ b/examples/experimental-k8s-snapshots/README.md
@@ -1,0 +1,59 @@
+## Kubernetes native snapshots
+
+This folder contains information about the development of generic snapshot
+support for Kale using Kubernetes Volume Snapshots. The feature is not yet fully working, 
+but any help with testing or development is greatly appreciated.
+
+# Permissions needed
+To be able to make use of create snapshots, get the storage classes, list snapshot proviers, etc. 
+some additional permissions are needed. Please note that setting these permissions might not be secure. This will need to be validated later. First, a new ClusterRole needs to be created using the command:
+```
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: snapshot-access
+rules:
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["create", "get", "list", "watch", "patch", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list"]
+EOF
+```
+
+To allow the default-editor ServiceAccount in the namespace `admin` access to these feautres 
+the following command can be used:
+```
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: allow-snapshot-nb-admin
+  namespace: admin
+subjects:
+- kind: ServiceAccount
+  name: default-editor
+  namespace: admin
+roleRef:
+  kind: ClusterRole
+  name: snapshot-access
+  apiGroup: rbac.authorization.k8s.io
+EOF
+```


### PR DESCRIPTION
Part of https://github.com/kubeflow-kale/kale/pull/217/files

This PR adds the ability to snapshot all the volumes connected to a pod, along with writing the container images of that pod to the snapshot metadata. 
Note, at the moment the snapshot name is `pod-snapshot-` + `pvc_name`. This means snapshotting a pod twice will result in an error as the snapshot with that name already exists. This will need to be solved with a UUID of some sorts, I was hoping to find one that is useful/meaningful for other methods of identification as well, so I am open to suggestions. 