### PR TITLE
Checking KFP version to add security context if supported

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,9 +12,15 @@ on:
   pull_request:
   # for testing
   workflow_dispatch:
+    inputs:
+      kfp_version:
+        description: 'KFP version to install'
+        required: false
+        default: '2.16.0'
+        type: string
 
 env:
-  KFP_VERSION: "2.16.0"
+  KFP_VERSION: ${{ inputs.kfp_version || '2.16.0' }}
   PYTHON_VERSION: "3.12"
 
 jobs:

--- a/kale/common/kfputils.py
+++ b/kale/common/kfputils.py
@@ -327,8 +327,12 @@ def load_mlpipeline_metrics(output):
 
 def get_kfp_host():
     """Get the KFP host URL from the client."""
-    client = _get_kfp_client()
-    return getattr(client, "_uihost", None) or getattr(client, "host", None)
+    try:
+        client = _get_kfp_client()
+        return getattr(client, "_uihost", None) or getattr(client, "host", None)
+    except Exception as e:
+        log.warning("Failed to get KFP host: %s", e)
+        return None
 
 
 def get_experiment_from_run_id(run_id: str):

--- a/kale/common/kfputils.py
+++ b/kale/common/kfputils.py
@@ -65,7 +65,7 @@ def get_kfp_server_version(host: str) -> str | None:
         response.raise_for_status()
         data = response.json()
         return data.get("apiServerTagName")
-    except (requests.RequestException, ValueError, KeyError) as e:
+    except Exception as e:
         log.warning("Failed to fetch KFP server version from %s: %s", healthz_url, e)
         return None
 

--- a/kale/common/kfputils.py
+++ b/kale/common/kfputils.py
@@ -25,6 +25,8 @@ from typing import Any
 
 import kfp
 from kfp_server_api.exceptions import ApiException
+from packaging.version import Version
+import requests
 
 from kale.common import utils
 
@@ -42,6 +44,56 @@ log = logging.getLogger(__name__)
 
 def _get_kfp_client(host=None, namespace: str = "kubeflow"):
     return kfp.Client(host=host, namespace=namespace)
