### PR TITLE
Bump dev version to 2.0.0a5

### DIFF
--- a/kale/__init__.py
+++ b/kale/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.0.0a4"
+__version__ = "2.0.0a5"
 
 from typing import Any, NamedTuple
 

--- a/labextension/package.json
+++ b/labextension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-kubeflow-kale",
-  "version": "2.0.0-alpha.4",
+  "version": "2.0.0-alpha.5",
   "description": "Convert Notebooks to Kubeflow pipelines with Kale",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
## Summary
- Bumps dev version to 2.0.0a5 after releasing v2.0.0a4

Replaces #691, which was automatically created by the `peter-evans/create-pull-request` action without a `Signed-off-by` trailer, causing the DCO check to fail. The release workflow's `bump-dev-version` job did not have `signoff: true` set on the action. This PR contains the same changes with a proper DCO sign-off.

The root cause fix is in #692.

Closes #691