### PR TITLE
Bump dev version to 2.1.0

### DIFF
--- a/kale/__init__.py
+++ b/kale/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.0.0rc2"
+__version__ = "2.1.0"
 
 from typing import Any, NamedTuple
 

--- a/labextension/package.json
+++ b/labextension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-kubeflow-kale",
-  "version": "2.0.0-rc.2",
+  "version": "2.1.0",
   "description": "Convert Notebooks to Kubeflow pipelines with Kale",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
## Summary
- Cut `release-2.0` branch for the 2.0.x release line
- Bump main to `2.1.0` so it tracks next development cycle
- Updates both `kale/__init__.py` and `labextension/package.json`