### PR TITLE
fix(examples): update data URLs to official kubeflow/kale repo

### DIFF
--- a/examples/openvaccine-kaggle-competition/open-vaccine.ipynb
+++ b/examples/openvaccine-kaggle-competition/open-vaccine.ipynb
@@ -170,11 +170,7 @@
     ]
    },
    "outputs": [],
-   "source": [
-    "train_url = \"https://raw.githubusercontent.com/kubeflow-kale/kale/refs/heads/main/examples/openvaccine-kaggle-competition/data/train.json\"\n",
-    "train_df = pd.read_json(train_url, lines = True)\n",
-    "train_df.head()"
-   ]
+   "source": "train_url = \"https://raw.githubusercontent.com/kubeflow/kale/refs/heads/main/examples/openvaccine-kaggle-competition/data/train.json\"\ntrain_df = pd.read_json(train_url, lines = True)\ntrain_df.head()"
   },
   {
    "cell_type": "code",
@@ -183,11 +179,7 @@
     "tags": []
    },
    "outputs": [],
-   "source": [
-    "test_url = \"https://raw.githubusercontent.com/kubeflow-kale/kale/refs/heads/main/examples/openvaccine-kaggle-competition/data/test.json\"\n",
-    "test_df = pd.read_json(test_url, lines = True)\n",
-    "test_df.head()"
-   ]
+   "source": "test_url = \"https://raw.githubusercontent.com/kubeflow/kale/refs/heads/main/examples/openvaccine-kaggle-competition/data/test.json\"\ntest_df = pd.read_json(test_url, lines = True)\ntest_df.head()"
   },
   {
    "cell_type": "markdown",

--- a/examples/titanic-ml-dataset/titanic_dataset_ml.ipynb
+++ b/examples/titanic-ml-dataset/titanic_dataset_ml.ipynb
@@ -79,11 +79,7 @@
     ]
    },
    "outputs": [],
-   "source": [
-    "train_url = \"https://raw.githubusercontent.com/hmtosi/kale/refs/heads/main/examples/titanic-ml-dataset/data/train.csv\"\n",
-    "train_df = pd.read_csv(train_url)\n",
-    "train_df.head()"
-   ]
+   "source": "train_url = \"https://raw.githubusercontent.com/kubeflow/kale/refs/heads/main/examples/titanic-ml-dataset/data/train.csv\"\ntrain_df = pd.read_csv(train_url)\ntrain_df.head()"
   },
   {
    "cell_type": "code",
@@ -92,11 +88,7 @@
     "tags": []
    },
    "outputs": [],
-   "source": [
-    "test_url = \"https://raw.githubusercontent.com/hmtosi/kale/refs/heads/main/examples/titanic-ml-dataset/data/test.csv\"\n",
-    "test_df = pd.read_csv(test_url)\n",
-    "test_df.head()"
-   ]
+   "source": "test_url = \"https://raw.githubusercontent.com/kubeflow/kale/refs/heads/main/examples/titanic-ml-dataset/data/test.csv\"\ntest_df = pd.read_csv(test_url)\ntest_df.head()"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary
- Titanic example pointed to `hmtosi/kale` (a contributor's fork) instead of the official repo
- OpenVaccine example pointed to `kubeflow-kale/kale` (old org before repo transfer)
- Both now point to `kubeflow/kale`

## Changes
- `examples/titanic-ml-dataset/titanic_dataset_ml.ipynb`: 2 URLs updated
- `examples/openvaccine-kaggle-competition/open-vaccine.ipynb`: 2 URLs updated


@jesuino @ederign @ada333 