### PR TITLE
feat(backend): auto-promote trailing cell variable to output artifact

### DIFF
--- a/docs/source/user-guide/annotating-notebooks.md
+++ b/docs/source/user-guide/annotating-notebooks.md
@@ -136,8 +136,8 @@ b = a + 1      # an assignment
 The variable must be defined in the step (or an ancestor), must not be a
 pipeline parameter, and is not duplicated if the step already outputs it.
 See the [RAG example notebook](https://github.com/kubeflow/kale/tree/main/examples/rag)
-for this in action: its final step ends with a bare `md5_hash`, which shows
-up as a downloadable artifact in the KFP UI.
+for this in action: its `create_vector_database` step ends with a bare
+`chroma_db`, which shows up as a downloadable artifact in the KFP UI.
 
 ## Organising a notebook for Kale
 

--- a/docs/source/user-guide/annotating-notebooks.md
+++ b/docs/source/user-guide/annotating-notebooks.md
@@ -95,6 +95,50 @@ Pipeline-level Kale settings live on the notebook (not on a cell) under the
 `metadata.kubeflow_notebook` key — these are the same fields the side panel
 exposes.
 
+## Output artifacts
+
+Kale passes a variable from one step to the next only when a later step
+actually uses it. A variable that nothing downstream consumes is normally
+dropped — including the "result" you leave on the last line of a cell, the
+idiomatic Jupyter way of displaying a value.
+
+Kale recognises that pattern: **if the last line of a step is a bare
+variable name, the variable is automatically promoted to a KFP output
+artifact**, even though no later step consumes it. You can then inspect and
+download it from the run's step details in the KFP UI.
+
+```python
+model = train(dataset)
+print(f"Training finished, accuracy={acc:.3f}")
+model          # <- bare trailing variable: becomes a KFP output artifact
+```
+
+The artifact type is inferred from the variable name:
+
+| Name contains        | KFP artifact type       |
+| -------------------- | ----------------------- |
+| `model`              | `Model`                 |
+| `dataset` or `data`  | `Dataset`               |
+| `metrics`            | `Metrics`               |
+| `classification`     | `ClassificationMetrics` |
+| anything else        | `Artifact`              |
+
+Only a *bare name* on the last line triggers the promotion. These do
+**not** create an artifact:
+
+```python
+print(model)   # a call, not a bare name
+df.head()      # a method call
+obj.attr       # an attribute access
+b = a + 1      # an assignment
+```
+
+The variable must be defined in the step (or an ancestor), must not be a
+pipeline parameter, and is not duplicated if the step already outputs it.
+See the [RAG example notebook](https://github.com/kubeflow/kale/tree/main/examples/rag)
+for this in action: its final step ends with a bare `md5_hash`, which shows
+up as a downloadable artifact in the KFP UI.
+
 ## Organising a notebook for Kale
 
 A notebook that compiles well with Kale usually follows this order:

--- a/examples/rag/portable_rag_langchain.ipynb
+++ b/examples/rag/portable_rag_langchain.ipynb
@@ -170,7 +170,9 @@
    },
    "source": [
     "### Check the vector DB\n",
-    "On this step we check the produced database and Kale will have to create the chroma_db output artifact to be passed to this, so we can download it from KFP"
+    "On this step we check the produced database and Kale will have to create the chroma_db output artifact to be passed to this, so we can download it from KFP.\n",
+    "\n",
+    "The step ends with a bare `md5_hash` on its last line: Kale automatically promotes a trailing variable like this to a KFP output artifact, so the hash can be inspected and downloaded from the KFP UI even though no later step consumes it."
    ]
   },
   {
@@ -186,7 +188,9 @@
    "outputs": [],
    "source": [
     "md5_hash = hashlib.md5(chroma_db).hexdigest()\n",
-    "print(f'Vector DB created sucessfully. MD5 Hash: {md5_hash}')"
+    "print(f'Vector DB created sucessfully. MD5 Hash: {md5_hash}')\n",
+    "# A bare variable on the last line becomes a KFP output artifact\n",
+    "md5_hash"
    ]
   },
   {

--- a/examples/rag/portable_rag_langchain.ipynb
+++ b/examples/rag/portable_rag_langchain.ipynb
@@ -134,7 +134,16 @@
    },
    "source": [
     "### Create Vector DB\n",
-    "We use the embeddings and the documents from the github repo to build the vector database, zip and store the zip file contents in a variable"
+    "\n",
+    "We use the embeddings and the documents from the GitHub repo to build the\n",
+    "Chroma vector database, zip it, and read the archive into the `chroma_db`\n",
+    "variable. We also compute and print an MD5 hash so the run logs record which\n",
+    "database was produced.\n",
+    "\n",
+    "The cell ends with a bare `chroma_db` on its last line. Because nothing\n",
+    "downstream consumes it, Kale automatically promotes that trailing variable to\n",
+    "a KFP output artifact, so the zipped database can be inspected and downloaded\n",
+    "from the KFP UI."
    ]
   },
   {
@@ -159,38 +168,12 @@
     "zip_file = shutil.make_archive('/tmp/chroma_db', 'zip', db_dir)\n",
     "with open(zip_file, 'rb') as f:\n",
     "    chroma_db = f.read()\n",
-    "print(f'File succesfully created and stored in {db_dir}')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "fc070eca-4281-4bee-ba21-1f224870fc37",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "### Check the vector DB\n",
-    "On this step we check the produced database and Kale will have to create the chroma_db output artifact to be passed to this, so we can download it from KFP.\n",
-    "\n",
-    "The step ends with a bare `md5_hash` on its last line: Kale automatically promotes a trailing variable like this to a KFP output artifact, so the hash can be inspected and downloaded from the KFP UI even though no later step consumes it."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "831e7fa9-2eda-413a-929c-a320d2538a45",
-   "metadata": {
-    "tags": [
-     "step:check_vector_db",
-     "prev:create_vector_database"
-    ]
-   },
-   "outputs": [],
-   "source": [
+    "print(f'File succesfully created and stored in {db_dir}')\n",
     "md5_hash = hashlib.md5(chroma_db).hexdigest()\n",
     "print(f'Vector DB created sucessfully. MD5 Hash: {md5_hash}')\n",
-    "# A bare variable on the last line becomes a KFP output artifact\n",
-    "md5_hash"
+    "# A bare variable on the last line is promoted by Kale to a KFP output\n",
+    "# artifact, so `chroma_db` can be downloaded from the KFP UI.\n",
+    "chroma_db"
    ]
   },
   {

--- a/kale/common/astutils.py
+++ b/kale/common/astutils.py
@@ -326,6 +326,43 @@ def parse_metrics_print_statements(code):
     return {re.sub("_", "-", v): v for v in variables}
 
 
+def get_trailing_variable(code):
+    """Return the variable name auto-displayed on the last line of a cell.
+
+    Kale marshals a step's ``outs`` only when a *descendant* step consumes
+    them. A variable that a user leaves on the final line of a cell -- the
+    idiomatic Jupyter way of "returning" a value (e.g. a bare ``chroma_db``)
+    -- is therefore lost, because no downstream step reads it. This helper
+    detects that pattern so the processor can promote such a variable to a
+    terminal output artifact.
+
+    In ``ast`` terms, the final statement of the cell must be an ``ast.Expr``
+    whose value is a plain ``ast.Name``. Anything else (an assignment, a
+    ``print(...)`` call, a method call like ``df.head()``, an attribute
+    access, a subscript, etc.) returns ``None``.
+
+    Args:
+        code: Multiline string representing the Python source of a cell.
+
+    Returns:
+        The variable name (str) if the last logical line is a bare name,
+        otherwise ``None``.
+    """
+    code = code.strip()
+    if not code:
+        return None
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return None
+    if not tree.body:
+        return None
+    last = tree.body[-1]
+    if isinstance(last, ast.Expr) and isinstance(last.value, ast.Name):
+        return last.value.id
+    return None
+
+
 def get_function_source(fn: Callable, strip_signature=True) -> str:
     """Get the source code of a function object.
 

--- a/kale/processors/nbprocessor.py
+++ b/kale/processors/nbprocessor.py
@@ -904,6 +904,27 @@ class NotebookProcessor:
                 # finalize bookkeeping for this step
                 step.fns_free_variables = fns_free_vars
 
+            # Terminal output artifacts -------------------------------------
+            # If the last logical line of the step is a bare variable (the
+            # idiomatic Jupyter way of surfacing a value, e.g. a trailing
+            # `chroma_db`), promote it to an output artifact even though no
+            # descendant step consumes it. Without this, such "result"
+            # variables are silently dropped. See kubeflow/kale#783.
+            trailing_var = astutils.get_trailing_variable(step_source)
+            if (
+                trailing_var
+                and trailing_var not in step.outs
+                and trailing_var in astutils.get_marshal_candidates(step_source)
+                and trailing_var not in self.pipeline.pipeline_parameters
+            ):
+                inferred_type = "Artifact"
+                for key, kfp_type in KFP_ARTIFACT_TYPE_MAP.items():
+                    if key in trailing_var.lower():
+                        inferred_type = kfp_type
+                        break
+                step.outs.append(trailing_var)
+                step.add_artifact(trailing_var, inferred_type, is_input=False)
+
     def _detect_in_dependencies(self, source_code: str, pipeline_parameters: dict | None = None):
         """Detect missing names from one pipeline step source code.
 

--- a/kale/tests/unit_tests/test_ast.py
+++ b/kale/tests/unit_tests/test_ast.py
@@ -273,12 +273,12 @@ def test_parse_assignments_expressions_exc_none():
         ("data = load()\n# trailing comment\ndata  ", "data"),
         ("def f():\n    return 1\nf", "f"),
         ("model = train()\nprint(model)", None),  # print, not a bare name
-        ("df = load()\ndf.head()", None),         # method call
-        ("obj = get()\nobj.attr", None),          # attribute access
-        ("a = 1\nb = a + 1", None),               # assignment last
+        ("df = load()\ndf.head()", None),  # method call
+        ("obj = get()\nobj.attr", None),  # attribute access
+        ("a = 1\nb = a + 1", None),  # assignment last
         ("", None),
         ("   \n   ", None),
-        ("x = (", None),                          # syntax error -> None
+        ("x = (", None),  # syntax error -> None
     ],
 )
 def test_get_trailing_variable(code, target):

