### PR TITLE
Detect docker image SHA instead of tag

### DIFF
--- a/backend/kale/common/podutils.py
+++ b/backend/kale/common/podutils.py
@@ -279,21 +279,13 @@ def print_volumes():
 
 def get_run_uuid():
     """Get the Workflow's UUID form inside a pipeline step."""
-    # Retrieve the pod
-    pod_name = get_pod_name()
     namespace = get_namespace()
-    workflow_name = workflowutils.get_workflow_name(pod_name, namespace)
-
-    # Retrieve the Argo workflow
-    api_group = "argoproj.io"
-    api_version = "v1alpha1"
-    co_name = "workflows"
-    co_client = k8sutils.get_co_client()
-    workflow = co_client.get_namespaced_custom_object(api_group, api_version,
-                                                      namespace, co_name,
-                                                      workflow_name)
-    run_uuid = workflow["metadata"].get("labels", {}).get(KFP_RUN_ID_LABEL_KEY,
-                                                          None)
+    workflow = workflowutils.get_workflow(
+        workflowutils.get_workflow_name(get_pod_name(), namespace),
+        namespace)
+    run_uuid = (workflow["metadata"]
+                .get("labels", {})
+                .get(KFP_RUN_ID_LABEL_KEY, None))
 
     # KFP api-server adds run UUID as label to workflows for KFP>=0.1.26.
     # Return run UUID if available. Else return workflow UUID to maintain

--- a/backend/kale/pipeline.py
+++ b/backend/kale/pipeline.py
@@ -137,8 +137,13 @@ class PipelineConfig(Config):
         if not self.docker_image:
             try:
                 self.docker_image = podutils.get_docker_base_image()
-            except (ConfigException, FileNotFoundError, ApiException):
-                # no K8s config found; use kfp default image
+            except (ConfigException, RuntimeError, FileNotFoundError,
+                    ApiException):
+                # * ConfigException: no K8s config found
+                # * RuntimeError, FileNotFoundError: this is not running in a
+                #   pod
+                # * ApiException: K8s call to read pod raised exception;
+                # Use kfp default image
                 self.docker_image = ""
 
     def _set_volume_storage_class(self):


### PR DESCRIPTION
This PR improves the detection of the base docker image being used by the Pod, retrieving the image SHA (when available).
This ensures that reproducibility even when the base image has a non-reproducible tag (e.g. `latest`)