### PR TITLE
Create KFP artifacts using the SDK

### DIFF
--- a/backend/kale/__init__.py
+++ b/backend/kale/__init__.py
@@ -21,6 +21,12 @@ class PipelineParam(NamedTuple):
     param_value: Any
 
 
+class Artifact(NamedTuple):
+    """A Step artifact."""
+    name: str
+    path: str
+
+
 from .step import Step, StepConfig
 from .pipeline import Pipeline, PipelineConfig, VolumeConfig
 from .compiler import Compiler

--- a/backend/kale/sdk/__init__.py
+++ b/backend/kale/sdk/__init__.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 
-from .api import pipeline, step
-from kale.common import logutils
+from .api import pipeline, step, artifact
 
+from kale.common import logutils
 
 logutils.get_or_create_logger(module=__name__, name="sdk")
 del logutils

--- a/backend/kale/step.py
+++ b/backend/kale/step.py
@@ -16,9 +16,9 @@ import logging
 
 from typing import Any, Dict, List, Callable, Union
 
-from kale import PipelineParam
-from kale.common import astutils
 from kale.marshal import Marshaller
+from kale import PipelineParam, Artifact
+from kale.common import astutils, runutils
 from kale.config import Config, Field, validators
 
 log = logging.getLogger(__name__)
@@ -53,6 +53,7 @@ class Step:
         self.source = source
         self.ins = ins or []
         self.outs = outs or []
+        self.artifacts: List[Artifact] = list()
 
         self.config = StepConfig(**kwargs)
 
@@ -76,8 +77,10 @@ class Step:
         marshaller = Marshaller(func=self.source, ins=self.ins, outs=self.outs,
                                 parameters=_params, marshal_dir='.marshal/')
         marshaller()
