### PR TITLE
Add download button for compiled pipeline file

### DIFF
--- a/backend/kale/rpc/nb.py
+++ b/backend/kale/rpc/nb.py
@@ -116,9 +116,13 @@ def compile_notebook(request, source_notebook_path, notebook_metadata_overrides=
 
         package_path = kfputils.compile_pipeline(script_path, pipeline.config.pipeline_name)
 
+        with open(script_path) as f:
+            script_content = f.read()
+
         return {
             "pipeline_package_path": os.path.relpath(package_path),
             "pipeline_metadata": pipeline.config.to_dict(),
+            "script_content": script_content,
         }
     except ValueError as e:
         msg = str(e)

--- a/labextension/src/lib/Commands.ts
+++ b/labextension/src/lib/Commands.ts
@@ -285,6 +285,7 @@ export default class Commands {
           'pipeline.yaml',
           'kale.py',
         ),
+        compiledContent: compileNotebook.script_content,
       });
     }
     return compileNotebook;

--- a/labextension/src/widgets/deploys-progress/DeployProgress.tsx
+++ b/labextension/src/widgets/deploys-progress/DeployProgress.tsx
@@ -21,6 +21,7 @@ import UnknownIcon from '@mui/icons-material/Help';
 import PendingIcon from '@mui/icons-material/Schedule';
 import SkippedIcon from '@mui/icons-material/SkipNext';
 import SuccessIcon from '@mui/icons-material/CheckCircle';
+import GetAppIcon from '@mui/icons-material/GetApp';
 
 import StatusRunning from '../../icons/statusRunning';
 import TerminatedIcon from '../../icons/statusTerminated';
@@ -166,6 +167,22 @@ export const DeployProgress: React.FunctionComponent<
     }
   };
 
+  const handleDownloadClick = () => {
+    if (props.compiledPath && props.compiledContent) {
+      const fileName =
+        props.compiledPath.split('/').pop() || 'pipeline.kale.py';
+      const blob = new Blob([props.compiledContent], { type: 'text/plain' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = fileName;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }
+  };
+
   // Handle close click safely
   const handleCloseClick = () => {
     if (props.onRemove) {
@@ -215,6 +232,11 @@ export const DeployProgress: React.FunctionComponent<
             style={{ color: DeployUtils.color.success, height: 18, width: 18 }}
           />
         </a>
+        <GetAppIcon
+          style={{ height: 18, width: 18, cursor: 'pointer', marginLeft: 4 }}
+          titleAccess="Download compiled file"
+          onClick={handleDownloadClick}
+        />
       </React.Fragment>
     );
   } else if (props.compiledPath === 'error') {

--- a/labextension/src/widgets/deploys-progress/DeploysProgress.tsx
+++ b/labextension/src/widgets/deploys-progress/DeploysProgress.tsx
@@ -36,6 +36,7 @@ export type DeployProgressState = {
   // snapshotWarnings?: any;
   showCompileProgress?: boolean;
   compiledPath?: string;
+  compiledContent?: string;
   compileWarnings?: string[];
   showUploadProgress?: boolean;
   pipeline?: boolean | UploadPipelineResp;
@@ -82,6 +83,7 @@ export const DeploysProgress: React.FunctionComponent<
             // snapshotWarnings={dpState.snapshotWarnings}
             showCompileProgress={dpState.showCompileProgress}
             compiledPath={dpState.compiledPath}
+            compiledContent={dpState.compiledContent}
             compileWarnings={dpState.compileWarnings}
             showUploadProgress={dpState.showUploadProgress}
             pipeline={dpState.pipeline}


### PR DESCRIPTION


- Added a "Download" button with icon next to the "Done" status after compilation, allowing users to download the compiled .kale.py file directly from the progress panel

