### PR TITLE
Adding a new RAG with Langchain example

### DIFF
--- a/examples/rag/portable_rag_langchain.ipynb
+++ b/examples/rag/portable_rag_langchain.ipynb
@@ -1,0 +1,253 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7b89e11d-1d54-47f2-905d-0d43e2367d4d",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# RAG Example\n",
+    "\n",
+    "In this example we build and export a Chroma Database that can be used on a local LLM execution for RAG.\n",
+    "The database is created against a Github repo passed as parameter.\n",
+    "\n",
+    "This notebook can run locally (make it sure to have installed the necessary dependencies) or on KFP. When running on KFP, it can be scheduled to regularly run against a github repo, generating fresh vector databases."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40e53260-7183-452a-8d11-21fcac571053",
+   "metadata": {
+    "tags": [
+     "imports"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import shutil\n",
+    "import hashlib\n",
+    "import sentence_transformers\n",
+    "from langchain_community.document_loaders import DirectoryLoader,TextLoader\n",
+    "from langchain_community.vectorstores import Chroma\n",
+    "from langchain_huggingface import HuggingFaceEmbeddings\n",
+    "from git import Repo\n",
+    "from langchain_chroma import Chroma"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf23be95-c5ef-41a1-acbe-fbc760e25eae",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Pipeline parameters\n",
+    "Using these parameters we can control which files will be read from the remote repo and loaded into the vector database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5b0539f-bb43-461e-bdf8-740c67e5f367",
+   "metadata": {
+    "tags": [
+     "pipeline-parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "files_pattern = \"**/*.py,**/*.ts,**/*.tsx,**/*.md\"\n",
+    "repo = \"kubeflow/kale\"\n",
+    "git_url = \"https://github.com\"\n",
+    "embeddings_model = \"all-MiniLM-L6-v2\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fca00853-2469-400f-b0ac-1aed838545ba",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Clone repo and retrieving documents\n",
+    "We clone the repo provided by the user and load the files into documents that will be used to build the database. This is a step that is not cached so we can always get the latest changes from the target repo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92a998ef-923a-4930-a2a3-670aab1bf71c",
+   "metadata": {
+    "tags": [
+     "step:clone_repo",
+     "cache:disabled"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "# Clone the repo and save the zipped content\n",
+    "repo_dir = '/tmp/repo'\n",
+    "repo_url = f'{git_url}/{repo}'\n",
+    "shutil.rmtree(repo_dir, ignore_errors=True)\n",
+    "Repo.clone_from(repo_url, repo_dir)\n",
+    "loader = DirectoryLoader(repo_dir, glob=files_pattern.split(\",\"),loader_cls=TextLoader,use_multithreading=True)\n",
+    "docs = loader.load()\n",
+    "if len(docs) == 0:\n",
+    "    raise Exception(\"No documents to build the vector database\")\n",
+    "print(f'Finished reading {len(docs)} docs from repo {repo_url}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a0213ac-b1b7-4b52-b4f3-c2278e06dfcb",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Loading embeddings model\n",
+    "\n",
+    "The embeddings model is downloaded and loaded. Notice that we ensure that this step is cached so we don't have to re-download the model for each run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dc6d255f-dc7a-49c0-b46d-1e1abcec50fc",
+   "metadata": {
+    "tags": [
+     "step:load_embeddings_model",
+     "cache:enabled"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "embeddings = HuggingFaceEmbeddings(model_name=embeddings_model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7062d9a5-64dd-4e90-a5e8-fbf19a89fb65",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Create Vector DB\n",
+    "We use the embeddings and the documents from the github repo to build the vector database, zip and store the zip file contents in a variable"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bcad267-6bb8-4393-8fb5-1aea568a65a3",
+   "metadata": {
+    "tags": [
+     "step:create_vector_database",
+     "prev:clone_repo",
+     "prev:load_embeddings_model"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "db_dir = \"/tmp/chroma_db\"\n",
+    "Chroma.from_documents(\n",
+    "    documents=docs, \n",
+    "    embedding=embeddings, \n",
+    "    persist_directory=db_dir\n",
+    ")\n",
+    "zip_file = shutil.make_archive('/tmp/chroma_db', 'zip', db_dir)\n",
+    "with open(zip_file, 'rb') as f:\n",
+    "    chroma_db = f.read()\n",
+    "print(f'File succesfully created and stored in {db_dir}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc070eca-4281-4bee-ba21-1f224870fc37",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Check the vector DB\n",
+    "On this step we check the produced database and Kale will have to create the chroma_db output artifact to be passed to this, so we can download it from KFP"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "831e7fa9-2eda-413a-929c-a320d2538a45",
+   "metadata": {
+    "tags": [
+     "step:check_vector_db",
+     "prev:create_vector_database"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "md5_hash = hashlib.md5(chroma_db).hexdigest()\n",
+    "print(f'Vector DB created sucessfully. MD5 Hash: {md5_hash}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09e529d1-a75a-4297-aaa1-c15e3189e666",
+   "metadata": {},
+   "source": [
+    "### Verify the Vector DB\n",
+    "With this code we verify if the file can be loaded correcly from the file system and it is skipped for the pipeline execution. Notice that this can run on a different computer using the artifact downloaded from KFP"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7b66e481-c642-4b54-95c0-9bd022b0593e",
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "vector_db = Chroma(\n",
+    "  embedding_function=embeddings,\n",
+    "  persist_directory=db_dir\n",
+    ")\n",
+    "vector_db.similarity_search(\"What is Kale?\", k=1)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "kubeflow_notebook": {
+   "base_image": "",
+   "enable_caching": true,
+   "experiment": {
+    "id": "ba152d07-b583-4a65-82e1-9c8d9ad8c5eb",
+    "name": "Default"
+   },
+   "experiment_name": "Default",
+   "pipeline_description": "This pipeline builds a Vector database from a given github repo to be reused locally with a LLM client.",
+   "pipeline_name": "portable-rag",
+   "steps_defaults": []
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adding a RAG with langchain example. This was built for building a reusable "RAG file" so I can load locally on my LLM client and make it run scheduled on KFP.

This example is using almost all Kale features and doing a good test of data passing between steps and when working on this I did identify some improvements that could be done in Kale:

https://github.com/kubeflow/kale/issues/782
https://github.com/kubeflow/kale/issues/783


Once these two issues are implemented, we can revisit this example to make sure that the performance is improved as intended.

When running this example, make it sure that you have at least ~15g free on your cluster for it non cached run. It used pytorch and pars of langchain that are large pip packages and they are downloaded for each step execution, so takes a good amount of disk space and the whole pipeline takes around 30 minutes to run. Once the above issues are implemented, we will see a good performance improvement for this pipeline!