### PR TITLE
chore: bump python version on gha

### DIFF
--- a/.github/workflows/build_backend.yml
+++ b/.github/workflows/build_backend.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.10.18
+          python-version: 3.10.19
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.10.18
+          python-version: 3.10.19
       - name: Install flake8
         run: |
           pip install flake8 flake8-docstrings


### PR DESCRIPTION
Seems like GHA actions/setup-python@v1 doesn't support 3.10.18 anymore:

> Error: Version 3.10.18 with arch x64 not found

This PR bumps the Python version from 3.10.18 to 3.10.19, unblocking other PR's.