### PR TITLE
Removing Default Security Context

### DIFF
--- a/labextension/src/widgets/LeftPanelTypes.ts
+++ b/labextension/src/widgets/LeftPanelTypes.ts
@@ -60,11 +60,5 @@ export const DefaultState = {
     base_image: '',
     enable_caching: true,
     steps_defaults: [] as string[],
-    security_context: {
-      enabled: true,
-      run_as_user: 65534,
-      run_as_group: 0,
-      run_as_non_root: true,
-    },
   } as IKaleNotebookMetadata,
 };


### PR DESCRIPTION
The default security context is preventing the user settings to be applied correctly.
We didn't see this before because the examples have a default metatada, which means that the default from the labextension is not being used.

How to test it:

* Clear the current user settings (usually the settings are in file `~/.jupyter/lab/user-settings/jupyterlab-kubeflow
-kale/kale-settings.jupyterlab-settings`)
* Before starting KFP, use a value for some of the security context setting env var, such as: `export KALE_SECURITY_CONTEXT_RUN_AS_USER=123`
* Open Jupyter Lab and check the Kale settings, make it sure that the env vars you set are reflect on the default settings
* Create a new notebook
* Enable Kale and add at least a single step
*  COmpile the notebook and look for the security context, it should have the same values you saw in User settings
* Modify the user settings and add a new value for some of the Security context fields. Open the compiled DSL and confirm that it has the correct value:

<img width="1475" height="622" alt="image" src="https://github.com/user-attachments/assets/3179d1a1-e8fb-4ef9-a8a6-b6ce440ed62a" />


closes #822