### PR TITLE
ci: add stale issues and PRs workflow

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,37 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '0 0 * * *' # Run every day at midnight
+
+jobs:
+  stale:
+    if: ${{ github.repository == 'kubeflow/kale' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 60
+        days-before-close: 21
+        stale-issue-message: >
+          This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.
+        close-issue-message: >
+          This issue has been automatically closed because it has not had recent activity. Please comment "/reopen" to reopen it.
+        stale-issue-label: lifecycle/stale
+        exempt-issue-labels: lifecycle/frozen,enhancement,good first issue
+        stale-pr-message: "This pull request has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions. \n"
+        close-pr-message: "This pull request has been automatically closed because it has not had recent  activity.You can reopen the PR if you want. \n"
+        stale-pr-label: lifecycle/stale
+        exempt-pr-labels: lifecycle/frozen,enhancement,good first issue
+        exempt-all-milestones: true
+        operations-per-run: 250


### PR DESCRIPTION
## Summary
- Add workflow to automatically mark and close stale issues and PRs
- Issues/PRs are marked stale after 60 days of inactivity, closed after 21 more days
- Exempt labels: `lifecycle/frozen`, `enhancement`, `good first issue`
- Follows the same pattern as [kubeflow/community-distribution](https://github.com/kubeflow/community-distribution/blob/master/.github/workflows/stale.yaml)