### PR TITLE
Bump MLMD version

### DIFF
--- a/backend/kale/common/mlmdutils.py
+++ b/backend/kale/common/mlmdutils.py
@@ -236,21 +236,14 @@ class MLMetadata(object):
         context.id = self.store.put_contexts([context])[0]
         return context
 
-    def _get_context_by_name(self, context_name: str):
-        matching_contexts = [context
-                             for context in self.store.get_contexts()
-                             if context.name == context_name]
-        assert len(matching_contexts) <= 1
-        return (None if len(matching_contexts) == 0
-                else matching_contexts[0])
-
     def _get_or_create_context_with_type(self, context_name: str,
                                          type_name: str,
                                          property_types: dict = None,
                                          properties: dict = None):
         log.info("Creating context '%s' of type '%s'...", context_name,
                  type_name)
-        context = self._get_context_by_name(context_name)
+        context = self.store.get_context_by_type_and_name(
+            type_name=type_name, context_name=context_name)
         if not context:
             try:
                 context = self._create_context_with_type(
@@ -261,7 +254,8 @@ class MLMetadata(object):
                 # XXX: We get here if two concurrent steps try to create this
                 # new context
                 log.info("Context already exists")
-                context = self._get_context_by_name(context_name)
+                context = self.store.get_context_by_type_and_name(
+                    type_name=type_name, context_name=context_name)
         else:
             log.info("Context already exists")
         log.info("ContextType ID: %s - Context ID: %s", context.type_id,

--- a/backend/kale/common/mlmdutils.py
+++ b/backend/kale/common/mlmdutils.py
@@ -31,9 +31,13 @@ from ml_metadata.errors import AlreadyExistsError
 from kale.common import utils, podutils, workflowutils, k8sutils, kfputils
 
 
+METADATA_GRPC_SERVICE_SERVICE_HOST_ENV = "METADATA_GRPC_SERVICE_SERVICE_HOST"
 DEFAULT_METADATA_GRPC_SERVICE_SERVICE_HOST = ("metadata-grpc-service.kubeflow"
                                               ".svc")
+METADATA_GRPC_SERVICE_SERVICE_PORT_ENV = "METADATA_GRPC_SERVICE_SERVICE_PORT"
 DEFAULT_METADATA_GRPC_SERVICE_SERVICE_PORT = 8080
+METADATA_GRPC_MAX_RECEIVE_MESSAGE_LENGTH_ENV = (
+    "METADATA_GRPC_MAX_RECEIVE_MESSAGE_LENGTH")
 # 4MB is the default gRPC channel size. Having this setting configurable from
 # ENV can be very useful when troubleshooting gRPC issues.
 DEFAULT_METADATA_GRPC_MAX_RECEIVE_MESSAGE_LENGTH = 4 * 1024 ** 2  # 4MB
@@ -153,13 +157,13 @@ class MLMetadata(object):
             return False
 
         metadata_service_host = os.environ.get(
-            "METADATA_GRPC_SERVICE_SERVICE_HOST",
+            METADATA_GRPC_SERVICE_SERVICE_HOST_ENV,
             DEFAULT_METADATA_GRPC_SERVICE_SERVICE_HOST)
         metadata_service_port = int(os.environ.get(
-            "METADATA_GRPC_SERVICE_SERVICE_PORT",
+            METADATA_GRPC_SERVICE_SERVICE_PORT_ENV,
             DEFAULT_METADATA_GRPC_SERVICE_SERVICE_PORT))
         metadata_service_max_msg = int(os.environ.get(
-            "METADATA_GRPC_MAX_RECEIVE_MESSAGE_LENGTH",
+            METADATA_GRPC_MAX_RECEIVE_MESSAGE_LENGTH_ENV,
             DEFAULT_METADATA_GRPC_MAX_RECEIVE_MESSAGE_LENGTH))
 
         metadata_service_channel_args = GrpcChannelArguments(

--- a/backend/kale/common/mlmdutils.py
+++ b/backend/kale/common/mlmdutils.py
@@ -24,13 +24,7 @@ import logging
 
 from ml_metadata.proto import metadata_store_pb2
 from ml_metadata.metadata_store import metadata_store
-# FIXME: We make use of metadata_store.errors which is essentially this:
-# from tensorflow.python.framework import errors
-# https://github.com/google/ml-metadata/blob/v0.21.2/ml_metadata/metadata_store/metadata_store.py#L36  # noqa:E501
-# We need to track the following issue/PR and, if anything changes, change this
-# accordingly.
-# https://github.com/google/ml-metadata/issues/25
-# https://github.com/google/ml-metadata/pull/35
+from ml_metadata.errors import AlreadyExistsError
 
 from kale.common import utils, podutils, workflowutils, k8sutils, kfputils
 
@@ -263,7 +257,7 @@ class MLMetadata(object):
                     context_name=context_name, type_name=type_name,
                     property_types=property_types, properties=properties)
                 log.info("Succesfully created context")
-            except metadata_store.errors.AlreadyExistsError:
+            except AlreadyExistsError:
                 # XXX: We get here if two concurrent steps try to create this
                 # new context
                 log.info("Context already exists")

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -49,7 +49,7 @@ setup(
         'ipykernel >= 5.1.4',
         'notebook >= 6.0.0',
         'packaging > 20',
-        'ml_metadata == 0.24.0',
+        'ml_metadata >= 0.26.0, < 1',
         'progress >= 1.5',
         'kfserving >= 0.4.0, < 0.5.0',
         'kubernetes < 12.0.0',


### PR DESCRIPTION
* Update ML Metadata requirement
  * Fix error handling after the upgrade
* Use a client method available in the newer version
* Allow configuring the max length of gRPC messages