### PR TITLE
docs: add KEP proposal template

### DIFF
--- a/docs/proposals/NNNN-template/README.md
+++ b/docs/proposals/NNNN-template/README.md
@@ -1,0 +1,191 @@
+# KEP-NNNN: Your KEP Title
+
+|                     |                                                    |
+| ------------------- | -------------------------------------------------- |
+| **Authors**         | [your-name](https://github.com/your-github-handle) |
+| **Created**         | YYYY-MM-DD                                         |
+| **Google Doc (draft)** | https://docs.google.com/document/d/1SBgVL91Z_2mz1R0WH2UXIX0V4WZECK2KvUl4LE016Cw/edit |
+| **Relevant Issues** | https://github.com/kubeflow/kale/issues/NNN        |
+
+## Table of Contents
+
+<!-- Update this TOC to match the sections you include. -->
+
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+  - [Non-Goals](#non-goals)
+- [User Stories](#user-stories)
+- [Proposal](#proposal)
+  - [Architecture](#architecture)
+  - [API](#api)
+- [Design Details](#design-details)
+  - [Notes/Constraints/Caveats](#notesconstraintscaveats)
+  - [Risks and Mitigations](#risks-and-mitigations)
+  - [Test Plan](#test-plan)
+  - [Graduation Criteria](#graduation-criteria)
+- [Implementation Plan](#implementation-plan)
+- [Migration](#migration)
+- [Implementation History](#implementation-history)
+- [Drawbacks](#drawbacks)
+- [Alternatives Considered](#alternatives-considered)
+- [Consequences](#consequences)
+
+## Summary
+
+<!-- One paragraph explanation of the proposal. -->
+
+## Motivation
+
+<!-- Why is this change needed? What problem does it solve? -->
+
+### Goals
+
+<!-- Bulleted list of specific goals this KEP aims to achieve. -->
+
+1. Goal 1
+2. Goal 2
+
+### Non-Goals
+
+<!-- Bulleted list of things explicitly out of scope. -->
+
+- Non-goal 1
+- Non-goal 2
+
+---
+
+## User Stories
+
+<!-- Concrete examples of how users will interact with the proposed feature.
+     Include code samples where applicable. -->
+
+### Story 1: Title
+
+<!-- As a [role], I want [capability] so that [benefit]. -->
+
+```python
+# Example code showing the user workflow
+```
+
+---
+
+## Proposal
+
+<!-- Detailed description of the proposed solution. Include architecture,
+     API surface, data models, and any relevant diagrams. -->
+
+### Architecture
+
+<!-- How does this fit into the existing system?
+     Include diagrams (ASCII or image) if helpful. -->
+
+### API
+
+<!-- Public API surface: methods, parameters, return types.
+     Show constructor, key methods, and usage examples. -->
+
+---
+
+## Design Details
+
+<!-- Implementation-level details: package structure, type definitions,
+     error handling, dependencies, etc. -->
+
+### Notes/Constraints/Caveats
+
+<!-- Optional. Known limitations, open questions, or assumptions. -->
+
+### Risks and Mitigations
+
+<!-- Optional. Potential risks and how they will be addressed. -->
+
+| Risk | Mitigation |
+|------|------------|
+|      |            |
+
+### Test Plan
+
+<!-- How will this be tested? -->
+
+- **Unit Tests**: ...
+- **E2E Tests**: ...
+
+### Graduation Criteria
+
+<!-- Optional. What conditions must be met to move between alpha/beta/stable? -->
+
+---
+
+## Implementation Plan
+
+<!-- Sequencing, milestones, phasing, and ownership. -->
+
+| Phase | Feature | Description |
+|-------|---------|-------------|
+|       |         |             |
+
+---
+
+## Migration
+
+<!-- Optional. How do existing users migrate to the new approach?
+     Include a mapping table if replacing existing APIs. -->
+
+---
+
+## Implementation History
+
+<!-- Chronological list of major changes to this KEP. -->
+
+- YYYY-MM-DD: Initial KEP creation
+
+---
+
+## Drawbacks
+
+<!-- Optional. Why should this proposal NOT be implemented?
+     Honest assessment of limitations or costs. -->
+
+---
+
+## Alternatives Considered
+
+<!-- What other options were evaluated? For each alternative, describe
+     the approach and explicitly state why it was rejected. -->
+
+### Alternative 1: Title
+
+Description of the alternative approach.
+
+**Rejected because**:
+- Reason 1
+- Reason 2
+
+### Alternative 2: Title
+
+Description of the alternative approach.
+
+**Rejected because**:
+- Reason 1
+- Reason 2
+
+---
+
+## Consequences
+
+<!-- What becomes easier or more difficult to do because of this change? -->
+
+### Positive
+
+- Benefit 1
+- Benefit 2
+
+### Negative
+
+- Drawback 1
+- Drawback 2
+
+### Neutral
+
+- Trade-off 1


### PR DESCRIPTION
## Summary
- Add a KEP (Kubeflow Enhancement Proposal) template under `docs/proposals/NNNN-template/`
- Template structure derived from all existing kubeflow/sdk KEPs (107, 125, 2, 46)
- Includes ADR-style "Alternatives Considered" (with explicit **Rejected because** reasoning) and "Consequences" (Positive/Negative/Neutral) sections
- A matching Google Doc template is available for drafting: https://docs.google.com/document/d/1SBgVL91Z_2mz1R0WH2UXIX0V4WZECK2KvUl4LE016Cw/edit

## Test plan
- [ ] Verify template renders correctly on GitHub
- [ ] Verify Google Doc template matches the markdown structure