### PR TITLE
ISSUE-736: Change cancel to OK in Cache Dialog

### DIFF
--- a/labextension/src/widgets/cell-metadata/CellMetadataEditor.tsx
+++ b/labextension/src/widgets/cell-metadata/CellMetadataEditor.tsx
@@ -753,7 +753,7 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
           </DialogContent>
           <DialogActions>
             <Button onClick={() => this.toggleCacheDialog()} color="primary">
-              Close
+              Ok
             </Button>
           </DialogActions>
         </Dialog>


### PR DESCRIPTION
#736 
This super easy fix just makes user experience little better and the CellMetadataEditor dialogs consistent. It changes "Cancel" to "OK" in cache dialog

<img width="1415" height="607" alt="image" src="https://github.com/user-attachments/assets/091bdfab-fcb5-483f-96ee-fd552c4c5011" />
