### PR TITLE
feat(frontend): Add clear metadata button to cell metadata editor

### DIFF
--- a/labextension/src/lib/TagsUtils.ts
+++ b/labextension/src/lib/TagsUtils.ts
@@ -261,10 +261,13 @@ export default class TagsUtils {
         'tags',
       ) || [];
 
-    const kaleTagPrefixes = KALE_TAG_PREFIXES;
+    // Extract the step name from 'step:<name>' tag before wiping
+    const stepTag = currentTags.find(tag => tag.startsWith('step:'));
+    const clearedStepName = stepTag ? stepTag.replace('step:', '') : null;
 
+    // Clear all Kale tags from the active cell
     const filteredTags = currentTags.filter(
-      tag => !kaleTagPrefixes.some(prefix => tag.startsWith(prefix)),
+      tag => !KALE_TAG_PREFIXES.some(prefix => tag.startsWith(prefix)),
     );
 
     CellUtils.setCellMetaData(
@@ -272,7 +275,13 @@ export default class TagsUtils {
       activeCellIndex,
       'tags',
       filteredTags,
-    );
+    ).then(() => {
+      // If this cell had a step name, remove all prev:<stepName> refs
+      // from dependent cells using the existing updateKaleCellsTags
+      if (clearedStepName) {
+        TagsUtils.updateKaleCellsTags(notebook, clearedStepName, '');
+      }
+    });
   }
 
   public static cellsToArray(notebook: NotebookPanel) {

--- a/labextension/src/lib/TagsUtils.ts
+++ b/labextension/src/lib/TagsUtils.ts
@@ -15,6 +15,7 @@
 import { Notebook, NotebookPanel } from '@jupyterlab/notebook';
 import CellUtils from './CellUtils';
 import { RESERVED_CELL_NAMES } from '../widgets/cell-metadata/CellMetadataEditor';
+import { KALE_TAG_PREFIXES } from '../widgets/cell-metadata/constants';
 
 const IMAGE_TAG = 'image:';
 const CACHE_TAG = 'cache:';
@@ -249,7 +250,7 @@ export default class TagsUtils {
       TagsUtils.updateKaleCellsTags(notebook, oldStepName, value);
     });
   }
