### PR TITLE
Release v2.0.0rc1

### DIFF
--- a/kale/__init__.py
+++ b/kale/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.0.0a6"
+__version__ = "2.0.0rc1"
 
 from typing import Any, NamedTuple
 

--- a/labextension/package.json
+++ b/labextension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-kubeflow-kale",
-  "version": "2.0.0-alpha.6",
+  "version": "2.0.0-rc.1",
   "description": "Convert Notebooks to Kubeflow pipelines with Kale",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
Summary
---

- Bump version from `2.0.0a6` to `2.0.0rc1` (first release candidate)
- Updates both `kale/__init__.py` and `labextension/package.json`

Post-merge
---

- Tag `v2.0.0rc1` on the merge commit
- Trigger release workflow
