### PR TITLE
Remove stale CLI entrypoints kale_server and kale-volumes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,6 @@ authors = [
 
 [project.scripts]
 kale = "kale.cli:main"
-kale_server = "kale.cli:server"
-kale-volumes = "kale.cli:kale_volumes"
 
 [project.urls]
 Homepage = "https://github.com/kubeflow/kale"


### PR DESCRIPTION
These entrypoints reference functions that no longer exist in kale/cli.py and are not used anywhere in the codebase.