### PR TITLE
docs: Add roadmap item to hide HTML Report

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,6 +10,7 @@
 - Support KFP control flow: conditions, loops, and exit handlers: https://github.com/kubeflow/kale/issues/857
 - Better notebook validation: https://github.com/kubeflow/kale/issues/560
 - Auto include output parameters on a step if the last parameter is a variable: https://github.com/kubeflow/kale/issues/783
+- Allow users to hide the HTML Report https://github.com/kubeflow/kale/issues/885
 
 ### Kubeflow SDK Integration
 


### PR DESCRIPTION
I am proposing to add this to the roadmap because I think it will be a very important feature for generating clear and less confusing pipeline definitions.