### PR TITLE
Making sure that the editor and the tags come before the cell

### DIFF
--- a/labextension/src/widgets/cell-metadata/CellMetadataEditor.tsx
+++ b/labextension/src/widgets/cell-metadata/CellMetadataEditor.tsx
@@ -159,7 +159,7 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
 
     if (editor && inlineElement && !isEditorAlreadInPlace) {
       metadataWrapper.style.display = 'flex';
-      metadataWrapper.style.flexDirection = 'row';
+      metadataWrapper.style.flexDirection = 'column';
       editor.remove();
       metadataWrapper.prepend(editor);
     }


### PR DESCRIPTION
To solve issue [486 ](https://github.com/kubeflow-kale/kale/issues/486) I did make the notebook cell container a flex box and made sure that the editor will show first on it

TO test this fix you must open and scroll the notebook - before this fix you would notice that sometimes the editor was placed after the Notebook cell, now it show always come first.