### PR TITLE
Remove deprecated `block:` cell tag

### DIFF
--- a/examples/openvaccine-kaggle-competition/open-vaccine.ipynb
+++ b/examples/openvaccine-kaggle-competition/open-vaccine.ipynb
@@ -672,7 +672,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "block:"
+     "step:"
     ]
    },
    "outputs": [],

--- a/kale/processors/nbprocessor.py
+++ b/kale/processors/nbprocessor.py
@@ -33,13 +33,7 @@ SKIP_TAG = r"^skip$"
 IMPORT_TAG = r"^imports$"
 FUNCTIONS_TAG = r"^functions$"
 PREV_TAG = r"^prev:[_a-z]([_a-z0-9]*)?$"
-# `step` has the same functionality as `block` and is
-# supposed to be the new name
 STEP_TAG = r"^step:([_a-z]([_a-z0-9]*)?)?$"
-# Extension may end up with 'block:' as a tag. We handle
-# that as if it was empty.
-# TODO: Deprecate `block` tag in future release
-BLOCK_TAG = r"^block:([_a-z]([_a-z0-9]*)?)?$"
 PIPELINE_PARAMETERS_TAG = r"^pipeline-parameters$"
 PIPELINE_METRICS_TAG = r"^pipeline-metrics$"
 # Annotations map to actual pod annotations that can be set via KFP SDK
@@ -64,7 +58,6 @@ _TAGS_LANGUAGE = [
     IMPORT_TAG,
     FUNCTIONS_TAG,
     PREV_TAG,
-    BLOCK_TAG,
     STEP_TAG,
     PIPELINE_PARAMETERS_TAG,
     PIPELINE_METRICS_TAG,
@@ -503,7 +496,7 @@ class NotebookProcessor:
         if not parsed_tags["step_names"] and parsed_tags["prev_steps"]:
             raise ValueError(
                 "A cell can not provide `prev` annotations without "
-                "providing a `block` or `step` annotation as well"
+                "providing a `step` annotation as well"
             )
         missing_step_names = not parsed_tags["step_names"]
         if cell_annotations:

--- a/labextension/src/lib/CellUtils.ts
+++ b/labextension/src/lib/CellUtils.ts
@@ -510,7 +510,7 @@ export default class CellUtilities {
       this.getCellMetaData(notebook.content, index, 'tags') || []
     )
       .filter((t: string) => !t.startsWith('prev:'))
-      .map((t: string) => t.replace('block:', ''));
+      .map((t: string) => t.replace('step:', ''));
     return names.length > 0 ? names[0] : '';
   }
 

