### PR TITLE
docs: add v2.1 release news and good first issues link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 
 Latest News 🔥
 
+- [2026/06] Kubeflow Kale v2.1 is released!
 - [2026/04] Kubeflow Kale v2.0 is officially released with support for Kubeflow Pipelines 2.16.0!
 - [2026/04] The new Kubeflow Kale [docs](./docs) is now available!
 
@@ -151,6 +152,7 @@ We'd love to have you!
 
 - **Questions?** Join [#kubeflow](https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels) on Slack
 - **Found a bug?** [Open an issue](https://github.com/kubeflow-kale/kale/issues)
+- **New here?** Check out our [good first issues](https://github.com/kubeflow/kale/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22) — a great way to start contributing!
 - **Want to contribute?** See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Learn More

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
   <b>No pipeline code. No SDK learning curve. Just tag your cells and deploy.</b>
 </p>
 
+<p>
+  📍 <a href="./docs/source/roadmap.md">See our Roadmap</a> for what's coming next.
+</p>
+
 ---
 
 Latest News 🔥


### PR DESCRIPTION
## Summary

- Add Kale v2.1 release announcement to Latest News section
- Add "good first issues" link in the Community section for new contributors

## Hold

This PR should be merged **after** https://github.com/kubeflow/kale/pull/858.

## Roadmap

See the full [roadmap](./docs/source/roadmap.md) for what's coming next.