-        log.info("%s Successfully run step '%s'... %s", "-" * 10, self.name,
+        log.info("%s Successfully ran step '%s'... %s", "-" * 10, self.name,
                  "-" * 10)
+        runutils.link_artifacts({a.name: a.path for a in self.artifacts},
+                                link=False)
 
     @property
     def name(self):

--- a/backend/kale/templates/pipeline_template.jinja2
+++ b/backend/kale/templates/pipeline_template.jinja2
@@ -164,6 +164,12 @@ def auto_generated_pipeline({%- for arg in pipeline.pps_names -%}
     _kale_output_artifacts.update({'mlpipeline-ui-metadata': '/tmp/mlpipeline-ui-metadata.json'})
     _kale_output_artifacts.update({'{{ step.name }}': '/{{ step.name }}.html'})
     {%- endif %}
+    {%- if pipeline.processor.id == "py" and step.artifacts and step.name != "final_auto_snapshot" and step.name != "pipeline_metrics" %}
+    _kale_output_artifacts.update({'mlpipeline-ui-metadata': '/tmp/mlpipeline-ui-metadata.json'})
+    {%- for artifact in step.artifacts %}
+    _kale_output_artifacts.update({'{{ artifact["name"] }}': '{{ artifact["path"] }}'})
+    {%- endfor %}
+    {%- endif %}
     _kale_{{ step.name }}_task.output_artifact_paths.update(_kale_output_artifacts)
     _kale_{{ step.name }}_task.add_pod_label("pipelines.kubeflow.org/metadata_written", "true")
     _kale_dep_names = (_kale_{{ step.name }}_task.dependent_names +

--- a/backend/kale/templates/py_function_template.jinja2
+++ b/backend/kale/templates/py_function_template.jinja2
@@ -23,6 +23,7 @@ def {{ step.name }}({%- for arg in step.pps_names -%}
 
 {%- if step.config.timeout %}from kale.common.runutils import ttl{% endif %}
     from kale.marshal.decorator import marshal
+    from kale.common.runutils import link_artifacts as _kale_link_artifacts
 
     pipeline_parameters = {
 {%- if step.pps_names|length %}
@@ -38,6 +39,17 @@ def {{ step.name }}({%- for arg in step.pps_names -%}
 {{ step.rendered_source|indent(4, True) }}
 
     {{ step.source.__name__ }}()
+
+    _kale_artifacts = {
+{%- if step.artifacts|length %}
+    {%- for artifact in step.artifacts -%}
+        "{{ artifact.name }}": "{{ artifact.path }}"
+    {%- if loop.index < step.pps_names|length -%},
+    {%- endif -%}
+    {%- endfor -%}
+{%- endif %}}
+
+    _kale_link_artifacts(_kale_artifacts)
 
 {%- if autosnapshot %}
 {%- if step.name == 'final_auto_snapshot' %}

--- a/backend/kale/templates/py_function_template.jinja2
+++ b/backend/kale/templates/py_function_template.jinja2
@@ -21,11 +21,11 @@ def {{ step.name }}({%- for arg in step.pps_names -%}
 {% endif %}
 
 
-{%- if step.config.timeout %}from kale.common.runutils import ttl{% endif %}
-    from kale.marshal.decorator import marshal
+    {% if step.config.timeout %}from kale.common.runutils import ttl as _kale_ttl{% endif %}
+    from kale.marshal.decorator import marshal as _kale_marshal
     from kale.common.runutils import link_artifacts as _kale_link_artifacts
 
-    pipeline_parameters = {
+    _kale_pipeline_parameters = {
 {%- if step.pps_names|length %}
     {%- for arg in step.pps_names -%}
         "{{ arg }}": {{ arg }}
@@ -34,8 +34,8 @@ def {{ step.name }}({%- for arg in step.pps_names -%}
     {%- endfor -%}
 {%- endif %}}
 
-{%- if step.config.timeout %}@ttl({{ step.config.timeout }}){% endif %}
-    @marshal({{ step.ins }}, {{ step.outs }}, pipeline_parameters, "{{ marshal_path }}")
+    {% if step.config.timeout %}@_kale_ttl({{ step.config.timeout }}){% endif %}
+    @_kale_marshal({{ step.ins }}, {{ step.outs }}, _kale_pipeline_parameters, "{{ marshal_path }}")
 {{ step.rendered_source|indent(4, True) }}
 
     {{ step.source.__name__ }}()

--- a/backend/kale/tests/assets/kfp_dsl/pipeline_parameters.py
+++ b/backend/kale/tests/assets/kfp_dsl/pipeline_parameters.py
@@ -20,6 +20,7 @@ def step1():
         before=True)
 
     from kale.marshal.decorator import marshal
+    from kale.common.runutils import link_artifacts as _kale_link_artifacts
 
     pipeline_parameters = {}
 
@@ -28,6 +29,10 @@ def step1():
         return 10
 
     step1()
+
+    _kale_artifacts = {}
+
+    _kale_link_artifacts(_kale_artifacts)
     _rok_snapshot_task = _kale_rokutils.snapshot_pipeline_step(
         "test",
         "step1",
@@ -51,6 +56,7 @@ def step3(b: str):
         before=True)
 
     from kale.marshal.decorator import marshal
+    from kale.common.runutils import link_artifacts as _kale_link_artifacts
 
     pipeline_parameters = {"b": b}
 
@@ -59,6 +65,10 @@ def step3(b: str):
         print(st)
 
     step3()
+
+    _kale_artifacts = {}
+
+    _kale_link_artifacts(_kale_artifacts)
     _rok_snapshot_task = _kale_rokutils.snapshot_pipeline_step(
         "test",
         "step3",
@@ -82,6 +92,7 @@ def step2(a: int, c: int):
         before=True)
 
     from kale.marshal.decorator import marshal
+    from kale.common.runutils import link_artifacts as _kale_link_artifacts
 
     pipeline_parameters = {"a": a, "c": c}
 
@@ -91,6 +102,10 @@ def step2(a: int, c: int):
         return 'Test'
 
     step2()
+
+    _kale_artifacts = {}
+
+    _kale_link_artifacts(_kale_artifacts)
     _rok_snapshot_task = _kale_rokutils.snapshot_pipeline_step(
         "test",
         "step2",
@@ -106,6 +121,7 @@ def final_auto_snapshot():
     _kale_mlmdutils.init_metadata()
 
     from kale.marshal.decorator import marshal
+    from kale.common.runutils import link_artifacts as _kale_link_artifacts
 
     pipeline_parameters = {}
 
@@ -114,6 +130,10 @@ def final_auto_snapshot():
         pass
 
     _no_op()
+
+    _kale_artifacts = {}
+
+    _kale_link_artifacts(_kale_artifacts)
     from kale.common import rokutils as _kale_rokutils
     _kale_mlmdutils.call("link_input_rok_artifacts")
     _rok_snapshot_task = _kale_rokutils.snapshot_pipeline_step(

--- a/backend/kale/tests/assets/kfp_dsl/pipeline_parameters.py
+++ b/backend/kale/tests/assets/kfp_dsl/pipeline_parameters.py
@@ -19,12 +19,12 @@ def step1():
         "",
         before=True)
 
-    from kale.marshal.decorator import marshal
+    from kale.marshal.decorator import marshal as _kale_marshal
     from kale.common.runutils import link_artifacts as _kale_link_artifacts
 
-    pipeline_parameters = {}
+    _kale_pipeline_parameters = {}
 
-    @marshal([], ['data'], pipeline_parameters, "/marshal")
+    @_kale_marshal([], ['data'], _kale_pipeline_parameters, "/marshal")
     def step1():
         return 10
 
@@ -55,12 +55,12 @@ def step3(b: str):
         "",
         before=True)
 
-    from kale.marshal.decorator import marshal
+    from kale.marshal.decorator import marshal as _kale_marshal
     from kale.common.runutils import link_artifacts as _kale_link_artifacts
 
-    pipeline_parameters = {"b": b}
+    _kale_pipeline_parameters = {"b": b}
 
-    @marshal(['b', 'data'], [], pipeline_parameters, "/marshal")
+    @_kale_marshal(['b', 'data'], [], _kale_pipeline_parameters, "/marshal")
     def step3(st, st2):
         print(st)
 
@@ -91,12 +91,12 @@ def step2(a: int, c: int):
         "",
         before=True)
 
-    from kale.marshal.decorator import marshal
+    from kale.marshal.decorator import marshal as _kale_marshal
     from kale.common.runutils import link_artifacts as _kale_link_artifacts
 
-    pipeline_parameters = {"a": a, "c": c}
+    _kale_pipeline_parameters = {"a": a, "c": c}
 
-    @marshal(['c', 'a', 'data'], ['res'], pipeline_parameters, "/marshal")
+    @_kale_marshal(['c', 'a', 'data'], ['res'], _kale_pipeline_parameters, "/marshal")
     def step2(var1, var2, data):
         print(var1 + var2)
         return 'Test'
@@ -120,12 +120,12 @@ def final_auto_snapshot():
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    from kale.marshal.decorator import marshal
+    from kale.marshal.decorator import marshal as _kale_marshal
     from kale.common.runutils import link_artifacts as _kale_link_artifacts
 
-    pipeline_parameters = {}
+    _kale_pipeline_parameters = {}
 
-    @marshal([], [], pipeline_parameters, "/marshal")
+    @_kale_marshal([], [], _kale_pipeline_parameters, "/marshal")
     def _no_op():
         pass
 

--- a/backend/kale/tests/assets/kfp_dsl/simple_data_passing.py
+++ b/backend/kale/tests/assets/kfp_dsl/simple_data_passing.py
@@ -11,12 +11,12 @@ def step1():
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    from kale.marshal.decorator import marshal
+    from kale.marshal.decorator import marshal as _kale_marshal
     from kale.common.runutils import link_artifacts as _kale_link_artifacts
 
-    pipeline_parameters = {}
+    _kale_pipeline_parameters = {}
 
-    @marshal([], ['_b', '_a'], pipeline_parameters, "/marshal")
+    @_kale_marshal([], ['_b', '_a'], _kale_pipeline_parameters, "/marshal")
     def step1():
         a = 1
         b = 2
@@ -34,12 +34,12 @@ def step2():
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    from kale.marshal.decorator import marshal
+    from kale.marshal.decorator import marshal as _kale_marshal
     from kale.common.runutils import link_artifacts as _kale_link_artifacts
 
-    pipeline_parameters = {}
+    _kale_pipeline_parameters = {}
 
-    @marshal(['_b', '_a'], ['_c'], pipeline_parameters, "/marshal")
+    @_kale_marshal(['_b', '_a'], ['_c'], _kale_pipeline_parameters, "/marshal")
     def step2(a, b):
         c = a + b
         print(c)
@@ -57,12 +57,12 @@ def step3():
     from kale.common import mlmdutils as _kale_mlmdutils
     _kale_mlmdutils.init_metadata()
 
-    from kale.marshal.decorator import marshal
+    from kale.marshal.decorator import marshal as _kale_marshal
     from kale.common.runutils import link_artifacts as _kale_link_artifacts
 
-    pipeline_parameters = {}
+    _kale_pipeline_parameters = {}
 
-    @marshal(['_a', '_c'], [], pipeline_parameters, "/marshal")
+    @_kale_marshal(['_a', '_c'], [], _kale_pipeline_parameters, "/marshal")
     def step3(a, c):
         d = c + a
         print(d)

--- a/backend/kale/tests/assets/kfp_dsl/simple_data_passing.py
+++ b/backend/kale/tests/assets/kfp_dsl/simple_data_passing.py
@@ -12,6 +12,7 @@ def step1():
     _kale_mlmdutils.init_metadata()
 
     from kale.marshal.decorator import marshal
+    from kale.common.runutils import link_artifacts as _kale_link_artifacts
 
     pipeline_parameters = {}
 
@@ -22,6 +23,10 @@ def step1():
         return a, b
 
     step1()
+
+    _kale_artifacts = {}
+
+    _kale_link_artifacts(_kale_artifacts)
     _kale_mlmdutils.call("mark_execution_complete")
 
 
@@ -30,6 +35,7 @@ def step2():
     _kale_mlmdutils.init_metadata()
 
     from kale.marshal.decorator import marshal
+    from kale.common.runutils import link_artifacts as _kale_link_artifacts
 
     pipeline_parameters = {}
 
@@ -40,6 +46,10 @@ def step2():
         return c
 
     step2()
+
+    _kale_artifacts = {}
+
+    _kale_link_artifacts(_kale_artifacts)
     _kale_mlmdutils.call("mark_execution_complete")
 
 
@@ -48,6 +58,7 @@ def step3():
     _kale_mlmdutils.init_metadata()
 
     from kale.marshal.decorator import marshal
+    from kale.common.runutils import link_artifacts as _kale_link_artifacts
 
     pipeline_parameters = {}
 
@@ -57,6 +68,10 @@ def step3():
         print(d)
 
     step3()
+
+    _kale_artifacts = {}
+
+    _kale_link_artifacts(_kale_artifacts)
     _kale_mlmdutils.call("mark_execution_complete")
 
 

--- a/examples/sdk/artifact.py
+++ b/examples/sdk/artifact.py
@@ -1,0 +1,26 @@
+"""
+This pipeline showcases how you can create a KFP artifact as part
+of a step.
+"""
+
+from kale.sdk import pipeline, step, artifact
+
+
+# Annotate the step with the @artifact decorator and specify the path to
+# a HTML file
+@artifact(name="test-artifact", path="/home/jovyan/myartifact.html")
+@step(name="artifact_generator")
+def generate_artifact():
+    print("Creating HTML artifact...")
+    with open("/home/jovyan/myartifact.html", "w") as f:
+        f.write("<html>Hello, World!<html>")
+    print("HTML artifact created successfully!")
+
+
+@pipeline(name="generate-artifact", experiment="generate-artifact")
+def artifact_pipeline():
+    generate_artifact()
+
+
+if __name__ == "__main__":
+    artifact_pipeline()


### PR DESCRIPTION
This PR introduces a new SDK decorator that allows users to declare
the artifacts created during a step execution. The `@artifact` decorator
is thus supposed to be used on functions that have already been
decorated with the `@step` decorator.

Declaring step artifacts must be done before the step actually executes,
because Kale needs to create a pipeline that is aware of these outputs,
and properly update each step's output artifacts dictionary in the KFP
DSL.

Currently only HTML artifacts are supported.