### PR TITLE
refactor: Replace string-based import parsing with AST-based detection

### DIFF
--- a/backend/kale/common/imports.py
+++ b/backend/kale/common/imports.py
@@ -25,61 +25,220 @@ The key components are:
 """
 
 import ast
-import sys
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Set
-
 
 # Python standard library modules (should not be pip installed)
 # This is a comprehensive list for Python 3.10+
-STDLIB_MODULES: Set[str] = {
+STDLIB_MODULES: set[str] = {
     # Built-in modules
-    "abc", "aifc", "argparse", "array", "ast", "asynchat", "asyncio",
-    "asyncore", "atexit", "audioop", "base64", "bdb", "binascii",
-    "binhex", "bisect", "builtins", "bz2",
-    "calendar", "cgi", "cgitb", "chunk", "cmath", "cmd", "code",
-    "codecs", "codeop", "collections", "colorsys", "compileall",
-    "concurrent", "configparser", "contextlib", "contextvars", "copy",
-    "copyreg", "cProfile", "crypt", "csv", "ctypes", "curses",
-    "dataclasses", "datetime", "dbm", "decimal", "difflib", "dis",
-    "distutils", "doctest",
-    "email", "encodings", "enum", "errno",
-    "faulthandler", "fcntl", "filecmp", "fileinput", "fnmatch",
-    "fractions", "ftplib", "functools",
-    "gc", "getopt", "getpass", "gettext", "glob", "graphlib", "grp", "gzip",
-    "hashlib", "heapq", "hmac", "html", "http",
-    "idlelib", "imaplib", "imghdr", "imp", "importlib", "inspect", "io",
-    "ipaddress", "itertools",
+    "abc",
+    "aifc",
+    "argparse",
+    "array",
+    "ast",
+    "asynchat",
+    "asyncio",
+    "asyncore",
+    "atexit",
+    "audioop",
+    "base64",
+    "bdb",
+    "binascii",
+    "binhex",
+    "bisect",
+    "builtins",
+    "bz2",
+    "calendar",
+    "cgi",
+    "cgitb",
+    "chunk",
+    "cmath",
+    "cmd",
+    "code",
+    "codecs",
+    "codeop",
+    "collections",
+    "colorsys",
+    "compileall",
+    "concurrent",
+    "configparser",
+    "contextlib",
+    "contextvars",
+    "copy",
+    "copyreg",
+    "cProfile",
+    "crypt",
+    "csv",
+    "ctypes",
+    "curses",
+    "dataclasses",
+    "datetime",
+    "dbm",
+    "decimal",
+    "difflib",
+    "dis",
+    "distutils",
+    "doctest",
+    "email",
+    "encodings",
+    "enum",
+    "errno",
+    "faulthandler",
+    "fcntl",
+    "filecmp",
+    "fileinput",
+    "fnmatch",
+    "fractions",
+    "ftplib",
+    "functools",
+    "gc",
+    "getopt",
+    "getpass",
+    "gettext",
+    "glob",
+    "graphlib",
+    "grp",
+    "gzip",
+    "hashlib",
+    "heapq",
+    "hmac",
+    "html",
+    "http",
+    "idlelib",
+    "imaplib",
+    "imghdr",
+    "imp",
+    "importlib",
+    "inspect",
+    "io",
+    "ipaddress",
+    "itertools",
     "json",
     "keyword",
-    "lib2to3", "linecache", "locale", "logging", "lzma",
-    "mailbox", "mailcap", "marshal", "math", "mimetypes", "mmap",
-    "modulefinder", "multiprocessing",
-    "netrc", "nis", "nntplib", "numbers",
-    "operator", "optparse", "os", "ossaudiodev",
-    "pathlib", "pdb", "pickle", "pickletools", "pipes", "pkgutil",
-    "platform", "plistlib", "poplib", "posix", "posixpath", "pprint",
-    "profile", "pstats", "pty", "pwd", "py_compile", "pyclbr", "pydoc",
-    "queue", "quopri",
-    "random", "re", "readline", "reprlib", "resource", "rlcompleter",
+    "lib2to3",
+    "linecache",
+    "locale",
+    "logging",
+    "lzma",
+    "mailbox",
+    "mailcap",
+    "marshal",
+    "math",
+    "mimetypes",
+    "mmap",
+    "modulefinder",
+    "multiprocessing",
+    "netrc",
+    "nis",
+    "nntplib",
+    "numbers",
+    "operator",
+    "optparse",
+    "os",
+    "ossaudiodev",
+    "pathlib",
+    "pdb",
+    "pickle",
+    "pickletools",
+    "pipes",
+    "pkgutil",
+    "platform",
+    "plistlib",
+    "poplib",
+    "posix",
+    "posixpath",
+    "pprint",
+    "profile",
+    "pstats",
+    "pty",
+    "pwd",
+    "py_compile",
+    "pyclbr",
+    "pydoc",
+    "queue",
+    "quopri",
+    "random",
+    "re",
+    "readline",
+    "reprlib",
+    "resource",
+    "rlcompleter",
     "runpy",
-    "sched", "secrets", "select", "selectors", "shelve", "shlex",
-    "shutil", "signal", "site", "smtpd", "smtplib", "sndhdr", "socket",
-    "socketserver", "spwd", "sqlite3", "ssl", "stat", "statistics",
-    "string", "stringprep", "struct", "subprocess", "sunau", "symtable",
-    "sys", "sysconfig", "syslog",
-    "tabnanny", "tarfile", "telnetlib", "tempfile", "termios", "test",
-    "textwrap", "threading", "time", "timeit", "tkinter", "token",
-    "tokenize", "trace", "traceback", "tracemalloc", "tty", "turtle",
-    "turtledemo", "types", "typing",
-    "unicodedata", "unittest", "urllib", "uu", "uuid",
+    "sched",
+    "secrets",
+    "select",
+    "selectors",
+    "shelve",
+    "shlex",
+    "shutil",
+    "signal",
+    "site",
+    "smtpd",
+    "smtplib",
+    "sndhdr",
+    "socket",
+    "socketserver",
+    "spwd",
+    "sqlite3",
+    "ssl",
+    "stat",
+    "statistics",
+    "string",
+    "stringprep",
+    "struct",
+    "subprocess",
+    "sunau",
+    "symtable",
+    "sys",
+    "sysconfig",
+    "syslog",
+    "tabnanny",
+    "tarfile",
+    "telnetlib",
+    "tempfile",
+    "termios",
+    "test",
+    "textwrap",
+    "threading",
+    "time",
+    "timeit",
+    "tkinter",
+    "token",
+    "tokenize",
+    "trace",
+    "traceback",
+    "tracemalloc",
+    "tty",
+    "turtle",
+    "turtledemo",
+    "types",
+    "typing",
+    "unicodedata",
+    "unittest",
+    "urllib",
+    "uu",
+    "uuid",
     "venv",
-    "warnings", "wave", "weakref", "webbrowser", "winreg", "winsound",
+    "warnings",
+    "wave",
+    "weakref",
+    "webbrowser",
+    "winreg",
+    "winsound",
     "wsgiref",
-    "xdrlib", "xml", "xmlrpc",
-    "zipapp", "zipfile", "zipimport", "zlib", "zoneinfo",
+    "xdrlib",
+    "xml",
+    "xmlrpc",
+    "zipapp",
+    "zipfile",
+    "zipimport",
+    "zlib",
+    "zoneinfo",
     # Common submodules that might be imported directly
-    "os.path", "urllib.parse", "urllib.request", "collections.abc",
+    "os.path",
+    "urllib.parse",
+    "urllib.request",
+    "collections.abc",
     "typing_extensions",  # Not stdlib but often bundled
 }
 
@@ -88,7 +247,7 @@ STDLIB_MODULES: Set[str] = {
 # - If the import name matches the PyPI name, it doesn't need to be here
 # - If the value is None, the package should be skipped (e.g., stdlib)
 # - Add new mappings here as needed
-PACKAGE_NAME_MAP: Dict[str, Optional[str]] = {
+PACKAGE_NAME_MAP: dict[str, str | None] = {
     # Common packages where import name differs from PyPI name
     "sklearn": "scikit-learn",
     "cv2": "opencv-python",
@@ -122,18 +281,19 @@ class ImportInfo:
         is_from: True if this is a "from X import Y" statement
         line_number: Source line number for error reporting
     """
