### PR TITLE
remove `default` `version_name` because it is never used

### DIFF
--- a/backend/kale/common/kfputils.py
+++ b/backend/kale/common/kfputils.py
@@ -178,12 +178,9 @@ def run_pipeline(
     pipeline_name = pipeline.display_name
 
     try:
-        if version_id:
-            version_name = client.get_pipeline_version(
-                pipeline_id=pipeline_id, pipeline_version_id=version_id
-            ).display_name
-        else:
-            version_name = "default"
+        version_name = client.get_pipeline_version(
+            pipeline_id=pipeline_id, pipeline_version_id=version_id
+        ).display_name
     except Exception:
         log.debug("Could not retrieve pipeline version with ID '%s'. Using 'unknown'.", version_id)
         version_name = "unknown"


### PR DESCRIPTION
I did further testing of the pipeline-naming behavior addressed in #514, with help from Claude Code.

I found that in the case of a pipeline being triggered by the kale UI, it will have
`run_name = {pipeline_name}-{version_name}-{random_string}`

The `pipeline_name` is retrieved from the pipeline metadata. If a user provides a pipeline name in the left-hand kale panel, it will pull that. Otherwise, it will use the name of the notebook as the pipeline name.

The `version_name` is retrieved from the KFP API, or assigned to be "unknown" if the API call fails. There are three possible scenarios:
- First upload of a new pipeline
      - when a pipeline is new, KFP automatically creates an initial version, and sets the `version_name` = `pipeline_name`
      - in the Titanic example, the run name will be `titanic-ml-titanic-ml-a1b2c`
- Subsequent uploads of an existing pipeline 
      - when a pipeline already exists, kale generates `version_name` as a `random_string`
      - the run name will be `titanic-ml-n9s7l-m3t1s`
- API Failure / Error Scenario
      - if an Exception is thrown for any reason, kale is still able to compile and run the pipeline, but it will assign `version_name = unknown` 
      - (see code at `backend/kale/common/kfputils.py:184-186`)
      - the run name will be `titanic-ml-unknown-h1m3t`

The `default` scenario from #514 is never reached, as that requires that 
1. the `version_id` didn't exist (not possible with normal UI flow, because it is always either `pipeline_name` or `random_string`, and
2. there was no exception thrown (we would expect an exception if the code failed to provide `version_id` for some reason)

Thus, this PR cleans out that unused code, and documents the naming conventions for the pipelines.
