### PR TITLE
Allowing users to configure pip trusted hosts

### DIFF
--- a/backend/kale/common/utils.py
+++ b/backend/kale/common/utils.py
@@ -245,3 +245,23 @@ def compute_pip_index_urls() -> list[str]:
     if pypi_prod_url not in urls:
         urls.append(pypi_prod_url)
     return urls
+
+
+def compute_trusted_hosts() -> list[str]:
+    """Compute the list of trusted hosts for use with pip.
+
+    If user set a comma separated list of hosts using the
+    system property KALE_PIP_TRUSTED_HOSTS, then these hosts
+    will be used as trusted hosts, otherwise the list will be
+    empty.
+
+
+    :return: The list of trusted hosts configured by the user
+    :rtype: list[str]
+    """
+    pip_trusted_hosts = os.getenv("KALE_PIP_TRUSTED_HOSTS")
+    trusted_hosts: list[str] = []
+    if pip_trusted_hosts:
+        trusted_hosts = [u.strip() for u in pip_trusted_hosts.split(",")
+                         if u.strip()]
+    return trusted_hosts

--- a/backend/kale/compiler.py
+++ b/backend/kale/compiler.py
@@ -192,9 +192,11 @@ class Compiler:
             )
 
         packages_list = self._get_package_list_from_imports()
-
+        pip_index_urls = utils.compute_pip_index_urls()
+        pip_trusted_hosts = utils.compute_trusted_hosts()
         fn_code = template.render(
-            pip_index_urls=utils.compute_pip_index_urls(),
+            pip_index_urls=pip_index_urls,
+            pip_trusted_hosts=pip_trusted_hosts,
             step=step,
             component_signature_args=component_signature_args,
             pipeline_params=pipeline_params,

--- a/backend/kale/templates/new_nb_function_template.jinja2
+++ b/backend/kale/templates/new_nb_function_template.jinja2
@@ -2,6 +2,7 @@
     base_image='python:3.10',
     packages_to_install={{ packages_list}},
     pip_index_urls = {{ pip_index_urls }},
+    pip_trusted_hosts = {{ pip_trusted_hosts }}
 )
 def {{ step.name }}_step({{ component_signature_args }}):
     _kale_pipeline_parameters_block = f'''

--- a/backend/kale/tests/assets/kfp_dsl/iris.py
+++ b/backend/kale/tests/assets/kfp_dsl/iris.py
@@ -8,6 +8,7 @@ from kfp.dsl import Input, Output, Dataset, HTML, Metrics, ClassificationMetrics
     packages_to_install=['kfp>=2.0.0',
                          'kubeflow-kale', 'numpy', 'scikit-learn'],
     pip_index_urls=['https://pypi.org/simple'],
+    pip_trusted_hosts=[]
 )
 def load_transform_data_step(load_transform_data_html_report: Output[HTML], x_trn_artifact: Output[Dataset], x_tst_artifact: Output[Dataset], y_trn_artifact: Output[Dataset], y_tst_artifact: Output[Dataset], n_estimators_param: int = 500, max_depth_param: int = 2):
     _kale_pipeline_parameters_block = f'''
@@ -98,6 +99,7 @@ def load_transform_data_step(load_transform_data_html_report: Output[HTML], x_tr
     packages_to_install=['kfp>=2.0.0',
                          'kubeflow-kale', 'numpy', 'scikit-learn'],
     pip_index_urls=['https://pypi.org/simple'],
+    pip_trusted_hosts=[]
 )
 def train_model_step(train_model_html_report: Output[HTML], x_trn_artifact: Input[Dataset], y_trn_artifact: Input[Dataset], model_artifact: Output[Model], n_estimators_param: int = 500, max_depth_param: int = 2):
     _kale_pipeline_parameters_block = f'''
@@ -188,6 +190,7 @@ def train_model_step(train_model_html_report: Output[HTML], x_trn_artifact: Inpu
     packages_to_install=['kfp>=2.0.0',
                          'kubeflow-kale', 'numpy', 'scikit-learn'],
     pip_index_urls=['https://pypi.org/simple'],
+    pip_trusted_hosts=[]
 )
 def evaluate_model_step(evaluate_model_html_report: Output[HTML], model_artifact: Input[Model], x_tst_artifact: Input[Dataset], y_tst_artifact: Input[Dataset], n_estimators_param: int = 500, max_depth_param: int = 2):
     _kale_pipeline_parameters_block = f'''

--- a/backend/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
+++ b/backend/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
@@ -7,6 +7,7 @@ from kfp.dsl import Input, Output, Dataset, HTML, Metrics, ClassificationMetrics
     base_image='python:3.10',
     packages_to_install=['kfp>=2.0.0', 'kubeflow-kale', 'numpy'],
     pip_index_urls=['https://pypi.org/simple'],
+    pip_trusted_hosts=[]
 )
 def create_matrix_step(create_matrix_html_report: Output[HTML], rnd_matrix_artifact: Output[Dataset], d1: int = 5, d2: int = 6, booltest: bool = True, strtest: str = 'test'):
     _kale_pipeline_parameters_block = f'''
@@ -82,6 +83,7 @@ def create_matrix_step(create_matrix_html_report: Output[HTML], rnd_matrix_artif
     base_image='python:3.10',
     packages_to_install=['kfp>=2.0.0', 'kubeflow-kale', 'numpy'],
     pip_index_urls=['https://pypi.org/simple'],
+    pip_trusted_hosts=[]
 )
 def sum_matrix_step(sum_matrix_html_report: Output[HTML], rnd_matrix_artifact: Input[Dataset], d1: int = 5, d2: int = 6, booltest: bool = True, strtest: str = 'test'):
     _kale_pipeline_parameters_block = f'''


### PR DESCRIPTION
This will allow users to set pip trusted hosts and not rely on pipelines auto trusted hosts generation.

To test this:

* Before running Kale, set a value for the system property `KALE_PIP_TRUSTED_HOSTS`. For example:
```
export KALE_PIP_TRUSTED_HOSTS=abc,cba
```
* Now compile a pipeline and you should see that this is added to the compiled Python file:
```
@kfp_dsl.component(
    base_image='python:3.10',
    packages_to_install=[
        'kfp>=2.0.0', 'kubeflow-kale==0.7.1.dev27+g6147892b8.d20251205', 'random2'],
    pip_index_urls=[
        'http://host.minikube.internal:3141/root/dev/+simple', 'https://pypi.org/simple'],
    pip_trusted_hosts=['abc', 'cba']
)
```

And also to the compiled YAML file:

```
        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
          \ python3 -m pip install --quiet --no-warn-script-location --index-url http://host.minikube.internal:3141/root/dev/+simple\
          \ --extra-index-url https://pypi.org/simple --trusted-host abc --trusted-host\
          \ cba 'kfp>=2.0.0' 'kubeflow-kale==0.7.1.dev27+g6147892b8.d20251205' 'random2'\
          \ && \"$0\" \"$@\"\n"
```