+
     module: str
-    names: List[str]
-    alias: Optional[str]
+    names: list[str]
+    alias: str | None
     is_from: bool
     line_number: int
 
     @property
     def top_level_package(self) -> str:
         """Get the top-level package name (before the first dot)."""
-        return self.module.split('.')[0]
+        return self.module.split(".")[0]
 
-    def get_pypi_package(self) -> Optional[str]:
+    def get_pypi_package(self) -> str | None:
         """Get the PyPI package name for this import.
 
         Returns:
@@ -155,7 +315,7 @@ class ImportInfo:
         return top_level
 
 
-def parse_imports_ast(code: str) -> List[ImportInfo]:
+def parse_imports_ast(code: str) -> list[ImportInfo]:
     """Parse all import statements from Python code using AST.
 
     This function properly handles all Python import forms:
@@ -177,7 +337,7 @@ def parse_imports_ast(code: str) -> List[ImportInfo]:
     Raises:
         SyntaxError: If the code cannot be parsed
     """
-    imports: List[ImportInfo] = []
+    imports: list[ImportInfo] = []
 
     try:
         tree = ast.parse(code)
@@ -190,31 +350,32 @@ def parse_imports_ast(code: str) -> List[ImportInfo]:
         if isinstance(node, ast.Import):
             # Handle: import foo, import foo.bar, import foo as f
             for alias in node.names:
-                imports.append(ImportInfo(
-                    module=alias.name,
-                    names=[alias.name.split('.')[-1]],
-                    alias=alias.asname,
-                    is_from=False,
-                    line_number=node.lineno
-                ))
-        elif isinstance(node, ast.ImportFrom):
+                imports.append(
+                    ImportInfo(
+                        module=alias.name,
+                        names=[alias.name.split(".")[-1]],
+                        alias=alias.asname,
+                        is_from=False,
+                        line_number=node.lineno,
+                    )
+                )
+        elif isinstance(node, ast.ImportFrom) and node.module is not None:
             # Handle: from foo import bar, from foo import bar as b
-            if node.module is not None:
-                # Regular from import
-                imports.append(ImportInfo(
+            # Skip relative imports like "from . import x" as they won't need pip install
+            imports.append(
+                ImportInfo(
                     module=node.module,
                     names=[a.name for a in node.names],
                     alias=node.names[0].asname if len(node.names) == 1 else None,
                     is_from=True,
-                    line_number=node.lineno
-                ))
-            # else: relative import like "from . import x" - skip these
-            # as they won't need to be pip installed
+                    line_number=node.lineno,
+                )
+            )
 
     return imports
 
 
-def get_packages_to_install(code: str) -> Set[str]:
+def get_packages_to_install(code: str) -> set[str]:
     """Extract pip-installable package names from Python code.
 
     This function parses the import statements in the code and returns
