### PR TITLE
Add DCO signoff to automated version bump PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -282,3 +282,4 @@ jobs:
           title: "Bump dev version to ${{ steps.next.outputs.next }}"
           body: "Automated version bump after releasing v${{ needs.prepare.outputs.version }}."
           committer: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          signoff: true


### PR DESCRIPTION
## Summary
- Adds `signoff: true` to the `peter-evans/create-pull-request` action in the release workflow
- Fixes DCO check failures on automated version bump PRs (e.g. #691)

## Test plan
- [ ] Trigger a dry-run release and verify the bump PR commit includes `Signed-off-by` trailer