### PR TITLE
Registering Metadata Listener when enabling Kale and updating dependencies in order

### DIFF
--- a/labextension/src/widgets/cell-metadata/hooks/useCellTags.ts
+++ b/labextension/src/widgets/cell-metadata/hooks/useCellTags.ts
@@ -45,14 +45,13 @@ export function useUpdateCellTags({
   const updateStepName = useCallback(
     (value: string) => {
       const oldStepName = stepName || '';
+      TagsUtils.updateKaleCellsTags(notebook, oldStepName, value);
       TagsUtils.setKaleCellTags(notebook, activeCellIndex, {
         prevStepNames: stepDependencies,
         limits: limits || {},
         baseImage,
         enableCaching,
         stepName: value,
-      }).then(() => {
-        TagsUtils.updateKaleCellsTags(notebook, oldStepName, value);
       });
     },
     [

--- a/labextension/src/widgets/cell-metadata/hooks/useInlineMetadata.tsx
+++ b/labextension/src/widgets/cell-metadata/hooks/useInlineMetadata.tsx
@@ -257,7 +257,7 @@ export function useInlineMetadata(
     return () => {
       cellModel.metadataChanged.disconnect(onMetadataChange);
     };
-  }, [notebook, activeCellIndex, onMetadataChange]);
+  }, [enabled, notebook, activeCellIndex, onMetadataChange]);
 
   const prevEnabledRef = useRef(enabled);
   useEffect(() => {


### PR DESCRIPTION
closes #814


The issue #814 is caused by the metatada listener not being registered when enabling Kale and not clicking on a cell:

* When a cell is clicked, then the metadata listener is correctly registered so everything works fine
* Currently the code effect to register the metadata listener was not using enabled - adding it to the effect fixed this problem

I also found a related issue:

* When the step name was modified, the metadata listeners were cleaned and only registered for the current cell
* It also triggers the full cells UI representation (chips, inline editor and so on)
* The dependencies were not correctly reflected on the UI, because when we update the metadata the listener was not there to rebuild the UI
* The solution is update the dependencies before updating active cell metadata - once the active cell is updated, the listener in place rebuilds the UI, making it up to date


To test this:

* create a new notebook
* enable Kale
* on the current cell you have to add a step and it should work as expected
* Now add a new cell and make the first cell as a dependency
* go back to the first cell and edit its name - the last cell should have the dependencies updated accordingly

A further test:

* open the candies example and enable kale
* play with the cells that are a step, for example, modify "sack" step name and see if the change is applied to "kid1"


