### PR TITLE
docs: fix typos and outdated info in v2.0 docs

### DIFF
--- a/docs/source/concepts/compilation.md
+++ b/docs/source/concepts/compilation.md
@@ -18,18 +18,27 @@ notebook path and (optionally) a dictionary of metadata overrides, it:
 4. Builds a {py:class}`kale.pipeline.Pipeline` — internally a
    `networkx.DiGraph` — where each node is a {py:class}`kale.step.Step`
    carrying its source code, dependencies, inputs and outputs.
-5. Runs
-   {py:func}`kale.common.astutils.get_marshal_candidates`
-   on every step to resolve data dependencies between steps.
 
 The processor returns the `Pipeline` object along with the combined string
 of `imports` + `functions` code, ready to be pasted into every generated
 component.
 
-### 2. Compiler.generate_lightweight_component
+### 2. Dependency analysis
 
-For each `Step` in the pipeline, the
-{py:class}`kale.compiler.Compiler` renders
+{py:func}`kale.common.astutils.get_marshal_candidates` runs over every step
+to resolve data dependencies: names that are assigned in one step and read in
+another must be saved and loaded at runtime. The output is a set of "marshal
+candidates" per step that the compiler later turns into `marshal.save` /
+`marshal.load` calls.
+
+### 3. Compiler
+
+Once the `Pipeline` object is ready, {py:class}`kale.compiler.Compiler` turns
+it into a single Python file in three passes:
+
+#### generate_lightweight_component
+
+For each `Step`, the compiler renders
 `kale/templates/nb_function_template.jinja2` to produce a
 `@kfp_dsl.component` function. The template:
 
@@ -44,7 +53,7 @@ For each `Step` in the pipeline, the
   {py:func}`kale.compiler.Compiler._get_package_list_from_imports`, which
   walks the imports AST and resolves module names to pip package names.
 
-### 3. Compiler.generate_pipeline
+#### generate_pipeline
 
 Next, the compiler renders
 `kale/templates/pipeline_template.jinja2` to generate the top-level
@@ -56,13 +65,13 @@ Next, the compiler renders
 - Wires task dependencies using KFP's `.after(...)` and input/output
   references so KFP builds the same DAG Kale has in memory.
 
-### 4. Compiler.generate_dsl
+#### generate_dsl
 
 The compiler concatenates:
 
 - A header with imports for the KFP SDK and Kale marshal helpers.
-- All component functions from stage 2.
-- The pipeline function from stage 3.
+- All component functions from the previous pass.
+- The pipeline function from the previous pass.
 - A `__main__` block that invokes `kfp.compiler.Compiler().compile()` so the
   generated file can be executed directly.
 
@@ -70,7 +79,7 @@ The final text is formatted with `autopep8` and written to
 `.kale/<pipeline_name>.kale.py`. **This file is plain KFP v2 DSL** — no
 Kale-specific runtime, just standard Kubeflow Pipelines code.
 
-### 5. Submission (optional)
+### 4. Submission (optional)
 
 If you pass `--run_pipeline` (or the equivalent extension setting),
 {py:func}`kale.common.kfputils.compile_pipeline` invokes the KFP SDK

--- a/docs/source/getting-started/installation.md
+++ b/docs/source/getting-started/installation.md
@@ -22,15 +22,12 @@ older environment, ensure your Python deps include `kfp[kubernetes]>=2.16.0`.
 ```{admonition} Kale v2.0 pre-release
 :class: important
 
-Kale v2.0 is not yet published on PyPI. Until it is, use the "Install from
-source" instructions below. This section will become the recommended path
-once v2.0 ships.
+Kale v2.0 is available on PyPI as a release candidate. Install it with the
+`--pre` flag until the final release is tagged.
 ```
 
-When v2.0 is released, you will be able to install the package directly:
-
 ```bash
-pip install "jupyterlab>=4.0.0" "kubeflow-kale[jupyter]"
+pip install --pre "jupyterlab>=4.0.0" "kubeflow-kale[jupyter]"
 jupyter lab
 ```
 

--- a/docs/source/user-guide/annotating-notebooks.md
+++ b/docs/source/user-guide/annotating-notebooks.md
@@ -47,7 +47,7 @@ so you can't create cycles.
 
 The side panel's pipeline settings form is mapped to fields on
 {py:class}`kale.pipeline.PipelineConfig`. Changes are saved into the
-notebook's top-level metadata under the `kubeflow_noteobok` key, so they
+notebook's top-level metadata under the `kubeflow_notebook` key, so they
 travel with the notebook and show up on the next open.
 
 ### Submitting
@@ -92,7 +92,7 @@ A step with a dependency and a GPU request:
 ```
 
 Pipeline-level Kale settings live on the notebook (not on a cell) under the
-`metadata.kubeflow_noteobok` key — these are the same fields the side panel
+`metadata.kubeflow_notebook` key — these are the same fields the side panel
 exposes.
 
 ## Organising a notebook for Kale


### PR DESCRIPTION
Fixes #774

Changes:
- Fix `kubeflow_noteobok` typo in `annotating-notebooks.md` (2 places)
- Update PyPI admonition in `installation.md` — rc1 and rc2 are already published, add `--pre` install command
- Align compilation stage count between `compilation.md` and `index.md` — both now consistently describe 4 stages

cc @ederign @jesuino