### PR TITLE
ci: add PR title check workflow with conventional commits

### DIFF
--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -24,7 +24,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           types: |
+            build
             chore
+            docs
             fix
             feat
             revert

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -1,0 +1,44 @@
+name: Check PR Title
+
+on:
+  pull_request_target:
+    branches:
+      - main
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            chore
+            fix
+            feat
+            revert
+
+          scopes: |
+            frontend
+            backend
+            ci
+            docs
+            deps
+            examples
+            test
+          requireScope: false
+          ignoreLabels: |
+            do-not-merge/work-in-progress
+            dependencies
+            area/release

--- a/.github/workflows/check-pr-title.yaml
+++ b/.github/workflows/check-pr-title.yaml
@@ -38,6 +38,7 @@ jobs:
             docs
             deps
             examples
+            release
             test
           requireScope: false
           ignoreLabels: |


### PR DESCRIPTION
## Summary
- Add PR title check using [conventional commits](https://www.conventionalcommits.org/) format
- Allowed types: `build`, `chore`, `docs`, `fix`, `feat`, `revert`
- Allowed scopes (optional): `frontend`, `backend`, `ci`, `docs`, `deps`, `examples`, `release`, `test`
- Follows the same pattern as [kubeflow/sdk](https://github.com/kubeflow/sdk/blob/main/.github/workflows/check-pr-title.yaml)