### PR TITLE
ISSUE-715: Validate pipeline name length in UI (max 124 characters)

### DIFF
--- a/labextension/src/components/Input.tsx
+++ b/labextension/src/components/Input.tsx
@@ -191,6 +191,8 @@ export interface IInputProps extends Omit<
   value: string | number;
   regex?: string;
   regexErrorMsg?: string;
+  maxLength?: number;
+  maxLengthErrorMsg?: string;
   inputIndex?: number;
   helperText?: string;
   readOnly?: boolean;
@@ -207,6 +209,8 @@ export const Input: React.FunctionComponent<IInputProps> = props => {
     helperText = null,
     regex,
     regexErrorMsg,
+    maxLength,
+    maxLengthErrorMsg,
     validation,
     placeholder,
     inputIndex,
@@ -251,7 +255,19 @@ export const Input: React.FunctionComponent<IInputProps> = props => {
     regexPattern !== undefined && value !== ''
       ? !new RegExp(regexPattern).test(value)
       : false;
-  const error = regexError || beforeUpdateError;
+  const maxLengthError =
+    maxLength !== undefined ? value.length > maxLength : false;
+  const error = regexError || maxLengthError || beforeUpdateError;
+
+  const getErrorMessage = (): string | undefined => {
+    if (maxLengthError) {
+      return (
+        maxLengthErrorMsg ??
+        `Must be ${maxLength} characters or fewer (currently ${value.length})`
+      );
+    }
+    return getRegexMessage();
+  };
 
   const handleChange = (evt: React.ChangeEvent<HTMLInputElement>) => {
     const newValue = evt.target.value;
@@ -268,11 +284,20 @@ export const Input: React.FunctionComponent<IInputProps> = props => {
       variant={variant}
       className={className}
       error={error}
+      sx={
+        error
+          ? {
+              '& .MuiInputLabel-root': { color: 'error.main' },
+              '& .MuiInputBase-input': { color: 'error.main' },
+              '& .MuiFormHelperText-root': { color: 'error.main' },
+            }
+          : undefined
+      }
       value={value}
       margin="dense"
       placeholder={placeholder}
       spellCheck={false}
-      helperText={error ? getRegexMessage() : helperText}
+      helperText={error ? getErrorMessage() : helperText}
       slotProps={{
         input: {
           readOnly: readOnly,

--- a/labextension/src/widgets/LeftPanel.tsx
+++ b/labextension/src/widgets/LeftPanel.tsx
@@ -42,6 +42,7 @@ const KFP_STATUS_REFRESH_MS = 30_000;
 
 const KALE_NOTEBOOK_METADATA_KEY = 'kubeflow_notebook';
 const DEFAULT_UI_URL = 'http://localhost:8080';
+const PIPELINE_NAME_MAX_LENGTH = 124;
 
 export interface IExperiment {
   id: string;
@@ -654,9 +655,10 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
         experimentInputValue = selectedExperiments[0].name;
       }
     }
-    const pipelineNameValid = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(
-      this.state.metadata.pipeline_name,
-    );
+    const pipelineNameValid =
+      /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(
+        this.state.metadata.pipeline_name,
+      ) && this.state.metadata.pipeline_name.length <= PIPELINE_NAME_MAX_LENGTH;
     const experimentNameRegex = /^[a-z]([-a-z0-9]*[a-z0-9])?$/;
     const experimentNameValid =
       experimentInputSelected !== NEW_EXPERIMENT.id ||
@@ -683,6 +685,8 @@ export class KubeflowKaleLeftPanel extends React.Component<IProps, IState> {
         regexErrorMsg={
           "Pipeline name must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character."
         }
+        maxLength={PIPELINE_NAME_MAX_LENGTH}
+        maxLengthErrorMsg={`Pipeline name must be ${PIPELINE_NAME_MAX_LENGTH} characters or fewer.`}
       />
     );
 


### PR DESCRIPTION
## Summary

Fixes #715.

Pipeline names longer than 124 characters cause a runtime error in KFP. Previously there was no UI-level validation, so users only discovered the limit after a failed pipeline run with a cryptic error.

## Changes

### `labextension/src/components/Input.tsx`
- Added optional `maxLength?: number` and `maxLengthErrorMsg?: string` props to `IInputProps`
- When `value.length > maxLength`, the field enters error state: label, input text, and helper text all render in red
- `getErrorMessage()` surfaces the length error with priority over regex errors, since it is the more actionable fix
- Soft-validation approach (show error, do not hard-block input) is intentional — consistent with existing regex validation and allows paste-then-edit workflows

### `labextension/src/widgets/LeftPanel.tsx`
- Pass `maxLength={124}` and `maxLengthErrorMsg` to the Pipeline Name field
- Extended `pipelineNameValid` to include `length <= 124` so the compile/run button is disabled for over-limit values — this also covers names pre-populated from existing notebook metadata that were saved before this validation existed

## Behaviour

| Scenario | Before | After |
|---|---|---|
| Typing a name > 124 chars | No feedback | Error state on field, button disabled |
| Pasting a name > 124 chars | No feedback | Error state on field, button disabled |
| Opening notebook with saved name > 124 chars | No feedback until runtime error | Error state on field, button disabled |
| Submitting pipeline with valid name | Works | Unchanged |

<img width="383" height="760" alt="Screenshot 2026-04-15 at 10 16 43" src="https://github.com/user-attachments/assets/8716541c-64da-4d77-b4a2-5715e39b52f0" />


## Test plan

- [ ] Type a pipeline name longer than 124 characters — field shows red label, red text, red error message, compile button disabled
- [ ] Reduce the name to ≤ 124 characters — error clears, button re-enables
- [ ] Paste a 200-character string — same error behaviour as typing
- [ ] Open a notebook whose metadata contains a `pipeline_name` longer than 124 characters — error shown on load
- [ ] Existing regex validation (invalid characters) still works as before