@@ -228,7 +389,7 @@ def get_packages_to_install(code: str) -> Set[str]:
     Returns:
         Set of PyPI package names to install
     """
-    packages: Set[str] = set()
+    packages: set[str] = set()
 
     for imp in parse_imports_ast(code):
         pkg = imp.get_pypi_package()
@@ -247,5 +408,5 @@ def is_stdlib_module(module_name: str) -> bool:
     Returns:
         True if the module is part of stdlib, False otherwise
     """
-    top_level = module_name.split('.')[0]
+    top_level = module_name.split(".")[0]
     return top_level in STDLIB_MODULES or module_name in STDLIB_MODULES

--- a/backend/kale/compiler.py
+++ b/backend/kale/compiler.py
@@ -283,7 +283,7 @@ class Compiler:
         # Parse imports using AST and resolve to PyPI package names
         package_names.update(get_packages_to_install(self.imports_and_functions))
 
-        return sorted(list(package_names))
+        return sorted(package_names)
 
     def _get_templating_env(self, templates_path=None):
         if self.templating_env:

--- a/backend/kale/tests/unit_tests/test_imports.py
+++ b/backend/kale/tests/unit_tests/test_imports.py
@@ -29,19 +29,44 @@ from kale.common.imports import (
 class TestStdlibModules:
     """Tests for STDLIB_MODULES set."""
 
-    @pytest.mark.parametrize("module", [
-        "os", "sys", "re", "json", "random", "collections",
-        "typing", "pathlib", "datetime", "functools", "itertools",
-        "math", "subprocess", "threading", "multiprocessing",
-    ])
+    @pytest.mark.parametrize(
+        "module",
+        [
+            "os",
+            "sys",
+            "re",
+            "json",
+            "random",
+            "collections",
+            "typing",
+            "pathlib",
+            "datetime",
+            "functools",
+            "itertools",
+            "math",
+            "subprocess",
+            "threading",
+            "multiprocessing",
+        ],
+    )
     def test_common_stdlib_modules_included(self, module):
         """Verify common stdlib modules are in the set."""
         assert module in STDLIB_MODULES
 
-    @pytest.mark.parametrize("module", [
-        "numpy", "pandas", "sklearn", "tensorflow", "torch",
-        "requests", "flask", "django", "pytest",
-    ])
+    @pytest.mark.parametrize(
+        "module",
+        [
+            "numpy",
+            "pandas",
+            "sklearn",
+            "tensorflow",
+            "torch",
+            "requests",
+            "flask",
+            "django",
+            "pytest",
+        ],
+    )
     def test_third_party_modules_not_included(self, module):
         """Verify third-party modules are not in stdlib set."""
         assert module not in STDLIB_MODULES
@@ -50,14 +75,17 @@ class TestStdlibModules:
 class TestPackageNameMap:
     """Tests for PACKAGE_NAME_MAP dictionary."""
 
-    @pytest.mark.parametrize("import_name,pypi_name", [
-        ("sklearn", "scikit-learn"),
-        ("cv2", "opencv-python"),
-        ("PIL", "pillow"),
-        ("yaml", "pyyaml"),
-        ("bs4", "beautifulsoup4"),
-        ("skimage", "scikit-image"),
-    ])
+    @pytest.mark.parametrize(
+        "import_name,pypi_name",
+        [
+            ("sklearn", "scikit-learn"),
+            ("cv2", "opencv-python"),
+            ("PIL", "pillow"),
+            ("yaml", "pyyaml"),
+            ("bs4", "beautifulsoup4"),
+            ("skimage", "scikit-image"),
+        ],
+    )
     def test_common_mappings_exist(self, import_name, pypi_name):
         """Verify common import-to-PyPI mappings are correct."""
         assert PACKAGE_NAME_MAP.get(import_name) == pypi_name
@@ -68,13 +96,7 @@ class TestImportInfo:
 
     def test_top_level_package_simple(self):
         """Test top_level_package with simple module."""
-        info = ImportInfo(
-            module="numpy",
-            names=["array"],
-            alias=None,
-            is_from=True,
-            line_number=1
-        )
+        info = ImportInfo(module="numpy", names=["array"], alias=None, is_from=True, line_number=1)
         assert info.top_level_package == "numpy"
 
     def test_top_level_package_nested(self):
@@ -84,18 +106,14 @@ class TestImportInfo:
             names=["RandomForestClassifier"],
             alias=None,
             is_from=True,
-            line_number=1
+            line_number=1,
         )
         assert info.top_level_package == "sklearn"
 
     def test_get_pypi_package_direct_mapping(self):
         """Test get_pypi_package with direct mapping."""
         info = ImportInfo(
-            module="sklearn",
-            names=["sklearn"],
-            alias=None,
-            is_from=False,
-            line_number=1
+            module="sklearn", names=["sklearn"], alias=None, is_from=False, line_number=1
         )
         assert info.get_pypi_package() == "scikit-learn"
 
