### PR TITLE
build(release): use changelog file for GitHub Release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -227,13 +227,32 @@ jobs:
           name: wheel
           path: dist/
 
+      - name: Read changelog
+        id: changelog
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          MAJOR=$(echo "$VERSION" | cut -d. -f1)
+          MINOR=$(echo "$VERSION" | cut -d. -f2)
+          CHANGELOG_FILE="CHANGELOG/CHANGELOG-${MAJOR}.${MINOR}.md"
+          if [ -f "$CHANGELOG_FILE" ]; then
+            {
+              echo "body<<CHANGELOG_EOF"
+              cat "$CHANGELOG_FILE"
+              echo "CHANGELOG_EOF"
+            } >> "$GITHUB_OUTPUT"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: ${{ needs.prepare.outputs.tag }}
           name: ${{ needs.prepare.outputs.tag }}
           prerelease: ${{ needs.prepare.outputs.prerelease == 'true' }}
-          generate_release_notes: true
+          body: ${{ steps.changelog.outputs.body || '' }}
+          generate_release_notes: ${{ steps.changelog.outputs.found != 'true' }}
           files: dist/*
 
   bump-dev-version:

--- a/cliff.toml
+++ b/cliff.toml
@@ -22,7 +22,7 @@ trim = true
 
 [git]
 conventional_commits = true
-filter_unconventional = true
+filter_unconventional = false
 split_commits = false
 commit_parsers = [
     { message = "^feat", group = "Features" },
@@ -36,6 +36,7 @@ commit_parsers = [
     { message = "^chore|^ci", group = "Miscellaneous" },
     { body = ".*security", group = "Security" },
     { message = "^build", group = "Build" },
+    { message = ".*", group = "Other" },
 ]
 protect_breaking_commits = false
 filter_commits = false


### PR DESCRIPTION
## Summary
- Include non-conventional commits in changelog generation by setting `filter_unconventional=false` and adding a catch-all parser in `cliff.toml`
- Read `CHANGELOG/{major}.{minor}.md` for GitHub Release body when present, falling back to auto-generated notes otherwise

## Context
Preparing for the v2.0.0 final release. The current `cliff.toml` filters out ~64 of 122 commits since v0.7.0 because they don't follow conventional commit format (e.g., `ISSUE-715: ...`, `Remove deprecated ...`). This change ensures the generated changelog captures all contributions.

The release workflow change allows us to provide a curated changelog file (generated by `git-cliff`) as the GitHub Release body instead of relying solely on auto-generated notes from the previous tag.

## Test plan
- [ ] Verify `cliff.toml` change: run `git-cliff v0.7.0..HEAD --tag v2.0.0` and confirm non-conventional commits appear under "Other"
- [ ] Verify workflow change: when `CHANGELOG/CHANGELOG-2.0.md` exists, the release step reads it as body; when absent, falls back to `generate_release_notes: true`