### PR TITLE
Fix log in web console and delete non existing RPC call to backend

### DIFF
--- a/labextension/src/lib/Commands.ts
+++ b/labextension/src/lib/Commands.ts
@@ -17,7 +17,6 @@ import { NotebookPanel } from '@jupyterlab/notebook';
 import {
   _legacy_executeRpc,
   _legacy_executeRpcAndShowRPCError,
-  RPCError,
 } from './RPCUtils';
 
 import { DeployProgressState, RunPipeline } from '../widgets/deploys-progress/DeploysProgress';
@@ -88,26 +87,8 @@ export default class Commands {
     const cmd: string =
       'from kale.rpc.nb import unmarshal_data as __kale_rpc_unmarshal_data\n' +
       `locals().update(__kale_rpc_unmarshal_data("${nbFileName}"))`;
-    console.log('Executing command: ' + cmd);
+    console.debug('Executing command: ' + cmd);
     await NotebookUtils.sendKernelRequestFromNotebook(this._notebook, cmd, {});
-  };
-
-  getBaseImage = async () => {
-    let baseImage: string | null = null;
-    try {
-      baseImage = await _legacy_executeRpc(
-        this._notebook,
-        this._kernel,
-        'nb.get_base_image',
-      );
-    } catch (error) {
-      if (error instanceof RPCError) {
-        console.warn('Kale is not running in a Notebook Server', error.error);
-      } else {
-        throw error;
-      }
-    }
-    return baseImage;
   };
 
   getDefaultBaseImage = async (): Promise<string> => {
@@ -435,7 +416,10 @@ export default class Commands {
         'nb.get_namespace',
       );
     } catch (error) {
-      console.error("Failed to retrieve notebook's namespace");
+      console.warn(
+        "Could not detect the notebook's namespace. " +
+        'Pipeline and run links may not include the correct namespace parameter.'
+      );
       return '';
     }
   };

--- a/labextension/src/lib/RPCUtils.tsx
+++ b/labextension/src/lib/RPCUtils.tsx
@@ -151,7 +151,7 @@ export const executeRpc = async (
     `__kale_rpc_result = __kale_rpc_run("${func}", '${serialize(
       kwargs
     )}', '${serialize(ctx)}')`;
-  console.log('Executing command: ' + cmd);
+  console.debug('Executing command: ' + cmd);
   const expressions = { result: '__kale_rpc_result' };
   let output: any = null;
   try {

--- a/labextension/src/widgets/LeftPanel.tsx
+++ b/labextension/src/widgets/LeftPanel.tsx
@@ -354,14 +354,6 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
         if (nbFilePath) {
           await commands.resumeStateIfExploreNotebook(nbFilePath);
         }
-        // Detect the base image of the current Notebook Server
-        const baseImage = await commands.getBaseImage();
-        if (baseImage) {
-          DefaultState.metadata.base_image = baseImage;
-        } else {
-          DefaultState.metadata.base_image = '';
-        }
-
         // Get experiment information last because it may take more time to respond
         this.setState({ gettingExperiments: true });
         const { experiments, experiment, experiment_name } =


### PR DESCRIPTION
this PR solves #749  - 

1. deletes non-existent RPC getBaseImage call that threw warning everytime Kale was turned on
2. turns error to warning when there is no Kubeflow namespace found, and makes better log message
3. makes all the RPC command logs only in debug mode -> this was filling up console with nonsense logs

Before:
<img width="1276" height="551" alt="Screenshot From 2026-04-09 13-39-08" src="https://github.com/user-attachments/assets/17334b4c-3ea3-4cbf-84b6-d916c12d9d7c" />


After:
<img width="1053" height="720" alt="Screenshot From 2026-04-13 12-58-54" src="https://github.com/user-attachments/assets/99357876-e460-4d0b-af27-5e5810300ba9" />