@@ -106,30 +124,18 @@ class TestImportInfo:
             names=["RandomForestClassifier"],
             alias=None,
             is_from=True,
-            line_number=1
+            line_number=1,
         )
         assert info.get_pypi_package() == "scikit-learn"
 
     def test_get_pypi_package_stdlib_returns_none(self):
         """Test get_pypi_package returns None for stdlib."""
-        info = ImportInfo(
-            module="os",
-            names=["path"],
-            alias=None,
-            is_from=True,
-            line_number=1
-        )
+        info = ImportInfo(module="os", names=["path"], alias=None, is_from=True, line_number=1)
         assert info.get_pypi_package() is None
 
     def test_get_pypi_package_no_mapping(self):
         """Test get_pypi_package with no mapping (uses import name)."""
-        info = ImportInfo(
-            module="numpy",
-            names=["array"],
-            alias=None,
-            is_from=True,
-            line_number=1
-        )
+        info = ImportInfo(module="numpy", names=["array"], alias=None, is_from=True, line_number=1)
         assert info.get_pypi_package() == "numpy"
 
 
@@ -212,8 +218,7 @@ from sklearn.ensemble import RandomForestClassifier
         result = parse_imports_ast(code)
         assert len(result) == 1
         assert result[0].module == "collections"
-        assert sorted(result[0].names) == sorted(
-            ["OrderedDict", "defaultdict", "Counter"])
+        assert sorted(result[0].names) == sorted(["OrderedDict", "defaultdict", "Counter"])
 
     def test_dotted_import(self):
         """Test parsing dotted import."""