-    public static removeAllKaleTags(
+  public static removeAllKaleTags(
     notebook: NotebookPanel,
     activeCellIndex: number,
   ) {
@@ -260,18 +261,7 @@ export default class TagsUtils {
         'tags',
       ) || [];
 
-    const kaleTagPrefixes = [
-      'step:',
-      'prev:',
-      'limit:',
-      'image:',
-      'cache:',
-      'skip',
-      'imports',
-      'functions',
-      'pipeline-parameters',
-      'final',
-    ];
+    const kaleTagPrefixes = KALE_TAG_PREFIXES;
 
     const filteredTags = currentTags.filter(
       tag => !kaleTagPrefixes.some(prefix => tag.startsWith(prefix)),

--- a/labextension/src/lib/TagsUtils.ts
+++ b/labextension/src/lib/TagsUtils.ts
@@ -249,6 +249,41 @@ export default class TagsUtils {
       TagsUtils.updateKaleCellsTags(notebook, oldStepName, value);
     });
   }
+    public static removeAllKaleTags(
+    notebook: NotebookPanel,
+    activeCellIndex: number,
+  ) {
+    const currentTags: string[] =
+      CellUtils.getCellMetaData(
+        notebook.content,
+        activeCellIndex,
+        'tags',
+      ) || [];
+
+    const kaleTagPrefixes = [
+      'step:',
+      'prev:',
+      'limit:',
+      'image:',
+      'cache:',
+      'skip',
+      'imports',
+      'functions',
+      'pipeline-parameters',
+      'final',
+    ];
+
+    const filteredTags = currentTags.filter(
+      tag => !kaleTagPrefixes.some(prefix => tag.startsWith(prefix)),
+    );
+
+    CellUtils.setCellMetaData(
+      notebook,
+      activeCellIndex,
+      'tags',
+      filteredTags,
+    );
+  }
 
   public static cellsToArray(notebook: NotebookPanel) {
     const cells = notebook.model?.cells;

--- a/labextension/src/widgets/cell-metadata/CellMetadataEditor.tsx
+++ b/labextension/src/widgets/cell-metadata/CellMetadataEditor.tsx
@@ -17,6 +17,7 @@ import { useCallback, useContext, useRef, useState } from 'react';
 import { NotebookPanel } from '@jupyterlab/notebook';
 import TagsUtils from '../../lib/TagsUtils';
 import CloseIcon from '@mui/icons-material/Close';
+import LayersClearIcon from '@mui/icons-material/LayersClear';
 import ColorUtils from '../../lib/ColorUtils';
 import { CellMetadataContext } from '../../lib/CellMetadataContext';
 import { Button, IconButton, Tooltip } from '@mui/material';
@@ -246,7 +247,19 @@ export const CellMetadataEditor: React.FC<IProps> = props => {
               </>
             )}
 
-            <IconButton aria-label="delete" onMouseDown={closeEditor}>
+            {(hasStepName || RESERVED_CELL_NAMES.includes(stepName)) && (
+              <Tooltip title="Clear all cell metadata" placement="top" arrow>
+                <IconButton
+                  aria-label="clear metadata"
+                  onMouseDown={updateCellTags.clearCellMetadata}
+                  size="small"
+                >
+                  <LayersClearIcon fontSize="small" />
+                </IconButton>
+              </Tooltip>
+            )}
+
+            <IconButton aria-label="close editor" onMouseDown={closeEditor}>
               <CloseIcon fontSize="small" />
             </IconButton>
           </div>

--- a/labextension/src/widgets/cell-metadata/constants.ts
+++ b/labextension/src/widgets/cell-metadata/constants.ts
@@ -38,6 +38,7 @@ export const KALE_TAG_PREFIXES = [
   'imports',
   'functions',
   'pipeline-parameters',
+  'pipeline-metrics',
 ];
 
 export const RESERVED_CELL_NAMES_HELP_TEXT: { [id: string]: string } = {

--- a/labextension/src/widgets/cell-metadata/constants.ts
+++ b/labextension/src/widgets/cell-metadata/constants.ts
@@ -28,6 +28,18 @@ export const RESERVED_CELL_NAMES = [
   'pipeline-metrics',
   'skip',
 ];
+export const KALE_TAG_PREFIXES = [
+  'step:',
+  'prev:',
+  'limit:',
+  'image:',
+  'cache:',
+  'skip',
+  'imports',
+  'functions',
+  'pipeline-parameters',
+  'final',
+];
 
 export const RESERVED_CELL_NAMES_HELP_TEXT: { [id: string]: string } = {
   imports:

--- a/labextension/src/widgets/cell-metadata/constants.ts
+++ b/labextension/src/widgets/cell-metadata/constants.ts
@@ -38,7 +38,6 @@ export const KALE_TAG_PREFIXES = [
   'imports',
   'functions',
   'pipeline-parameters',
-  'final',
 ];
 
 export const RESERVED_CELL_NAMES_HELP_TEXT: { [id: string]: string } = {

--- a/labextension/src/widgets/cell-metadata/hooks/useCellTags.ts
+++ b/labextension/src/widgets/cell-metadata/hooks/useCellTags.ts
@@ -162,6 +162,9 @@ export function useUpdateCellTags({
     },
     [notebook, activeCellIndex, stepName, stepDependencies, limits, baseImage],
   );
+  const clearCellMetadata = useCallback(() => {
+    TagsUtils.removeAllKaleTags(notebook, activeCellIndex);
+  }, [notebook, activeCellIndex]);
 
   return {
     updateCellType,
@@ -170,5 +173,6 @@ export function useUpdateCellTags({
     updateLimits,
     updateBaseImage,
     updateCaching,
+    clearCellMetadata,
   };
 }


### PR DESCRIPTION
## Summary

This PR adds a clear metadata action to the Kale cell metadata editor, allowing users to quickly remove Kale-specific metadata from a notebook cell.

## Changes Made

### UI Updates

* Added a new "Clear Metadata" button to `CellMetadataEditor.tsx`
* Used `LayersClearIcon` for better UX clarity
* Kept the existing close editor action separate from metadata clearing
* The button is only shown when the cell contains Kale metadata or reserved Kale cell types

### Hook Updates

* Added `clearCellMetadata()` to `useCellTags.ts`
* Exposed the action through the existing metadata update hook

### Utility Updates

* Added `removeAllKaleTags()` to `TagsUtils.ts`
* Removes only Kale-related tags while preserving unrelated/custom notebook tags

## Behavior

The new clear action removes:

* `step:` tags
* dependency (`prev:`) tags
* limit tags
* image tags
* cache tags
* reserved Kale metadata tags

Non-Kale/custom tags remain untouched.

## Why This Change

Previously, users had to manually reset or modify metadata field-by-field. This improvement provides a faster and more user-friendly way to completely clear Kale metadata from a cell.

## Testing

Tested locally by:

* adding metadata to cells
* clearing metadata using the new button
* verifying reserved Kale cells
* confirming editor close behavior still works
* ensuring unrelated notebook tags are preserved
* running eslint and pre-commit hooks successfully
## Screenshots

<img width="2720" height="697" alt="Screenshot 2026-05-27 183644" src="https://github.com/user-attachments/assets/107a7215-dd4f-4bd0-b9c9-0db1d85675ef" />

Closes #766