### PR TITLE
(Frontend): Add snapshot error tooltip to rpcutils

### DIFF
--- a/labextension/src/lib/RPCUtils.tsx
+++ b/labextension/src/lib/RPCUtils.tsx
@@ -84,6 +84,17 @@ export const rokErrorTooltip = (rokError: IRPCError) => {
   );
 };
 
+export const snapshotErrorTooltip = (snapshotError: IRPCError) => {
+  return (
+    <React.Fragment>
+      <div>
+        This feature requires snapshot support.{' '}
+        <a onClick={_ => showRpcError(snapshotError)}>More info...</a>
+      </div>
+    </React.Fragment>
+  );
+};
+
 const serialize = (obj: any) => window.btoa(JSON.stringify(obj));
 const deserialize = (raw_data: string) =>
   window.atob(raw_data.substring(1, raw_data.length - 1));

--- a/labextension/src/widget.tsx
+++ b/labextension/src/widget.tsx
@@ -84,6 +84,7 @@ async function activate(
   //  env we are in (like Local Laptop, MiniKF, GCP, UI without Kale, ...)
   const backend = await getBackend(kernel);
   let rokError: IRPCError = null;
+  let snapshotError: IRPCError = null;
   if (backend) {
     try {
       await executeRpc(kernel, 'log.setup_logging');
@@ -106,6 +107,26 @@ async function activate(
       ) {
         rokError = error.error;
         console.warn('Rok is not available', rokError);
+      } else {
+        globalUnhandledRejection({ reason: error });
+        throw error;
+      }
+    }
+
+    try {
+      await executeRpc(kernel, 'snapshot.check_snapshot_availability');
+    } catch (error) {
+      const unexpectedErrorCodes = [
+        RPC_CALL_STATUS.EncodingError,
+        RPC_CALL_STATUS.ImportError,
+        RPC_CALL_STATUS.UnhandledError,
+      ];
+      if (
+        error instanceof RPCError &&
+        !unexpectedErrorCodes.includes(error.error.code)
+      ) {
+        snapshotError = error.error;
+        console.warn('Snapshots are not available', snapshotError);
       } else {
         globalUnhandledRejection({ reason: error });
         throw error;
@@ -175,6 +196,7 @@ async function activate(
         backend={backend}
         kernel={kernel}
         rokError={rokError}
+        snapshotError={snapshotError}
       />,
     );
     widget.id = 'kubeflow-kale/kubeflowDeployment';

--- a/labextension/src/widgets/VolumesPanel.tsx
+++ b/labextension/src/widgets/VolumesPanel.tsx
@@ -19,7 +19,11 @@ import { Button, Switch, Zoom } from '@material-ui/core';
 import AddIcon from '@material-ui/icons/Add';
 import DeleteIcon from '@material-ui/icons/Delete';
 import { IVolumeMetadata } from './LeftPanel';
-import { IRPCError, rokErrorTooltip } from '../lib/RPCUtils';
+import {
+  IRPCError,
+  rokErrorTooltip,
+  snapshotErrorTooltip,
+} from '../lib/RPCUtils';
 import { Input } from '../components/Input';
 import { Select, ISelectOption } from '../components/Select';
 import { LightTooltip } from '../components/LightTooltip';
@@ -93,6 +97,7 @@ interface VolumesPanelProps {
   useNotebookVolumes: boolean;
   autosnapshot: boolean;
   rokError: IRPCError;
+  snapshotError: IRPCError;
   updateVolumes: Function;
   updateVolumesSwitch: Function;
   updateAutosnapshotSwitch: Function;
@@ -118,9 +123,9 @@ export const VolumesPanel: React.FunctionComponent<VolumesPanelProps> = props =>
   const addVolume = () => {
     // If we add a volume to an empty list, turn autosnapshot on
     const autosnapshot =
-      !props.rokError && props.volumes.length === 0
+      !props.rokError && !props.snapshotError && props.volumes.length === 0
         ? true
-        : !props.rokError && props.autosnapshot;
+        : !props.rokError && !props.snapshotError && props.autosnapshot;
     props.updateVolumes(
       [...props.volumes, DEFAULT_EMPTY_VOLUME],
       [...props.metadataVolumes, DEFAULT_EMPTY_VOLUME],
@@ -517,13 +522,16 @@ export const VolumesPanel: React.FunctionComponent<VolumesPanelProps> = props =>
     <div className="input-container">
       <LightTooltip
         title={
-          props.rokError
-            ? rokErrorTooltip(props.rokError)
+          props.rokError && props.snapshotError
+            ? rokErrorTooltip(props.rokError) &&
+              snapshotErrorTooltip(props.snapshotError)
             : "Enable this option to mount clones of this notebook's volumes " +
               'on your pipeline steps'
         }
         placement="top-start"
-        interactive={props.rokError ? true : false}
+        interactive={
+          props.rokError ? true : false && props.snapshotError ? true : false
+        }
         TransitionComponent={Zoom}
       >
         <div className="toolbar">
@@ -531,7 +539,8 @@ export const VolumesPanel: React.FunctionComponent<VolumesPanelProps> = props =>
           <Switch
             checked={props.useNotebookVolumes}
             disabled={
-              !!props.rokError || props.notebookMountPoints.length === 0
+              (!!props.rokError && !!props.snapshotError) ||
+              props.notebookMountPoints.length === 0
             }
             onChange={_ => props.updateVolumesSwitch()}
             color="primary"
@@ -548,13 +557,16 @@ export const VolumesPanel: React.FunctionComponent<VolumesPanelProps> = props =>
     <div className="input-container">
       <LightTooltip
         title={
-          props.rokError
-            ? rokErrorTooltip(props.rokError)
+          props.rokError && props.snapshotError
+            ? rokErrorTooltip(props.rokError) &&
+              snapshotErrorTooltip(props.snapshotError)
             : 'Enable this option to take Rok snapshots of your steps during ' +
               'pipeline execution'
         }
         placement="top-start"
-        interactive={props.rokError ? true : false}
+        interactive={
+          props.rokError ? true : false && props.snapshotError ? true : false
+        }
         TransitionComponent={Zoom}
       >
         <div className="toolbar">
@@ -563,7 +575,10 @@ export const VolumesPanel: React.FunctionComponent<VolumesPanelProps> = props =>
           </div>
           <Switch
             checked={props.autosnapshot}
-            disabled={!!props.rokError || props.volumes.length === 0}
+            disabled={
+              (!!props.rokError && !!props.snapshotError) ||
+              props.volumes.length === 0
+            }
             onChange={_ => props.updateAutosnapshotSwitch()}
             color="primary"
             name="enableKale"


### PR DESCRIPTION
Part of https://github.com/kubeflow-kale/kale/pull/217/files

This adds a snapshot error tooltip if a feature requires snapshot functionality but the storage provider of the PVCs mounted to the notebook do not have a volume snapshotclass associated with them. 