### PR TITLE
(Backend): Add ability to restore a notebook from a snapshot

### DIFF
--- a/backend/kale/common/snapshotutils.py
+++ b/backend/kale/common/snapshotutils.py
@@ -157,3 +157,55 @@ def get_notebook_resources():
         for key in resource_type[1]:
             resource_conf[resource_type[0] + "_" + key] = resource_type[1][key]
     return resource_conf
+
+
+def get_pvc_snapshot(snapshot_name):
+    """Get info about a pvc snapshot."""
+    co_client = k8sutils.get_co_client()
+    namespace = podutils.get_namespace()
+
+    pvc_snapshot = co_client.get_namespaced_custom_object(
+        group="snapshot.storage.k8s.io",
+        version="v1beta1",
+        namespace=namespace,
+        plural="volumesnapshots",
+        name=snapshot_name)
+    return pvc_snapshot
+
+
+def list_pvc_snapshots(label_selector=""):
+    """List pvc snapshots."""
+    co_client = k8sutils.get_co_client()
+    namespace = podutils.get_namespace()
+
+    pvc_snapshots = co_client.list_namespaced_custom_object(
+        group="snapshot.storage.k8s.io",
+        version="v1beta1",
+        namespace=namespace,
+        plural="volumesnapshots",
+        label_selector=label_selector)
+    return pvc_snapshots
+
+
+def delete_pvc(pvc_name):
+    """Delete a pvc."""
+    client = k8sutils.get_v1_client()
+    namespace = podutils.get_namespace()
+    client.delete_namespaced_persistent_volume_claim(
+        namespace=namespace,
+        name=pvc_name)
+    return
+
+
+def delete_pvc_snapshot(snapshot_name):
+    """Delete a pvc snapshot."""
+    co_client = podutils._get_k8s_custom_objects_client()
+    namespace = podutils.get_namespace()
+
+    co_client.delete_namespaced_custom_object(
+        group="snapshot.storage.k8s.io",
+        version="v1beta1",
+        namespace=namespace,
+        plural="volumesnapshots",
+        name=snapshot_name)
+    return

--- a/backend/kale/common/snapshotutils.py
+++ b/backend/kale/common/snapshotutils.py
@@ -1,0 +1,77 @@
+# Copyright 2020 The Kale Authors
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import logging
+
+from kale.common import podutils, k8sutils
+
+NOTEBOOK_SNAPSHOT_COMMIT_MESSAGE = """\
+This is a snapshot of notebook {} in namespace {}.
+This snapshot was created by Kale in order to clone the volumes of the notebook
+and use them to spawn a Kubeflow pipeline.\
+"""
+
+log = logging.getLogger(__name__)
+
+
+def snapshot_pvc(snapshot_name, pvc_name, labels, annotations):
+    """Perform a snapshot over a PVC."""
+    if annotations == {}:
+        annotations = {"access_mode": get_pvc_access_mode(pvc_name)}
+    snapshot_resource = {
+        "apiVersion": "snapshot.storage.k8s.io/v1beta1",
+        "kind": "VolumeSnapshot",
+        "metadata": {
+            "name": snapshot_name,
+            "annotations": annotations,
+            "labels": labels
+        },
+        "spec": {
+            "volumeSnapshotClassName": get_snapshotclass_name(pvc_name),
+            "source": {"persistentVolumeClaimName": pvc_name}
+        }
+    }
+    co_client = k8sutils.get_co_client()
+    namespace = podutils.get_namespace()
+    log.info("Taking a snapshot of PVC %s in namespace %s ...",
+             (pvc_name, namespace))
+    task_info = co_client.create_namespaced_custom_object(
+        group="snapshot.storage.k8s.io",
+        version="v1beta1",
+        namespace=namespace,
+        plural="volumesnapshots",
+        body=snapshot_resource)
+
+    return task_info
+
+
+def get_snapshotclass_name(pvc_name, label_selector=""):
+    """Get the Volume Snapshot Class Name for a PVC."""
+    client = k8sutils.get_v1_client()
+    namespace = podutils.get_namespace()
+    pvc = client.read_namespaced_persistent_volume_claim(pvc_name, namespace)
+    ann = pvc.metadata.annotations
+    provisioner = ann.get("volume.beta.kubernetes.io/storage-provisioner",
+                          None)
+    snapshotclasses = podutils.get_snapshotclasses(label_selector)
+    return [snapclass_name["metadata"]["name"] for snapclass_name in
+            snapshotclasses if snapclass_name["driver"] == provisioner][0]
+
+
+def get_pvc_access_mode(pvc_name):
+    """Get the access mode of a PVC."""
+    client = k8sutils.get_v1_client()
+    namespace = podutils.get_namespace()
+    pvc = client.read_namespaced_persistent_volume_claim(pvc_name, namespace)
+    return pvc.spec.access_modes[0]

--- a/backend/kale/common/snapshotutils.py
+++ b/backend/kale/common/snapshotutils.py
@@ -343,3 +343,20 @@ def get_nb_pvcs_from_snapshot(snapshot_name):
             "annotations": annotations}
         volumes.append(row)
     return volumes