@@ -343,28 +348,41 @@ import matplotlib.pyplot as plt
 import seaborn as sns
 """
         result = get_packages_to_install(code)
-        expected = {
-            "numpy", "pandas", "scikit-learn",
-            "matplotlib", "seaborn"
-        }
+        expected = {"numpy", "pandas", "scikit-learn", "matplotlib", "seaborn"}
         assert result == expected
 
 
 class TestIsStdlibModule:
     """Tests for is_stdlib_module function."""
 
-    @pytest.mark.parametrize("module", [
-        "os", "sys", "re", "json", "random",
-        "os.path", "collections.abc", "urllib.parse",
-    ])
+    @pytest.mark.parametrize(
+        "module",
+        [
+            "os",
+            "sys",
+            "re",
+            "json",
+            "random",
+            "os.path",
+            "collections.abc",
+            "urllib.parse",
+        ],
+    )
     def test_stdlib_modules(self, module):
         """Test that stdlib modules are correctly identified."""
         assert is_stdlib_module(module) is True
 
-    @pytest.mark.parametrize("module", [
-        "numpy", "pandas", "sklearn", "tensorflow",
-        "numpy.random", "pandas.core",
-    ])
+    @pytest.mark.parametrize(
+        "module",
+        [
+            "numpy",
+            "pandas",
+            "sklearn",
+            "tensorflow",
+            "numpy.random",
+            "pandas.core",
+        ],
+    )
     def test_non_stdlib_modules(self, module):
         """Test that non-stdlib modules are correctly identified."""
         assert is_stdlib_module(module) is False


### PR DESCRIPTION
## Summary
- Introduce a new `imports.py` module with proper AST-based import parsing
- Replace brittle hardcoded string matching in the compiler
- Add comprehensive test coverage (70 unit tests)

## Problem

When Kale compiles a notebook into a Kubeflow Pipeline, it needs to determine which Python packages should be installed in the pipeline steps. This is done by analyzing the import statements in the notebook cells.

The previous implementation used simple string matching to parse imports:

https://github.com/kubeflow/kale/blob/5c4a324ed915eed6d0a279622a8bb28f381a8453/backend/kale/compiler.py#L279-L298

This approach had several issues:

1. Hardcoded mappings: Only `random` and `sklearn` were mapped to their PyPI names. Other common mismatches (e.g., `PIL` → `pillow`, `cv2` → `opencv-python`, `yaml` → `pyyaml`) were not handled.
2. No stdlib filtering: Standard library modules like `os`, `sys`, `json`, etc. were being added to the package list unnecessarily.
3. Fragile parsing: String splitting doesn't handle all valid Python import syntaxes:

  - `import a, b, c` (multiple imports)
  - `from x import (a, b, c)` (parenthesized imports)
  - Multi-line imports
  - Comments on import lines
4. Not extensible: Adding new package mappings required modifying the compiler code directly.

## Solution
This PR introduces a new `backend/kale/common/imports.py` module that uses Python's `ast` module to properly parse imports:

**Key Components**
- `STDLIB_MODULES`: A comprehensive set of Python 3.12+ standard library modules to exclude from package requirements.
- `PACKAGE_NAME_MAP`: A centralized registry mapping import names to PyPI package names:

```python
PACKAGE_NAME_MAP = {
    "sklearn": "scikit-learn",
    "cv2": "opencv-python",
    "PIL": "pillow",
    "yaml": "pyyaml",
    # ... and more
}
```

- `ImportInfo:` A dataclass providing structured information about each import (module, names, alias, line number).
- `parse_imports_ast()`: Parses all imports from source code using AST, handling all valid Python import syntaxes.
- `get_packages_to_install()`: Returns the set of PyPI packages needed for given source code, filtering stdlib and applying name mappings.

**Benefits**
- Correct parsing: Handles all valid Python import syntax
- Extensible: New package mappings can be added to PACKAGE_NAME_MAP
- Maintainable: Centralized configuration instead of scattered conditionals
- Tested: 70 unit tests covering all import forms and edge cases

**Changes**
- New module: `backend/kale/common/imports.py`
- Refactored: `backend/kale/compiler.py` - Use new module instead of string matching
- Tests: `backend/kale/tests/unit_tests/test_imports.py` - 70 comprehensive tests