+
+
+def get_kfp_server_version(host: str) -> str | None:
+    """Fetch the KFP server version from the healthz endpoint.
+
+    Args:
+        host: The KFP host URL (e.g., http://localhost:8080)
+
+    Returns:
+        The KFP server version string (apiServerTagName), or None if unavailable
+    """
+    print(f"Fetching KFP server version from host: {host}")
+    if not host:
+        return None
+
+    healthz_url = f"{host.rstrip('/')}/apis/v2beta1/healthz"
+    try:
+        response = requests.get(healthz_url, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        return data.get("apiServerTagName")
+    except (requests.RequestException, ValueError, KeyError) as e:
+        log.warning("Failed to fetch KFP server version from %s: %s", healthz_url, e)
+        return None
+
+
+def supports_security_context(host: str) -> bool:
+    """Check if the KFP server supports security_context (version > 2.16).
+
+    Args:
+        host: The KFP host URL
+
+    Returns:
+        True if KFP version is greater than 2.16, False otherwise
+    """
+    version_str = get_kfp_server_version(host)
+    if not version_str:
+        # If we can't determine the version, assume it's supported to avoid blocking users with newer versions
+        return True
+
+    try:
+        # Handle version strings that may have prefixes like 'v' or suffixes
+        clean_version = version_str.lstrip("v").split("-")[0]
+        kfp_version = Version(clean_version)
+        min_version = Version("2.16")
+        return kfp_version > min_version
+    except Exception as e:
+        log.warning("Failed to parse KFP version '%s': %s", version_str, e)
+        # Assume it is supported if we can't parse the version, to avoid blocking users with newer versions
+        return True
 
 
 def get_pipeline_id(pipeline_name: str, host: str = None) -> str:
@@ -271,6 +323,12 @@ def load_mlpipeline_metrics(output):
             _kale_kfp_metrics = json.load(_kale_mf)
             for _metric_name, _metric_value in _kale_kfp_metrics.items():
                 output.log_metric(_metric_name, _metric_value)
+
+
+def get_kfp_host():
+    """Get the KFP host URL from the client."""
+    client = _get_kfp_client()
+    return getattr(client, "_uihost", None) or getattr(client, "host", None)
 
 
 def get_experiment_from_run_id(run_id: str):

--- a/kale/compiler.py
+++ b/kale/compiler.py
@@ -252,6 +252,10 @@ class Compiler:
             for step in self.pipeline.steps:
                 component_names[step.name] = step.name.replace("_", "-")
 
+        supports_security_context = kfputils.supports_security_context(
+            self.pipeline.config.kfp_host or kfputils.get_kfp_host()
+        )
+
         pipeline_code = template.render(
             pipeline=self.pipeline,
             lightweight_components=lightweight_components,
@@ -260,6 +264,7 @@ class Compiler:
             step_inputs_sources=step_inputs_sources,
             pipeline_param_info=pipeline_param_info,
             component_names=component_names,
+            supports_security_context=supports_security_context,
             **self.pipeline.config.to_dict(),
         )
         # fix code style using pep8 guidelines

--- a/kale/rpc/kfp.py
+++ b/kale/rpc/kfp.py
@@ -42,9 +42,7 @@ def list_experiments(request):
 
 def get_ui_host(request):
     """Get a UI Host. If it does not exist return None."""
-    c = _get_client()
-    host = getattr(c, "_uihost", None) or getattr(c, "host", None)
-    return host
+    return kfputils.get_kfp_host()
 
 
 def get_experiment(request, experiment_name):

--- a/kale/templates/pipeline_template.jinja2
+++ b/kale/templates/pipeline_template.jinja2
@@ -1,7 +1,9 @@
 import json
 import kfp.dsl as kfp_dsl
 from kfp.dsl import Input, Output, Dataset, HTML, Metrics, Artifact, Model
+{% if supports_security_context %}
 from kfp.kubernetes import security_context
+{% endif %}
 
 {{ lightweight_components | join('\n\n') }}
 
@@ -31,12 +33,14 @@ def auto_generated_pipeline(
     {%- endif %}
     )
 
+{% if supports_security_context %}
     security_context.set_security_context(
         task={{ step.name }}_task,
         run_as_user=65534,
         run_as_group=0,
         run_as_non_root=True
     )
+{% endif %}
     {{ step.name }}_task.set_env_variable(name="HOME", value="/tmp")
 
     {% if loop.index0 > 0 %}

--- a/kale/tests/assets/kfp_dsl/iris.py
+++ b/kale/tests/assets/kfp_dsl/iris.py
@@ -1,6 +1,7 @@
 import json
 import kfp.dsl as kfp_dsl
 from kfp.dsl import Input, Output, Dataset, HTML, Metrics, Artifact, Model
+
 from kfp.kubernetes import security_context
 
 
@@ -300,6 +301,7 @@ def auto_generated_pipeline(
         run_as_group=0,
         run_as_non_root=True
     )
+
     load_transform_data_task.set_env_variable(name="HOME", value="/tmp")
 
     load_transform_data_task.set_display_name("load-transform-data-step")
@@ -318,6 +320,7 @@ def auto_generated_pipeline(
         run_as_group=0,
         run_as_non_root=True
     )
+
     train_model_task.set_env_variable(name="HOME", value="/tmp")
 
     train_model_task.after(load_transform_data_task)
@@ -340,6 +343,7 @@ def auto_generated_pipeline(
         run_as_group=0,
         run_as_non_root=True
     )
+
     evaluate_model_task.set_env_variable(name="HOME", value="/tmp")
 
     evaluate_model_task.after(train_model_task)

--- a/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
+++ b/kale/tests/assets/kfp_dsl/pipeline_parameters_and_metrics.py
@@ -1,6 +1,7 @@
 import json
 import kfp.dsl as kfp_dsl
 from kfp.dsl import Input, Output, Dataset, HTML, Metrics, Artifact, Model
+
 from kfp.kubernetes import security_context
 
 
@@ -177,6 +178,7 @@ def auto_generated_pipeline(
         run_as_group=0,
         run_as_non_root=True
     )
+
     create_matrix_task.set_env_variable(name="HOME", value="/tmp")
 
     create_matrix_task.set_display_name("create-matrix-step")
@@ -198,6 +200,7 @@ def auto_generated_pipeline(
         run_as_group=0,
         run_as_non_root=True
     )
+
     sum_matrix_task.set_env_variable(name="HOME", value="/tmp")
 
     sum_matrix_task.after(create_matrix_task)

--- a/kale/tests/e2e/test_e2e.py
+++ b/kale/tests/e2e/test_e2e.py
@@ -37,8 +37,9 @@ EXAMPLES_DIR = os.path.join(THIS_DIR, "../../../examples/")
     ],
 )
 @mock.patch("kale.compiler.KALE_VERSION", new="0+unknown")
+@mock.patch("kale.common.kfputils.supports_security_context", return_value=True)
 @mock.patch("kale.common.utils.random_string")
-def test_notebook_to_dsl(random_string, notebook_path, dsl_path):
+def test_notebook_to_dsl(random_string, mock_supports_security_context, notebook_path, dsl_path):
     """Test code generation end to end from notebook to DSL."""
     random_string.return_value = "rnd"
 


### PR DESCRIPTION
closes #721 


**Overview**
This PR adds dynamic detection of the Kubeflow Pipelines (KFP) server version to conditionally apply security context settings only when the KFP version supports it (v2.16+).

Key Changes

1. KFP Version Detection 
Added get_kfp_server_version(host) - fetches KFP version from the /healthz endpoint
Added supports_security_context(host) - returns True if KFP version > 2.16
Added get_kfp_host() - retrieves KFP host URL from client configuration

2. Conditional Security Context
The compiler now checks if the KFP server supports security context before generating pipelines
Template conditionally imports and applies security_context.set_security_context() only when supported

3. Code Refactoring 
Refactored get_ui_host() to use the new centralized kfputils.get_kfp_host() method

4. CI/CD Enhancement
Added kfp_version input parameter for workflow dispatch to enable testing with different KFP versions

5. Test Updates

Added mock for supports_security_context to ensure tests pass with security context enabled

**Why This Matters**

This change ensures backward compatibility with older KFP versions that don't support the security context feature, while still enabling it for newer versions.