+
+
+def restore_pvcs_from_snapshot(snapshot_name):
+    """Restore the NB PVCs from their snapshots."""
+    source_snapshots = get_nb_pvcs_from_snapshot(snapshot_name)
+    replaced_volume_mounts = []
+    for snapshot in source_snapshots:
+        version = snapshot["labels"]["version_uuid"]
+        new_pvc_name = "restored-" + snapshot["source_pvc"] + "-" + version
+        pvc_name = hydrate_pvc_from_snapshot(
+            new_pvc_name=new_pvc_name,
+            source_snapshot_name=snapshot["snapshot_name"]
+        )
+        path = snapshot["annotations"]["volume_path"]
+        row = {"mountPath": path, "name": pvc_name["name"]}
+        replaced_volume_mounts.append(row)
+    return replaced_volume_mounts

--- a/backend/kale/common/snapshotutils.py
+++ b/backend/kale/common/snapshotutils.py
@@ -288,3 +288,36 @@ def hydrate_pvc_from_snapshot(new_pvc_name, source_snapshot_name, labels={}):
     else:
         raise RuntimeError("Unknown snapshot task status: %s", status)
     return {"name": ns_pvc.metadata.name}
+
+
+def get_nb_name_from_snapshot(snapshot_name):
+    """Get the name of the notebook that the snapshot was taken from."""
+    snapshot = get_pvc_snapshot(snapshot_name=snapshot_name)
+    return snapshot["metadata"]["labels"]["container_name"]
+
+
+def get_nb_image_from_snapshot(snapshot_name):
+    """Get the image of the notebook that the snapshot was taken from."""
+    snapshot = get_pvc_snapshot(snapshot_name=snapshot_name)
+    return snapshot["metadata"]["annotations"]["container_image"]
+
+
+def get_nb_snapshot_version(snapshot_name):
+    """Get the version of the notebook snapshot."""
+    snapshot = get_pvc_snapshot(snapshot_name=snapshot_name)
+    return snapshot["metadata"]["labels"]["version_uuid"]
+
+
+def get_nb_resources_from_snapshot(snapshot_name):
+    """Get the and process the resource spec from a snapshot."""
+    snapshot = get_pvc_snapshot(snapshot_name=snapshot_name)
+    annotations = snapshot["metadata"]["annotations"]
+    resources = {}
+    resources["limits"] = {}
+    resources["requests"] = {}
+    for key, value in annotations.items():
+        if 'limits_' in key.lower():
+            resources["limits"][key.split('_')[1]] = value
+        if 'requests_' in key.lower():
+            resources["requests"][key.split('_')[1]] = value
+    return resources

--- a/backend/kale/common/snapshotutils.py
+++ b/backend/kale/common/snapshotutils.py
@@ -321,3 +321,25 @@ def get_nb_resources_from_snapshot(snapshot_name):
         if 'requests_' in key.lower():
             resources["requests"][key.split('_')[1]] = value
     return resources
+
+
+def get_nb_pvcs_from_snapshot(snapshot_name):
+    """Get all PVCs that were mounted to the NB when the snapshot was taken."""
+    "Returns JSON list."
+    selector = "container_name=" + get_nb_name_from_snapshot(snapshot_name)
+    all_volumes = (list_pvc_snapshots(label_selector=selector)["items"]
+                   and "version_uuid=" + get_nb_snapshot_version(snapshot_name)
+                   )
+    volumes = []
+    for vol in all_volumes:
+        snapshot_name = vol["metadata"]["name"]
+        source_pvc_name = vol["spec"]["source"]["persistentVolumeClaimName"]
+        labels = vol["metadata"]["labels"]
+        annotations = vol["metadata"]["annotations"]
+        row = {
+            "snapshot_name": snapshot_name,
+            "source_pvc": source_pvc_name,
+            "labels": labels,
+            "annotations": annotations}
+        volumes.append(row)
+    return volumes

--- a/examples/experimental-k8s-snapshots/README.md
+++ b/examples/experimental-k8s-snapshots/README.md
@@ -1,0 +1,59 @@
+## Kubernetes native snapshots
+
+This folder contains information about the development of generic snapshot
+support for Kale using Kubernetes Volume Snapshots. The feature is not yet fully working, 
+but any help with testing or development is greatly appreciated.
+
+# Permissions needed
+To be able to make use of create snapshots, get the storage classes, list snapshot proviers, etc. 
+some additional permissions are needed. Please note that setting these permissions might not be secure. This will need to be validated later. First, a new ClusterRole needs to be created using the command:
+```
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: snapshot-access
+rules:
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["create", "get", "list", "watch", "patch", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list"]
+EOF
+```
+
+To allow the default-editor ServiceAccount in the namespace `admin` access to these feautres 
+the following command can be used:
+```
+cat <<EOF | kubectl apply -f -
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: allow-snapshot-nb-admin
+  namespace: admin
+subjects:
+- kind: ServiceAccount
+  name: default-editor
+  namespace: admin
+roleRef:
+  kind: ClusterRole
+  name: snapshot-access
+  apiGroup: rbac.authorization.k8s.io
+EOF
+```


### PR DESCRIPTION
Part of https://github.com/kubeflow-kale/kale/pull/217/files

This PR adds the function that restores a notebook from the metadata saved in the snapshots of the original notebook's PVCs. A helper function is used that deals with generating the volume mounts with the same mounting point and the new PVC(s) that were restored from the snapshot(s). 