### PR TITLE
chore: Add ADOPTERS.md for Kale

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -6,4 +6,4 @@ If you are using other Kubeflow components, consider adding your name as well to
 | Organization                       | Contact (GitHub User Name)              | Environment   | Description of Use                                                                 |
 |------------------------------------|----------------------------------------|---------------|------------------------------------------------------------------------------------|
 | [Red Hat](https://www.redhat.com)  | [@ederign](https://github.com/ederign) | Production    | Kale is part of [OpenShift AI](https://www.redhat.com/en/products/ai/openshift-ai) |
-| \<your organization\>              | \<your GitHub handle\>                 | \<your setup\>| \<brief description\>                                                              |
+| *your organization*                | *your GitHub handle*                   | *your setup*  | *brief description*                                                                |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,6 +1,6 @@
-# Adopters of Kale
+# Adopters of Kubeflow Kale
 
-Below are the adopters of Kale. If you are using this project in your organization, please add your name to the list by submitting a pull request: this will help foster the Kubeflow community. Kindly ensure the list remains in alphabetical order.
+Below are the adopters of Kubeflow Kale. If you are using this project in your organization, please add your name to the list by submitting a pull request: this will help foster the Kubeflow community. Kindly ensure the list remains in alphabetical order.
 If you are using other Kubeflow components, consider adding your name as well to the overall [Kubeflow Community Adopters file](https://github.com/kubeflow/community/blob/master/ADOPTERS.md).
 
 | Organization | Contact (GitHub User Name) | Environment | Description of Use |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -3,6 +3,7 @@
 Below are the adopters of Kubeflow Kale. If you are using this project in your organization, please add your name to the list by submitting a pull request: this will help foster the Kubeflow community. Kindly ensure the list remains in alphabetical order.
 If you are using other Kubeflow components, consider adding your name as well to the overall [Kubeflow Community Adopters file](https://github.com/kubeflow/community/blob/master/ADOPTERS.md).
 
-| Organization | Contact (GitHub User Name) | Environment | Description of Use |
-|---|---|---|---|
-| [Red Hat](https://www.redhat.com) | [@ederign](https://github.com/ederign) | Production | Kale is part of [OpenShift AI](https://www.redhat.com/en/products/ai/openshift-ai) |
+| Organization                       | Contact (GitHub User Name)              | Environment   | Description of Use                                                                 |
+|------------------------------------|----------------------------------------|---------------|------------------------------------------------------------------------------------|
+| [Red Hat](https://www.redhat.com)  | [@ederign](https://github.com/ederign) | Production    | Kale is part of [OpenShift AI](https://www.redhat.com/en/products/ai/openshift-ai) |
+| \<your organization\>              | \<your GitHub handle\>                 | \<your setup\>| \<brief description\>                                                              |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,9 @@
+# Adopters of Kale
+
+Below are the adopters of Kale. If you are using this project in your organization, please add your name to the list by submitting a pull request: this will help foster the Kubeflow community. Kindly ensure the list remains in alphabetical order.
+If you are using other Kubeflow components, consider adding your name as well to the overall [Kubeflow Community Adopters file](https://github.com/kubeflow/community/blob/master/ADOPTERS.md).
+
+| Organization | Contact (GitHub User Name) | Environment | Description of Use |
+|---|---|---|---|
+| [Red Hat](https://www.redhat.com) | [@ederign](https://github.com/ederign) | Production | Kale is part of [OpenShift AI](https://www.redhat.com/en/products/ai/openshift-ai) |
+| < company name here > | < your github handle here > | <Production/Testing/Experimenting/etc> | <any notes you'd like to share> |

--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -6,4 +6,3 @@ If you are using other Kubeflow components, consider adding your name as well to
 | Organization | Contact (GitHub User Name) | Environment | Description of Use |
 |---|---|---|---|
 | [Red Hat](https://www.redhat.com) | [@ederign](https://github.com/ederign) | Production | Kale is part of [OpenShift AI](https://www.redhat.com/en/products/ai/openshift-ai) |
-| < company name here > | < your github handle here > | <Production/Testing/Experimenting/etc> | <any notes you'd like to share> |


### PR DESCRIPTION
## Summary
- Add ADOPTERS.md file following the same format used in [kubeflow/hub](https://github.com/kubeflow/hub/blob/main/ADOPTERS.md)
- List Red Hat as an adopter of Kale