--- a/kale/tests/unit_tests/test_ast.py
+++ b/kale/tests/unit_tests/test_ast.py
@@ -262,3 +262,24 @@ def test_parse_assignments_expressions_exc_none():
     with pytest.raises(ValueError) as exec:
         kale_ast.parse_assignments_expressions("a = None")
     assert "`None` value None is not supported in pipeline parameters" in str(exec.value)
+
+
+@pytest.mark.parametrize(
+    "code,target",
+    [
+        ("chroma_db = build_db()\nchroma_db", "chroma_db"),
+        ("x = 1\ny = 2\ny", "y"),
+        ("result", "result"),
+        ("data = load()\n# trailing comment\ndata  ", "data"),
+        ("def f():\n    return 1\nf", "f"),
+        ("model = train()\nprint(model)", None),  # print, not a bare name
+        ("df = load()\ndf.head()", None),         # method call
+        ("obj = get()\nobj.attr", None),          # attribute access
+        ("a = 1\nb = a + 1", None),               # assignment last
+        ("", None),
+        ("   \n   ", None),
+        ("x = (", None),                          # syntax error -> None
+    ],
+)
+def test_get_trailing_variable(code, target):
+    assert kale_ast.get_trailing_variable(code) == target


### PR DESCRIPTION
When the last logical line of a cell is a bare variable (the idiomatic Jupyter way of surfacing a value, e.g. a trailing `chroma_db`), Kale now promotes it to a terminal output artifact even when no downstream step consumes it. Previously such 'result' variables were silently dropped because outs are only marshalled when a descendant step reads them.

- astutils.get_trailing_variable(): detect a trailing bare ast.Name
- nbprocessor.dependencies_detection(): promote it via add_artifact(), reusing KFP_ARTIFACT_TYPE_MAP for type inference
- unit tests for positive/negative cases

Closes #783