### PR TITLE
docs: add docstring to __default_execution_handler in step.py

### DIFF
--- a/kale/step.py
+++ b/kale/step.py
@@ -193,6 +193,23 @@ class Step:
 
 
 def __default_execution_handler(step: Step, *args, **kwargs):
+    """Default handler for executing a Step when no pipeline is registered.
+
+    Logs a warning and executes the step's source function directly if
+    it is callable. Raises a RuntimeError if the step was created from
+    a Notebook, as local execution is not supported in that case.
+
+    Args:
+        step (Step): The Step object to execute.
+        *args: Positional arguments passed to the step's source function.
+        **kwargs: Keyword arguments passed to the step's source function.
+
+    Returns:
+        Any: The return value of the step's source function.
+
+    Raises:
+        RuntimeError: If step source is not callable (e.g. from a Notebook).
+    """
     log.info("No Pipeline registration handler is set.")
     if not callable(step.source):
         raise RuntimeError(


### PR DESCRIPTION
Closes #622

Added missing docstring to __default_execution_handler  function in step.py to improve code documentation for  new contributors.

GSoC 2026 applicant interested in the Agentic RAG project.