--- a/labextension/src/lib/NotebookUtils.tsx
+++ b/labextension/src/lib/NotebookUtils.tsx
@@ -328,12 +328,12 @@ export default class NotebookUtilities {
       if (!cellModel || !isCodeCellModel(cellModel)) {
         continue;
       }
-      const blockName = CellUtilities.getStepName(notebook, i);
+      const stepName = CellUtilities.getStepName(notebook, i);
       // If a cell of that type is found, run that
       // and all consequent cells getting merged to that one
       if (
-        !reservedCellsToBeIgnored.includes(blockName) &&
-        RESERVED_CELL_NAMES.includes(blockName)
+        !reservedCellsToBeIgnored.includes(stepName) &&
+        RESERVED_CELL_NAMES.includes(stepName)
       ) {
         while (i < notebook.model.cells.length) {
           const currentCellModel = notebook.model.cells.get(i);
@@ -342,7 +342,7 @@ export default class NotebookUtilities {
             continue;
           }
           const cellName = CellUtilities.getStepName(notebook, i);
-          if (cellName !== blockName && cellName !== '') {
+          if (cellName !== stepName && cellName !== '') {
             // Decrement by 1 to parse that cell during the next for loop
             i--;
             break;
@@ -360,7 +360,7 @@ export default class NotebookUtilities {
             if (kernelMsg.content && kernelMsg.content.status === 'error') {
               return {
                 status: 'error',
-                cellType: blockName,
+                cellType: stepName,
                 cellIndex: i,
                 ename: kernelMsg.content.ename,
                 evalue: kernelMsg.content.evalue,
@@ -369,7 +369,7 @@ export default class NotebookUtilities {
           } catch (error) {
             return {
               status: 'error',
-              cellType: blockName,
+              cellType: stepName,
               cellIndex: i,
               ename: 'ExecutionError',
               evalue: String(error),

--- a/labextension/src/lib/TagsUtils.ts
+++ b/labextension/src/lib/TagsUtils.ts
@@ -21,8 +21,8 @@ const CACHE_TAG = 'cache:';
 const CACHE_ENABLED_VALUE = 'enabled';
 
 interface IKaleCellTags {
-  blockName: string;
-  prevBlockNames: string[];
+  stepName: string;
+  prevStepNames: string[];
   limits?: { [id: string]: string };
   baseImage?: string;
   enableCaching?: boolean;
@@ -31,26 +31,25 @@ interface IKaleCellTags {
 /** Contains utility functions for manipulating/handling Kale cell tags. */
 export default class TagsUtils {
   /**
-   * Get all the `block:<name>` tags in the notebook.
+   * Get all the `step:<name>` tags in the notebook.
    * @param notebook Notebook object
-   * @returns Array<str> - a list of the block names (i.e. the pipeline steps'
-   *  names)
+   * @returns Array<str> - a list of the pipeline step names
    */
-  public static getAllBlocks(notebook: Notebook, cellIndex: number = -1): string[] {
+  public static getAllSteps(notebook: Notebook, cellIndex: number = -1): string[] {
     if (!notebook.model) {
       return [];
     }
-    const blocks = new Set<string>();
+    const steps = new Set<string>();
     const toCell = cellIndex < 0 ? notebook.model.cells.length : cellIndex;
     // iterate through the notebook cells
     for (const idx of Array(toCell).keys()) {
       // get the tags of the current cell
       const mt = this.getKaleCellTags(notebook, idx);
-      if (mt && mt.blockName && mt.blockName !== '') {
-        blocks.add(mt.blockName);
+      if (mt && mt.stepName && mt.stepName !== '') {
+        steps.add(mt.stepName);
       }
     }
-    return Array.from(blocks);
+    return Array.from(steps);
   }
 
   /**
@@ -58,18 +57,18 @@ export default class TagsUtils {
    * tag
    * @param notebook The notebook object
    * @param current The index of the cell to start the search from
-   * @returns string - Name of the `block` tag of the closest previous cell
+   * @returns string - Name of the `step` tag of the closest previous cell
    */
-  public static getPreviousBlock(notebook: Notebook, current: number): string | undefined {
+  public static getPreviousStep(notebook: Notebook, current: number): string | undefined {
     for (let i = current - 1; i >= 0; i--) {
       const mt = this.getKaleCellTags(notebook, i);
       if (
         mt &&
-        mt.blockName &&
-        mt.blockName !== 'skip' &&
-        mt.blockName !== ''
+        mt.stepName &&
+        mt.stepName !== 'skip' &&
+        mt.stepName !== ''
       ) {
-        return mt.blockName;
+        return mt.stepName;
       }
     }
     return undefined;
@@ -130,8 +129,8 @@ export default class TagsUtils {
       }
 
       return {
-        blockName: b_name[0] || '',
-        prevBlockNames: prevs,
+        stepName: b_name[0] || '',
+        prevStepNames: prevs,
         limits: limits,
         baseImage: baseImage,
         enableCaching: enableCaching,
@@ -153,12 +152,12 @@ export default class TagsUtils {
     metadata: IKaleCellTags
   ): Promise<any> {
     // make the dict to save to tags
-    let nb = metadata.blockName;
+    let nb = metadata.stepName;
     // not a reserved name
-    if (!RESERVED_CELL_NAMES.includes(metadata.blockName)) {
+    if (!RESERVED_CELL_NAMES.includes(metadata.stepName)) {
       nb = 'step:' + nb;
     }
-    const stepDependencies = metadata.prevBlockNames || [];
+    const stepDependencies = metadata.prevStepNames || [];
     const limits = metadata.limits || {};
     const baseImage = metadata.baseImage;
     const tags = [nb]
@@ -181,18 +180,18 @@ export default class TagsUtils {
   }
 
   /**
-   * Parse the entire notebook cells to change a block name. This happens when
-   * the block name of a cell is changed by the user, using Kale's inline tag
+   * Parse the entire notebook cells to change a step name. This happens when
+   * the step name of a cell is changed by the user, using Kale's inline tag
    * editor. We need to parse the entire notebook because all the `prev` dependencies
    * specified in the cells must be bound to the new name.
    * @param notebookPanel NotebookPanel object
-   * @param oldBlockName previous block name
-   * @param newBlockName new block name
+   * @param oldStepName previous step name
+   * @param newStepName new step name
    */
   public static updateKaleCellsTags(
     notebookPanel: NotebookPanel,
-    oldBlockName: string,
-    newBlockName: string,
+    oldStepName: string,
+    newStepName: string,
   ) {
     let i: number;
     const allPromises = [];
@@ -206,10 +205,10 @@ export default class TagsUtils {
       // new one.
       const newTags: string[] = (tags || [])
         .map(t => {
-          if (t === 'prev:' + oldBlockName) {
-            return RESERVED_CELL_NAMES.includes(newBlockName)
+          if (t === 'prev:' + oldStepName) {
+            return RESERVED_CELL_NAMES.includes(newStepName)
               ? ''
-              : 'prev:' + newBlockName;
+              : 'prev:' + newStepName;
           } else {
             return t;
           }
@@ -224,7 +223,7 @@ export default class TagsUtils {
 
   /**
    * Clean up the Kale tags from a cell. After cleaning the cell, loop though
-   * the notebook to remove all occurrences of the deleted block name.
+   * the notebook to remove all occurrences of the deleted step name.
    * @param notebook NotebookPanel object
    * @param activeCellIndex The active cell index
    * @param stepName The old name of the active cell to be cleaned.
@@ -235,19 +234,19 @@ export default class TagsUtils {
     stepName: string,
   ) {
     const value = '';
-    const previousBlocks: string[] = [];
+    const previousSteps: string[] = [];
 
-    const oldBlockName: string = stepName;
+    const oldStepName: string = stepName;
     const cellMetadata = {
-      prevBlockNames: previousBlocks,
-      blockName: value,
+      prevStepNames: previousSteps,
+      stepName: value,
     };
     TagsUtils.setKaleCellTags(
       notebook,
       activeCellIndex,
       cellMetadata
     ).then(oldValue => {
-      TagsUtils.updateKaleCellsTags(notebook, oldBlockName, value);
+      TagsUtils.updateKaleCellsTags(notebook, oldStepName, value);
     });
   }
 
@@ -271,8 +270,8 @@ export default class TagsUtils {
       return;
     }
 
-    const allBlocks = this.getAllBlocks(notebook.content);
-    const allBlocksSet = new Set(allBlocks);
+    const allSteps = this.getAllSteps(notebook.content);
+    const allStepsSet = new Set(allSteps);
 
     for (let index = 0; index < cells.length; index++) {
       const kaleTags = this.getKaleCellTags(notebook.content, index);
@@ -280,14 +279,14 @@ export default class TagsUtils {
         continue;
       }
 
-      const newPrevBlockNames = kaleTags.prevBlockNames.filter(
-        dep => allBlocksSet.has(dep)
+      const newPrevStepNames = kaleTags.prevStepNames.filter(
+        dep => allStepsSet.has(dep)
       );
 
-      if (newPrevBlockNames.length !== kaleTags.prevBlockNames.length) {
+      if (newPrevStepNames.length !== kaleTags.prevStepNames.length) {
         const updatedMetadata = {
           ...kaleTags,
-          prevBlockNames: newPrevBlockNames,
+          prevStepNames: newPrevStepNames,
         };
 
         this.setKaleCellTags(notebook, index, updatedMetadata);

--- a/labextension/src/widgets/cell-metadata/CellMetadataEditor.tsx
+++ b/labextension/src/widgets/cell-metadata/CellMetadataEditor.tsx
@@ -93,18 +93,18 @@ export interface IProps {
   defaultBaseImage?: string;
 }
 
-// this stores the name of a block and its color (form the name hash)
-type BlockDependencyChoice = { value: string; color: string };
+// this stores the name of a step and its color (from the name hash)
+type StepDependencyChoice = { value: string; color: string };
 interface IState {
-  // used to store the closest preceding block name. Used in case the current
-  // block name is empty, to suggest merging to the previous one.
+  // used to store the closest preceding step name. Used in case the current
+  // step name is empty, to suggest merging to the previous one.
   previousStepName?: string;
   stepNameErrorMsg?: string;
-  // a list of blocks that the current step can be dependent on.
-  blockDependenciesChoices: BlockDependencyChoice[];
+  // a list of steps that the current step can be dependent on.
+  stepDependenciesChoices: StepDependencyChoice[];
   // flag to open the metadata editor dialog dialog
   // XXX (stefano): I would like to set this as required, but the return
-  // XXX (stefano): statement of updateBlockDependenciesChoices and
+  // XXX (stefano): statement of updateStepDependenciesChoices and
   // XXX (stefano): updatePreviousStepName don't allow me.
   cellMetadataEditorDialog: boolean;
   baseImageDialogOpen: boolean;
@@ -115,7 +115,7 @@ interface IState {
 const DefaultState: IState = {
   previousStepName: undefined,
   stepNameErrorMsg: STEP_NAME_ERROR_MSG,
-  blockDependenciesChoices: [],
+  stepDependenciesChoices: [],
   cellMetadataEditorDialog: false,
   baseImageDialogOpen: false,
   cacheDialogOpen: false,
@@ -136,9 +136,9 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
     // element.
     this.editorRef = React.createRef();
     this.state = DefaultState;
-    this.updateCurrentBlockName = this.updateCurrentBlockName.bind(this);
+    this.updateCurrentStepName = this.updateCurrentStepName.bind(this);
     this.updateCurrentCellType = this.updateCurrentCellType.bind(this);
-    this.updatePrevBlocksNames = this.updatePrevBlocksNames.bind(this);
+    this.updatePrevStepsNames = this.updatePrevStepsNames.bind(this);
     this.toggleTagsEditorDialog = this.toggleTagsEditorDialog.bind(this);
     this.toggleBaseImageDialog = this.toggleBaseImageDialog.bind(this);
   }
@@ -152,7 +152,7 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
 
   updateCurrentCellType = (value: string) => {
     if (RESERVED_CELL_NAMES.includes(value)) {
-      this.updateCurrentBlockName(value);
+      this.updateCurrentStepName(value);
     } else {
       TagsUtils.resetCell(
         this.props.notebook,
@@ -162,7 +162,7 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
     }
   };
 
-  isEqual(a: BlockDependencyChoice[], b: BlockDependencyChoice[]): boolean {
+  isEqual(a: StepDependencyChoice[], b: StepDependencyChoice[]): boolean {
     return JSON.stringify(a) === JSON.stringify(b);
   }
 
@@ -203,9 +203,9 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
   componentDidUpdate(prevProps: Readonly<IProps>, prevState: Readonly<IState>) {
     this.hideEditorIfNotCodeCell();
     this.moveEditor();
-    // this.setState(this.updateBlockDependenciesChoices);
+    // this.setState(this.updateStepDependenciesChoices);
     // this.setState(this.updatePreviousStepName);
-    const dependenciesState = this.updateBlockDependenciesChoices(
+    const dependenciesState = this.updateStepDependenciesChoices(
       this.state,
       this.props,
     );
@@ -242,35 +242,35 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
   }
 
   /**
-   * Scan the notebook for all block tags and get them all, excluded the current
-   * one (and the reserved cell tags) The value `previousBlockChoices` is used
+   * Scan the notebook for all step tags and get them all, excluded the current
+   * one (and the reserved cell tags) The value `previousStepChoices` is used
    * by the dependencies select option to select the current step's
    * dependencies.
    */
-  updateBlockDependenciesChoices(
+  updateStepDependenciesChoices(
     state: Readonly<IState>,
     props: Readonly<IProps>,
-  ): Pick<IState, 'blockDependenciesChoices'> | null {
+  ): Pick<IState, 'stepDependenciesChoices'> | null {
     if (!props.notebook) {
       return null;
     }
-    const allBlocks = TagsUtils.getAllBlocks(
+    const allSteps = TagsUtils.getAllSteps(
       props.notebook.content,
       this.context.activeCellIndex,
     );
-    const dependencyChoices: BlockDependencyChoice[] = allBlocks
+    const dependencyChoices: StepDependencyChoice[] = allSteps
       // remove all reserved names and current step name
       .filter(
         el => !RESERVED_CELL_NAMES.includes(el) && !(el === props.stepName),
       )
       .map(name => ({ value: name, color: `#${ColorUtils.getColor(name)}` }));
 
-    if (this.isEqual(state.blockDependenciesChoices, dependencyChoices)) {
+    if (this.isEqual(state.stepDependenciesChoices, dependencyChoices)) {
       return null;
     }
     // XXX (stefano): By setting state.cellMetadataEditorDialog NOT optional,
     // XXX (stefano): this return will require cellMetadataEditorDialog.
-    return { blockDependenciesChoices: dependencyChoices };
+    return { stepDependenciesChoices: dependencyChoices };
   }
 
   updatePreviousStepName(
@@ -280,30 +280,30 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
     if (!props.notebook) {
       return null;
     }
-    const prevBlockName = TagsUtils.getPreviousBlock(
+    const prevStepName = TagsUtils.getPreviousStep(
       props.notebook.content,
       this.context.activeCellIndex,
     );
-    if (prevBlockName === this.state.previousStepName) {
+    if (prevStepName === this.state.previousStepName) {
       return null;
     }
     // XXX (stefano): By setting state.cellMetadataEditorDialog NOT optional,
     // XXX (stefano): this return will require cellMetadataEditorDialog.
-    return { previousStepName: prevBlockName };
+    return { previousStepName: prevStepName };
   }
 
-  updateCurrentBlockName = (value: string) => {
-    const oldBlockName: string = this.props.stepName || '';
+  updateCurrentStepName = (value: string) => {
+    const oldStepName: string = this.props.stepName || '';
     const tags = TagsUtils.getKaleCellTags(
       this.props.notebook.content,
       this.context.activeCellIndex,
     );
     const currentCellMetadata = {
-      prevBlockNames: this.props.stepDependencies,
+      prevStepNames: this.props.stepDependencies,
       limits: this.props.limits || {},
       baseImage: this.props.baseImage,
       enableCaching: tags?.enableCaching,
-      blockName: value,
+      stepName: value,
     };
 
     TagsUtils.setKaleCellTags(
@@ -311,24 +311,24 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
       this.context.activeCellIndex,
       currentCellMetadata,
     ).then(() => {
-      TagsUtils.updateKaleCellsTags(this.props.notebook, oldBlockName, value);
+      TagsUtils.updateKaleCellsTags(this.props.notebook, oldStepName, value);
     });
   };
 
   /**
-   * Even handler of the MultiSelect used to select the dependencies of a block
+   * Event handler of the MultiSelect used to select the dependencies of a step
    */
-  updatePrevBlocksNames = (previousBlocks: string[]) => {
+  updatePrevStepsNames = (previousSteps: string[]) => {
     const tags = TagsUtils.getKaleCellTags(
       this.props.notebook.content,
       this.context.activeCellIndex,
     );
     const currentCellMetadata = {
-      blockName: this.props.stepName || '',
+      stepName: this.props.stepName || '',
       limits: this.props.limits || {},
       baseImage: this.props.baseImage,
       enableCaching: tags?.enableCaching,
-      prevBlockNames: previousBlocks,
+      prevStepNames: previousSteps,
     };
 
     TagsUtils.setKaleCellTags(
@@ -366,8 +366,8 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
       this.context.activeCellIndex,
     );
     const currentCellMetadata = {
-      blockName: this.props.stepName || '',
-      prevBlockNames: this.props.stepDependencies,
+      stepName: this.props.stepName || '',
+      prevStepNames: this.props.stepDependencies,
       limits: limits,
       baseImage: this.props.baseImage,
       enableCaching: tags?.enableCaching,
@@ -381,15 +381,15 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
   };
 
   /**
-   * Function called before updating the value of the block name input text
+   * Function called before updating the value of the step name input text
    * field. It acts as a validator.
    */
   onBeforeUpdate = (value: string) => {
     if (value === this.props.stepName) {
       return false;
     }
-    const blockNames = TagsUtils.getAllBlocks(this.props.notebook.content);
-    if (blockNames.includes(value)) {
+    const stepNames = TagsUtils.getAllSteps(this.props.notebook.content);
+    if (stepNames.includes(value)) {
       this.setState({ stepNameErrorMsg: 'This name already exists.' });
       return true;
     }
@@ -454,8 +454,8 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
       this.context.activeCellIndex,
     );
     const currentCellMetadata = {
-      blockName: this.props.stepName || '',
-      prevBlockNames: this.props.stepDependencies,
+      stepName: this.props.stepName || '',
+      prevStepNames: this.props.stepDependencies,
       limits: this.props.limits || {},
       baseImage: value || undefined,
       enableCaching: tags?.enableCaching,
@@ -470,8 +470,8 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
 
   updateEnableCaching = (value: boolean | undefined) => {
     const currentCellMetadata = {
-      blockName: this.props.stepName || '',
-      prevBlockNames: this.props.stepDependencies,
+      stepName: this.props.stepName || '',
+      prevStepNames: this.props.stepDependencies,
       limits: this.props.limits || {},
       baseImage: this.props.baseImage,
       enableCaching: value,
@@ -525,7 +525,7 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
               {cellType === 'step' ? (
                 <Input
                   label={'Step name'}
-                  updateValue={this.updateCurrentBlockName}
+                  updateValue={this.updateCurrentStepName}
                   value={this.props.stepName || ''}
                   regex={'^([_a-z]([_a-z0-9]*)?)?$'}
                   regexErrorMsg={this.state.stepNameErrorMsg}
@@ -541,7 +541,7 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
                   title={
                     !this.props.stepName || this.props.stepName.length === 0
                       ? 'Please enter a step name first'
-                      : this.state.blockDependenciesChoices.length === 0
+                      : this.state.stepDependenciesChoices.length === 0
                         ? 'No other steps available. Add more pipeline steps to create dependencies.'
                         : 'Select which steps this step depends on'
                   }
@@ -555,15 +555,15 @@ export class CellMetadataEditor extends React.Component<IProps, IState> {
                     }}
                   >
                     <SelectMulti
-                      id="select-previous-blocks"
+                      id="select-previous-steps"
                       label="Depends on"
                       disabled={
                         !(
                           this.props.stepName && this.props.stepName.length > 0
-                        ) || this.state.blockDependenciesChoices.length === 0
+                        ) || this.state.stepDependenciesChoices.length === 0
                       }
-                      updateSelected={this.updatePrevBlocksNames}
-                      options={this.state.blockDependenciesChoices}
+                      updateSelected={this.updatePrevStepsNames}
+                      options={this.state.stepDependenciesChoices}
                       variant="outlined"
                       selected={this.props.stepDependencies || []}
                     />

--- a/labextension/src/widgets/cell-metadata/InlineCellMetadata.tsx
+++ b/labextension/src/widgets/cell-metadata/InlineCellMetadata.tsx
@@ -47,7 +47,7 @@ type Editors = { [index: string]: EditorProps };
 
 interface IState {
   activeCellIndex: number;
-  prevBlockName?: string;
+  prevStepName?: string;
   metadataCmp?: React.ReactPortal[];
   checked?: boolean;
   editors?: Editors;
@@ -56,7 +56,7 @@ interface IState {
 
 const DefaultState: IState = {
   activeCellIndex: 0,
-  prevBlockName: undefined,
+  prevStepName: undefined,
   metadataCmp: [],
   checked: false,
   editors: {},
@@ -275,22 +275,22 @@ export class InlineCellsMetadata extends React.Component<IProps, IState> {
       let tags = TagsUtils.getKaleCellTags(this.props.notebook.content, index);
       if (!tags) {
         tags = {
-          blockName: '',
-          prevBlockNames: [],
+          stepName: '',
+          prevStepNames: [],
         };
       }
-      let previousBlockName: string | undefined = '';
+      let previousStepName: string | undefined = '';
 
-      if (!tags.blockName) {
-        previousBlockName = TagsUtils.getPreviousBlock(
+      if (!tags.stepName) {
+        previousStepName = TagsUtils.getPreviousStep(
           this.props.notebook.content,
           index,
         );
       }
       editors[index] = {
         notebook: this.props.notebook,
-        stepName: tags.blockName || '',
-        stepDependencies: tags.prevBlockNames || [],
+        stepName: tags.stepName || '',
+        stepDependencies: tags.prevStepNames || [],
         limits: tags.limits || {},
         baseImage: tags.baseImage,
         enableCaching: tags.enableCaching,
@@ -321,12 +321,12 @@ export class InlineCellsMetadata extends React.Component<IProps, IState> {
         <InlineMetadata
           key={index}
           cellElement={cellElement}
-          blockName={tags.blockName}
-          stepDependencies={tags.prevBlockNames}
+          stepName={tags.stepName}
+          stepDependencies={tags.prevStepNames}
           limits={tags.limits || {}}
           baseImage={tags.baseImage}
           enableCaching={tags.enableCaching}
-          previousBlockName={previousBlockName}
+          previousStepName={previousStepName}
           cellIndex={index}
           pipelineBaseImage={this.props.pipelineBaseImage}
           defaultBaseImage={this.props.defaultBaseImage}

--- a/labextension/src/widgets/cell-metadata/InlineMetadata.tsx
+++ b/labextension/src/widgets/cell-metadata/InlineMetadata.tsx
@@ -24,8 +24,8 @@ import EditIcon from '@mui/icons-material/Edit';
 import { CellMetadataContext } from '../../lib/CellMetadataContext';
 
 interface IProps {
-  blockName: string;
-  previousBlockName?: string;
+  stepName: string;
+  previousStepName?: string;
   stepDependencies: string[];
   limits: { [id: string]: string };
   baseImage?: string;
@@ -111,8 +111,8 @@ export class InlineMetadata extends React.Component<IProps, IState> {
     }
 
     if (
-      prevProps.blockName !== this.props.blockName ||
-      prevProps.previousBlockName !== this.props.previousBlockName
+      prevProps.stepName !== this.props.stepName ||
+      prevProps.previousStepName !== this.props.previousStepName
     ) {
       this.updateStyles();
     }
@@ -147,7 +147,7 @@ export class InlineMetadata extends React.Component<IProps, IState> {
   updateIsMergedState = (state: IState, props: IProps) => {
     let newIsMergedCell = false;
     const cellElement = props.cellElement;
-    if (!props.blockName) {
+    if (!props.stepName) {
       newIsMergedCell = true;
 
       // TODO: This is a side effect, consider moving it somewhere else.
@@ -168,13 +168,13 @@ export class InlineMetadata extends React.Component<IProps, IState> {
   };
 
   /**
-   * Check if the block tag of che current cell has a reserved name. If so,
+   * Check if the step tag of the current cell has a reserved name. If so,
    * apply the corresponding css class to the HTML Cell element.
    */
   checkIfReservedName() {
     this.setState((state: IState, props: IProps) => {
       let cellTypeClass = '';
-      if (RESERVED_CELL_NAMES.includes(props.blockName)) {
+      if (RESERVED_CELL_NAMES.includes(props.stepName)) {
         cellTypeClass = 'kale-reserved-cell';
       }
 
@@ -187,13 +187,13 @@ export class InlineMetadata extends React.Component<IProps, IState> {
 
   /**
    * Update the style of the active cell, by changing the left border with
-   * the correct color, based on the current block name.
+   * the correct color, based on the current step name.
    */
   updateStyles() {
     if (!isDOMElement(this.props.cellElement)) {
       return;
     }
-    const name = this.props.blockName || this.props.previousBlockName;
+    const name = this.props.stepName || this.props.previousStepName;
     const codeMirrorElem = this.props.cellElement.querySelector(
       '.CodeMirror',
     ) as HTMLElement;
@@ -264,7 +264,7 @@ export class InlineMetadata extends React.Component<IProps, IState> {
 
   /**
    * Create a list of div dots that represent the dependencies of the current
-   * block
+   * step
    */
   updateDependencies() {
     const dependencies = this.props.stepDependencies.map((name, i) => {
@@ -290,9 +290,7 @@ export class InlineMetadata extends React.Component<IProps, IState> {
   };
 
   render() {
-    const details = RESERVED_CELL_NAMES.includes(
-      this.props.blockName,
-    ) ? null : (
+    const details = RESERVED_CELL_NAMES.includes(this.props.stepName) ? null : (
       <>
         {/* Add a `depends on: ` string before the deps dots in case there are some*/}
         {this.state.dependencies.length > 0 ? (
@@ -318,7 +316,7 @@ export class InlineMetadata extends React.Component<IProps, IState> {
           }
         >
           {/* Add a `step: ` string before the Chip in case the chip belongs to a pipeline step*/}
-          {RESERVED_CELL_NAMES.includes(this.props.blockName) ? (
+          {RESERVED_CELL_NAMES.includes(this.props.stepName) ? (
             ''
           ) : (
             <p style={{ fontStyle: 'italic', marginRight: '5px' }}>step: </p>
@@ -326,18 +324,18 @@ export class InlineMetadata extends React.Component<IProps, IState> {
 
           <Tooltip
             placement="top"
-            key={this.props.blockName + 'tooltip'}
+            key={this.props.stepName + 'tooltip'}
             title={
-              RESERVED_CELL_NAMES.includes(this.props.blockName)
-                ? RESERVED_CELL_NAMES_HELP_TEXT[this.props.blockName]
-                : 'This cell starts the pipeline step: ' + this.props.blockName
+              RESERVED_CELL_NAMES.includes(this.props.stepName)
+                ? RESERVED_CELL_NAMES_HELP_TEXT[this.props.stepName]
+                : 'This cell starts the pipeline step: ' + this.props.stepName
             }
           >
             <Chip
               className={`kale-chip ${this.state.cellTypeClass}`}
               style={{ backgroundColor: `#${this.state.color}` }}
-              key={this.props.blockName}
-              label={this.props.blockName}
+              key={this.props.stepName}
+              label={this.props.stepName}
             />
           </Tooltip>
 


### PR DESCRIPTION
### Summary
  Drops the long-deprecated `block:` cell tag from Kale's notebook grammar and cleans up the labextension's internal naming to match. The `block:` tag was superseded by `step:` a while back and kept only as a compatibility alias — this
  branch finishes the migration.

  ### Changes

  **Commit 1 — `Remove deprecated block: cell tag`** (`7798229`)
  - `kale/processors/nbprocessor.py`: drop `BLOCK_TAG` regex and its entry in `_TAGS_LANGUAGE`; reword the `prev` validation error to mention only `step`.
  - `labextension/src/lib/CellUtils.ts`: fix `getStepName`, which was still stripping `block:` instead of `step:` (a leftover that silently broke step-name lookup for the exploration feature).
  - `examples/openvaccine-kaggle-competition/open-vaccine.ipynb`: replace the one stray `"block:"` tag with `"step:"`.

  **Commit 2 — `Rename block identifiers to step in labextension`** (`95ceec4`)
  Pure mechanical rename across 5 files, no behavioural change:
  - `blockName` → `stepName`, `prevBlockNames` → `prevStepNames`
  - `getAllBlocks` → `getAllSteps`, `getPreviousBlock` → `getPreviousStep`
  - `BlockDependencyChoice` → `StepDependencyChoice`, `blockDependenciesChoices` → `stepDependenciesChoices`
  - `updateCurrentBlockName` → `updateCurrentStepName`, `updatePrevBlocksNames` → `updatePrevStepsNames`
  - HTML id `select-previous-blocks` → `select-previous-steps`
  - Updated surrounding doc-comments ("block name" → "step name", etc.)

  Kept as a separate commit so the first one stays easy to revert if needed.

  ### Why split
  The labextension had already migrated its read/write paths to `step:` (`getKaleCellTags` only parses `step:`, `setKaleCellTags` only writes `step:`) — only the grammar entry, one leftover prefix strip, one example notebook, and the
  internal identifier naming remained. Rather than bundle a pure rename with an actual grammar change, the rename lives in its own commit so the deprecation removal can be reviewed (and reverted) independently.

### Breaking change
  Notebooks that still carry `block:<name>` tags will no longer be recognised as pipeline steps. Users should re-tag those cells as `step:<name>`. All example notebooks shipped in `examples/` have been checked; only `open-vaccine.ipynb`
  had a stray occurrence and it's fixed in this PR.