### PR TITLE
Add automated release workflow for PyPI and npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,89 @@
+name: Publish Kale Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  create_release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Create release with notes
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          generate_release_notes: true
+
+  publish_backend:
+    name: Publish backend to PyPI
+    needs: create_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Ensure PyPI token is configured
+        if: ${{ !secrets.PYPI_API_TOKEN }}
+        run: |
+          echo "PYPI_API_TOKEN secret is not configured."
+          exit 1
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Build backend distribution
+        working-directory: backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+          python -m build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          packages-dir: backend/dist
+          skip-existing: true
+
+  publish_labextension:
+    name: Publish labextension to npm
+    needs: create_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Ensure NPM token is configured
+        if: ${{ !secrets.NPM_TOKEN }}
+        run: |
+          echo "NPM_TOKEN secret is not configured."
+          exit 1
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+          cache-dependency-path: labextension/yarn.lock
+      - name: Install dependencies
+        working-directory: labextension
+        run: jlpm install --frozen-lockfile
+      - name: Build labextension package
+        working-directory: labextension
+        run: jlpm build:prod
+      - name: Publish to npm
+        working-directory: labextension
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish


### PR DESCRIPTION
## Summary
- add a tag-driven release workflow that creates a GitHub release with autogenerated notes
- publish the backend package to PyPI using the new workflow
- build and publish the labextension to npm as part of the release automation

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f79fbcf5d4832ca642d113e760d4bc