### PR TITLE
fix(backend): Cleanup pipeline version on first upload

### DIFF
--- a/backend/kale/common/kfputils.py
+++ b/backend/kale/common/kfputils.py
@@ -153,7 +153,7 @@ def upload_pipeline(pipeline_package_path: str, pipeline_name: str,
             pipeline_id=pipeline_id)
         # delete the first version which has the same name as the pipeline
         versions = client.list_pipeline_versions(pipeline_id=pipeline_id)
-        sorted_versions = sorted(versions.pipeline_versions, 
+        sorted_versions = sorted(versions.pipeline_versions,
                                  key=lambda v: v.created_at)
         delete_vid = sorted_versions[0].pipeline_version_id
         client.delete_pipeline_version(

--- a/backend/kale/common/kfputils.py
+++ b/backend/kale/common/kfputils.py
@@ -152,7 +152,10 @@ def upload_pipeline(pipeline_package_path: str, pipeline_name: str,
             pipeline_version_name=version_name,
             pipeline_id=pipeline_id)
         # delete the first version which has the same name as the pipeline
-        client.delete_pipeline_version(upp.pipeline_id)
+        versions = client.list_pipeline_versions(pipeline_id=pipeline_id)
+        sorted_versions = sorted(versions.pipeline_versions, key=lambda v: v.created_at)
+        delete_vid = sorted_versions[0].pipeline_version_id
+        client.delete_pipeline_version(pipeline_id=pipeline_id, pipeline_version_id=delete_vid)
         log.info("Deleted pipeline version with name '%s' and ID: %s",
                  pipeline_name, upp.pipeline_id)
     else:

--- a/backend/kale/common/kfputils.py
+++ b/backend/kale/common/kfputils.py
@@ -153,9 +153,13 @@ def upload_pipeline(pipeline_package_path: str, pipeline_name: str,
             pipeline_id=pipeline_id)
         # delete the first version which has the same name as the pipeline
         versions = client.list_pipeline_versions(pipeline_id=pipeline_id)
-        sorted_versions = sorted(versions.pipeline_versions, key=lambda v: v.created_at)
+        sorted_versions = sorted(versions.pipeline_versions, 
+                                 key=lambda v: v.created_at)
         delete_vid = sorted_versions[0].pipeline_version_id
-        client.delete_pipeline_version(pipeline_id=pipeline_id, pipeline_version_id=delete_vid)
+        client.delete_pipeline_version(
+            pipeline_id=pipeline_id, 
+            pipeline_version_id=delete_vid
+        )
         log.info("Deleted pipeline version with name '%s' and ID: %s",
                  pipeline_name, upp.pipeline_id)
     else:

--- a/backend/kale/common/kfputils.py
+++ b/backend/kale/common/kfputils.py
@@ -157,7 +157,7 @@ def upload_pipeline(pipeline_package_path: str, pipeline_name: str,
                                  key=lambda v: v.created_at)
         delete_vid = sorted_versions[0].pipeline_version_id
         client.delete_pipeline_version(
-            pipeline_id=pipeline_id, 
+            pipeline_id=pipeline_id,
             pipeline_version_id=delete_vid
         )
         log.info("Deleted pipeline version with name '%s' and ID: %s",

--- a/backend/kale/compiler.py
+++ b/backend/kale/compiler.py
@@ -270,7 +270,7 @@ class Compiler:
         """
         package_names = set()
         # Ensure 'kale' is always included
-        package_names.add("kubeflow-kale==1.0.0.dev8")
+        package_names.add("kubeflow-kale==1.0.0.dev13")
         # Ensure 'kfp' is always included
         package_names.add("kfp>=2.0.0")
         lines = self.imports_and_functions.strip().split('\n')

--- a/backend/kale/tests/assets/kfp_dsl/iris.py
+++ b/backend/kale/tests/assets/kfp_dsl/iris.py
@@ -6,7 +6,7 @@ from kfp.dsl import Input, Output, Dataset, HTML, Metrics, ClassificationMetrics
 @kfp_dsl.component(
     base_image='python:3.10',
     packages_to_install=['kfp>=2.0.0',
-                         'kubeflow-kale==1.0.0.dev8', 'numpy', 'scikit-learn'],
+                         'kubeflow-kale==1.0.0.dev13', 'numpy', 'scikit-learn'],
     pip_index_urls=['https://test.pypi.org/simple', 'https://pypi.org/simple'],
 )
 def load_transform_data_step(load_transform_data_html_report: Output[HTML], x_trn_artifact: Output[Dataset], x_tst_artifact: Output[Dataset], y_trn_artifact: Output[Dataset], y_tst_artifact: Output[Dataset], n_estimators_param: int = 500, max_depth_param: int = 2):
@@ -83,7 +83,7 @@ def load_transform_data_step(load_transform_data_html_report: Output[HTML], x_tr
 @kfp_dsl.component(
     base_image='python:3.10',
     packages_to_install=['kfp>=2.0.0',
-                         'kubeflow-kale==1.0.0.dev8', 'numpy', 'scikit-learn'],
+                         'kubeflow-kale==1.0.0.dev13', 'numpy', 'scikit-learn'],
     pip_index_urls=['https://test.pypi.org/simple', 'https://pypi.org/simple'],
 )
 def train_model_step(train_model_html_report: Output[HTML], x_trn_artifact: Input[Dataset], y_trn_artifact: Input[Dataset], model_artifact: Output[Model], n_estimators_param: int = 500, max_depth_param: int = 2):
@@ -159,7 +159,7 @@ def train_model_step(train_model_html_report: Output[HTML], x_trn_artifact: Inpu
 @kfp_dsl.component(
     base_image='python:3.10',
     packages_to_install=['kfp>=2.0.0',
-                         'kubeflow-kale==1.0.0.dev8', 'numpy', 'scikit-learn'],
+                         'kubeflow-kale==1.0.0.dev13', 'numpy', 'scikit-learn'],
     pip_index_urls=['https://test.pypi.org/simple', 'https://pypi.org/simple'],
 )
 def evaluate_model_step(evaluate_model_html_report: Output[HTML], model_artifact: Input[Model], x_tst_artifact: Input[Dataset], y_tst_artifact: Input[Dataset], n_estimators_param: int = 500, max_depth_param: int = 2):

--- a/backend/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
+++ b/backend/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
@@ -5,7 +5,7 @@ from kfp.dsl import Input, Output, Dataset, HTML, Metrics, ClassificationMetrics
 
 @kfp_dsl.component(
     base_image='python:3.10',
-    packages_to_install=['kfp>=2.0.0', 'kubeflow-kale==1.0.0.dev8', 'numpy'],
+    packages_to_install=['kfp>=2.0.0', 'kubeflow-kale==1.0.0.dev13', 'numpy'],
     pip_index_urls=['https://test.pypi.org/simple', 'https://pypi.org/simple'],
 )
 def create_matrix_step(create_matrix_html_report: Output[HTML], rnd_matrix_artifact: Output[Dataset], d1: int = 5, d2: int = 6, booltest: bool = True, strtest: str = 'test'):
@@ -76,7 +76,7 @@ def create_matrix_step(create_matrix_html_report: Output[HTML], rnd_matrix_artif
 
 @kfp_dsl.component(
     base_image='python:3.10',
-    packages_to_install=['kfp>=2.0.0', 'kubeflow-kale==1.0.0.dev8', 'numpy'],
+    packages_to_install=['kfp>=2.0.0', 'kubeflow-kale==1.0.0.dev13', 'numpy'],
     pip_index_urls=['https://test.pypi.org/simple', 'https://pypi.org/simple'],
 )
 def sum_matrix_step(sum_matrix_html_report: Output[HTML], rnd_matrix_artifact: Input[Dataset], d1: int = 5, d2: int = 6, booltest: bool = True, strtest: str = 'test'):

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 
 setup(
     name='kubeflow-kale',
-    version='1.0.0.dev8',
+    version='1.0.0.dev13',
     description='Convert JupyterNotebooks to Kubeflow Pipelines deployments',
     url='https://github.com/kubeflow-kale/kale',
     author='Stefano Fioravanzo',


### PR DESCRIPTION
The first time you create and upload a pipeline this happens:

```
2025-08-25 15:29:13 Kale kfputils:149         [INFO]     Uploaded Pipeline 'kale-pipeline' id: 3b92a161-2af1-41a4-8ae0-a89ee472ee02
Pipeline details: http://127.0.0.1:8080//#/pipelines/details/3b92a161-2af1-41a4-8ae0-a89ee472ee02/version/5a478f38-8f69-4b20-bfef-9c2bcdb7c0c9
Traceback (most recent call last):
  File "/Users/stefano/git/kubeflow-kale/kale/./backend/kale/cli.py", line 123, in <module>
    main()
  File "/Users/stefano/git/kubeflow-kale/kale/./backend/kale/cli.py", line 106, in main
    pipeline_id, version_id = kfputils.upload_pipeline(
  File "/Users/stefano/git/kubeflow-kale/kale/backend/kale/common/kfputils.py", line 155, in upload_pipeline
    client.delete_pipeline_version(upp.pipeline_id)
TypeError: Client.delete_pipeline_version() missing 1 required positional argument: 'pipeline_version_id'
```

This PR takes care of handling the first pipeline version properly