### PR TITLE
build(deps): combine security updates for labextension dependencies

### DIFF
--- a/labextension/yarn.lock
+++ b/labextension/yarn.lock
@@ -10771,15 +10771,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.2":
-  version: 7.5.2
-  resolution: "tar@npm:7.5.2"
+  version: 7.5.7
+  resolution: "tar@npm:7.5.7"
   dependencies:
     "@isaacs/fs-minipass": ^4.0.0
     chownr: ^3.0.0
     minipass: ^7.1.2
     minizlib: ^3.1.0
     yallist: ^5.0.0
-  checksum: 192559b0e7af17d57c7747592ef22c14d5eba2d9c35996320ccd20c3e2038160fe8d928fc5c08b2aa1b170c4d0a18c119441e81eae8f227ca2028d5bcaa6bf23
+  checksum: 82fa04804b6cae4c0b46b84e97a08c39e1c17bb959350baa32d139bcf5e1fc7ebc3ceb72465dd3e2e311992386ecc13599a257d5672158490ceb9464146d5573
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR combines three Dependabot security updates into a single PR to reduce CI overhead and simplify the merge process:

- **@isaacs/brace-expansion** 5.0.0 → 5.0.1
- **lodash** 4.17.21 → 4.17.23 (fixes prototype pollution vulnerability)
- **tar** 7.5.2 → 7.5.7 (fixes hard link sanitization issue)

All are indirect dependencies in `/labextension`.

## Why combine?

Each Dependabot PR triggers a full CI run. Combining them:
1. Reduces CI resource usage
2. Makes the git history cleaner
3. Ensures all security updates land together

## Closes

Closes #588
Closes #549
Closes #567