### PR TITLE
feat: Allow users to hide the HTML Report

### DIFF
--- a/docs/source/concepts/cell-types.md
+++ b/docs/source/concepts/cell-types.md
@@ -23,6 +23,7 @@ editing the notebook JSON directly.
 | `limit:<resource>:<value>`  | `limit:nvidia.com/gpu:1`        | Adds a Kubernetes resource limit to the step's pod.                    |
 | `image:<image>`             | `image:pytorch/pytorch:2.0`     | Overrides the base image for this step only.                           |
 | `cache:enabled` / `cache:disabled` | `cache:disabled`         | Opts the step into or out of KFP's built-in caching.                   |
+| `report:enabled` / `report:disabled` | `report:disabled`      | Enables or disables HTML report generation for this step.              |
 
 
 ## Per-cell-type details
@@ -128,7 +129,8 @@ A step cell can carry additional tags to customize its pod spec:
 #       limit:nvidia.com/gpu:1,
 #       annotation:team:ml,
 #       label:env:prod,
-#       cache:disabled
+#       cache:disabled,
+#       report:disabled
 ```
 
 - **`image:<image>`** — use a custom base image for just this step.
@@ -139,6 +141,10 @@ A step cell can carry additional tags to customize its pod spec:
   integration with observability tooling.
 - **`cache:disabled`** — opt the step out of KFP's caching. Use `cache:enabled`
   to force caching when it's been disabled globally.
+- **`report:disabled`** — disable HTML report generation for this step. By
+  default, each step produces an HTML artifact containing the rendered output
+  of its notebook cells. Use this tag to skip report generation when you don't
+  need it, reducing artifact storage overhead.
 
 ### `skip`
 

--- a/kale/compiler.py
+++ b/kale/compiler.py
@@ -137,7 +137,11 @@ class Compiler:
         template = self._get_templating_env().get_template(NB_FN_TEMPLATE)
 
         # Separate parameters with and without defaults for proper ordering
-        params_without_defaults = [f"{step.name}_html_report: Output[HTML]"]
+        params_without_defaults = []
+
+        # Add HTML report output only if not explicitly disabled
+        if step.config.generate_html_report is not False:
+            params_without_defaults.append(f"{step.name}_html_report: Output[HTML]")
 
         if hasattr(step, "metrics") and step.metrics:
             params_without_defaults.append("kale_metrics_artifact: Output[Metrics]")

--- a/kale/processors/nbprocessor.py
+++ b/kale/processors/nbprocessor.py
@@ -58,6 +58,11 @@ IMAGE_TAG = r"^image:(.+)$"
 CACHE_ENABLED = "enabled"
 CACHE_DISABLED = "disabled"
 CACHE_TAG = rf"^cache:({CACHE_ENABLED}|{CACHE_DISABLED})$"
+# Report tag for per-step HTML report generation control
+# E.g.: report:enabled or report:disabled
+REPORT_ENABLED = "enabled"
+REPORT_DISABLED = "disabled"
+REPORT_TAG = rf"^report:({REPORT_ENABLED}|{REPORT_DISABLED})$"
 
 _TAGS_LANGUAGE = [
     SKIP_TAG,
@@ -72,9 +77,10 @@ _TAGS_LANGUAGE = [
     LIMITS_TAG,
     IMAGE_TAG,
     CACHE_TAG,
+    REPORT_TAG,
 ]
 # These tags are applied to every step of the pipeline
-_STEPS_DEFAULTS_LANGUAGE = [ANNOTATION_TAG, LABEL_TAG, LIMITS_TAG, IMAGE_TAG, CACHE_TAG]
+_STEPS_DEFAULTS_LANGUAGE = [ANNOTATION_TAG, LABEL_TAG, LIMITS_TAG, IMAGE_TAG, CACHE_TAG, REPORT_TAG]
 
 
 METRICS_TEMPLATE = """\
@@ -176,6 +182,11 @@ class NotebookConfig(PipelineConfig):
                 # Cache value is 'enabled' or 'disabled'
                 cache_value = parts.pop(0)
                 result["enable_caching"] = cache_value == CACHE_ENABLED
+
+            if conf_type == "report":
+                # Report value is 'enabled' or 'disabled'
+                report_value = parts.pop(0)
+                result["generate_html_report"] = report_value == REPORT_ENABLED
         return result
 
 
@@ -377,6 +388,7 @@ class NotebookProcessor:
                         annotations=tags.get("annotations", {}),
                         base_image=tags.get("base_image", ""),
                         enable_caching=tags.get("enable_caching"),
+                        generate_html_report=tags.get("generate_html_report"),
                     )
                     self.pipeline.add_step(step)
                     for _prev_step in tags["prev_steps"]:
@@ -430,6 +442,7 @@ class NotebookProcessor:
         cell_limits = {}
         cell_base_image = None
         cell_enable_caching = None
+        cell_generate_html_report = None
 
         # the notebook cell was not tagged
         if "tags" not in metadata or len(metadata["tags"]) == 0:
@@ -490,6 +503,11 @@ class NotebookProcessor:
                 cache_value = tag_parts.pop(0)
                 cell_enable_caching = cache_value == CACHE_ENABLED
 
+            if tag_name == "report":
+                # Report value is 'enabled' or 'disabled'
+                report_value = tag_parts.pop(0)
+                cell_generate_html_report = report_value == REPORT_ENABLED
+
             # name of the future Pipeline step
             if tag_name in ["step"]:
                 step_name = tag_parts.pop(0)
@@ -543,6 +561,14 @@ class NotebookProcessor:
                     " cell that does not declare a step name."
                 )
             parsed_tags["enable_caching"] = cell_enable_caching
+
+        if cell_generate_html_report is not None:
+            if missing_step_names:
+                raise ValueError(
+                    "A cell can not provide HTML report control in a"
+                    " cell that does not declare a step name."
+                )
+            parsed_tags["generate_html_report"] = cell_generate_html_report
         return parsed_tags
 
     def get_pipeline_parameters_source(self):

--- a/kale/step.py
+++ b/kale/step.py
@@ -53,6 +53,7 @@ class StepConfig(Config):
     limits = Field(type=dict, default={}, validators=[validators.K8sLimitsValidator])
     base_image = Field(type=str, default="")
     enable_caching = Field(type=bool)
+    generate_html_report = Field(type=bool)
     retry_count = Field(type=int, default=0)
     retry_interval = Field(type=str)
     retry_factor = Field(type=int)

--- a/kale/templates/nb_function_template.jinja2
+++ b/kale/templates/nb_function_template.jinja2
@@ -70,7 +70,9 @@ def {{ step.name }}_step({{ component_signature_args }}):
         f.write(_kale_html_artifact)
 {%- else %}
     _kale_run_code(_kale_blocks)
-{%- endif %}{%- if step.outs|length > 0 %}
+{%- endif %}
+
+{%- if step.outs|length > 0 %}
     # Prepare output artifacts to be retrieved during the pipeline execution
     from kale import marshal as _kale_marshal
     _kale_marshal.set_data_dir("{{ marshal_path }}")

--- a/kale/templates/nb_function_template.jinja2
+++ b/kale/templates/nb_function_template.jinja2
@@ -64,15 +64,13 @@ def {{ step.name }}_step({{ component_signature_args }}):
         _kale_data_saving_block
     )
 
-{%- if step.config.generate_html_report is not false %}
+{% if step.config.generate_html_report is not false %}
     _kale_html_artifact = _kale_run_code(_kale_blocks)
     with open({{ step.name }}_html_report.path, "w") as f:
         f.write(_kale_html_artifact)
 {%- else %}
     _kale_run_code(_kale_blocks)
-{%- endif %}
-
-{%- if step.outs|length > 0 %}
+{%- endif %}{%- if step.outs|length > 0 %}
     # Prepare output artifacts to be retrieved during the pipeline execution
     from kale import marshal as _kale_marshal
     _kale_marshal.set_data_dir("{{ marshal_path }}")

--- a/kale/templates/nb_function_template.jinja2
+++ b/kale/templates/nb_function_template.jinja2
@@ -64,9 +64,13 @@ def {{ step.name }}_step({{ component_signature_args }}):
         _kale_data_saving_block
     )
 
+{%- if step.config.generate_html_report is not false %}
     _kale_html_artifact = _kale_run_code(_kale_blocks)
     with open({{ step.name }}_html_report.path, "w") as f:
         f.write(_kale_html_artifact)
+{%- else %}
+    _kale_run_code(_kale_blocks)
+{%- endif %}
 
 {%- if step.outs|length > 0 %}
     # Prepare output artifacts to be retrieved during the pipeline execution

--- a/kale/tests/unit_tests/test_parser.py
+++ b/kale/tests/unit_tests/test_parser.py
@@ -171,3 +171,81 @@ def test_get_pipeline_metrics_source_raises(notebook_processor):
     ):
         notebook_processor.notebook = notebook
         notebook_processor.get_pipeline_metrics_source()
+
+
+@pytest.mark.parametrize(
+    "metadata,expected_report_value",
+    [
+        ({"tags": ["step:test", "report:enabled"]}, True),
+        ({"tags": ["step:test", "report:disabled"]}, False),
+        ({"tags": ["step:test"]}, None),  # No report tag means None (use default)
+    ],
+)
+def test_parse_report_tag(notebook_processor, metadata, expected_report_value):
+    """Test that report:enabled and report:disabled tags are parsed correctly."""
+    result = notebook_processor.parse_cell_metadata(metadata)
+    assert result.get("generate_html_report") == expected_report_value
+
+
+def test_report_tag_requires_step(notebook_processor):
+    """Test that report tag raises an error when used without a step tag."""
+    metadata = {"tags": ["report:disabled"]}
+    with pytest.raises(
+        ValueError,
+        match=r"A cell can not provide HTML report control in a"
+        r" cell that does not declare a step name\.",
+    ):
+        notebook_processor.parse_cell_metadata(metadata)
+
+
+def test_compiler_includes_html_report_by_default():
+    """Test that HTML report output is included when generate_html_report is not disabled."""
+    from kale.compiler import Compiler
+    from kale.pipeline import Pipeline, PipelineConfig
+
+    config = PipelineConfig(pipeline_name="test", experiment_name="test")
+    pipeline = Pipeline(config)
+    step = Step(name="my_step", source=["x = 1"])
+    pipeline.add_step(step)
+
+    compiler = Compiler(pipeline, imports_and_functions="")
+    component_code = compiler.generate_lightweight_component(step)
+
+    assert "my_step_html_report: Output[HTML]" in component_code
+    assert "_kale_html_artifact = _kale_run_code(_kale_blocks)" in component_code
+
+
+def test_compiler_excludes_html_report_when_disabled():
+    """Test that HTML report output is excluded when generate_html_report=False."""
+    from kale.compiler import Compiler
+    from kale.pipeline import Pipeline, PipelineConfig
+
+    config = PipelineConfig(pipeline_name="test", experiment_name="test")
+    pipeline = Pipeline(config)
+    step = Step(name="my_step", source=["x = 1"], generate_html_report=False)
+    pipeline.add_step(step)
+
+    compiler = Compiler(pipeline, imports_and_functions="")
+    component_code = compiler.generate_lightweight_component(step)
+
+    assert "my_step_html_report: Output[HTML]" not in component_code
+    assert "_kale_html_artifact = _kale_run_code(_kale_blocks)" not in component_code
+    # Should still call _kale_run_code, just without capturing the artifact
+    assert "_kale_run_code(_kale_blocks)" in component_code
+
+
+def test_compiler_includes_html_report_when_explicitly_enabled():
+    """Test that HTML report output is included when generate_html_report=True."""
+    from kale.compiler import Compiler
+    from kale.pipeline import Pipeline, PipelineConfig
+
+    config = PipelineConfig(pipeline_name="test", experiment_name="test")
+    pipeline = Pipeline(config)
+    step = Step(name="my_step", source=["x = 1"], generate_html_report=True)
+    pipeline.add_step(step)
+
+    compiler = Compiler(pipeline, imports_and_functions="")
+    component_code = compiler.generate_lightweight_component(step)
+
+    assert "my_step_html_report: Output[HTML]" in component_code
+    assert "_kale_html_artifact = _kale_run_code(_kale_blocks)" in component_code

--- a/labextension/src/lib/TagsUtils.ts
+++ b/labextension/src/lib/TagsUtils.ts
@@ -20,6 +20,8 @@ import { KALE_TAG_PREFIXES } from '../widgets/cell-metadata/constants';
 const IMAGE_TAG = 'image:';
 const CACHE_TAG = 'cache:';
 const CACHE_ENABLED_VALUE = 'enabled';
+const REPORT_TAG = 'report:';
+const REPORT_ENABLED_VALUE = 'enabled';
 
 interface IKaleCellTags {
   stepName: string;
@@ -27,6 +29,7 @@ interface IKaleCellTags {
   limits?: { [id: string]: string };
   baseImage?: string;
   enableCaching?: boolean;
+  generateHtmlReport?: boolean;
 }
 
 /** Contains utility functions for manipulating/handling Kale cell tags. */
@@ -129,12 +132,21 @@ export default class TagsUtils {
         enableCaching = cacheValue === CACHE_ENABLED_VALUE ? true : false;
       }
 
+      // Parse report tag
+      let generateHtmlReport: boolean | undefined;
+      const reportTag = tags.find(v => v.startsWith(REPORT_TAG));
+      if (reportTag) {
+        const reportValue = reportTag.substring(REPORT_TAG.length);
+        generateHtmlReport = reportValue === REPORT_ENABLED_VALUE ? true : false;
+      }
+
       return {
         stepName: b_name[0] || '',
         prevStepNames: prevs,
         limits: limits,
         baseImage: baseImage,
         enableCaching: enableCaching,
+        generateHtmlReport: generateHtmlReport,
       };
     }
     return null;
@@ -175,6 +187,11 @@ export default class TagsUtils {
     // Add cache tag if specified
     if (metadata.enableCaching !== undefined) {
       tags.push(CACHE_TAG + (metadata.enableCaching ? 'enabled' : 'disabled'));
+    }
+
+    // Add report tag if specified
+    if (metadata.generateHtmlReport !== undefined) {
+      tags.push(REPORT_TAG + (metadata.generateHtmlReport ? 'enabled' : 'disabled'));
     }
 
     return CellUtils.setCellMetaData(notebookPanel, index, 'tags', tags);

--- a/labextension/src/widgets/cell-metadata/CellMetadataEditor.tsx
+++ b/labextension/src/widgets/cell-metadata/CellMetadataEditor.tsx
@@ -260,7 +260,7 @@ export const CellMetadataEditor: React.FC<IProps> = props => {
                     onClick={() => setHtmlReportDialogOpen(true)}
                     style={{ width: '5%' }}
                   >
-                    REPORT
+                    HTML REPORT
                   </Button>
                 </div>
               </>

--- a/labextension/src/widgets/cell-metadata/CellMetadataEditor.tsx
+++ b/labextension/src/widgets/cell-metadata/CellMetadataEditor.tsx
@@ -27,6 +27,7 @@ import { SelectMulti } from '../../components/SelectMulti';
 import { GpuDialog } from './dialogs/GpuDialog';
 import { BaseImageDialog } from './dialogs/BaseImageDialog';
 import { CacheDialog } from './dialogs/CacheDialog';
+import { HtmlReportDialog } from './dialogs/HtmlReportDialog';
 import { useUpdateCellTags } from './hooks/useCellTags';
 import { useEditorPosition } from './hooks/useEditorPosition';
 import {
@@ -48,6 +49,7 @@ export interface ICellEditorData {
   limits?: { [id: string]: string };
   baseImage?: string;
   enableCaching?: boolean;
+  generateHtmlReport?: boolean;
 }
 
 export interface IProps extends ICellEditorData {
@@ -62,6 +64,7 @@ export const CellMetadataEditor: React.FC<IProps> = props => {
     limits = {},
     baseImage,
     enableCaching,
+    generateHtmlReport,
     resolvedDefaultBaseImage,
   } = props;
 
@@ -77,6 +80,7 @@ export const CellMetadataEditor: React.FC<IProps> = props => {
     limits,
     baseImage,
     enableCaching,
+    generateHtmlReport,
   });
 
   useEditorPosition(editorRef, notebook);
@@ -132,6 +136,7 @@ export const CellMetadataEditor: React.FC<IProps> = props => {
   const [gpuDialogOpen, setGpuDialogOpen] = useState(false);
   const [baseImageDialogOpen, setBaseImageDialogOpen] = useState(false);
   const [cacheDialogOpen, setCacheDialogOpen] = useState(false);
+  const [htmlReportDialogOpen, setHtmlReportDialogOpen] = useState(false);
 
   const closeEditor = useCallback(() => {
     onEditorVisibilityChange(false);
@@ -231,7 +236,7 @@ export const CellMetadataEditor: React.FC<IProps> = props => {
                   </Button>
                 </div>
 
-                <div style={{ padding: 0 }}>
+                <div style={{ padding: 0, marginRight: '4px' }}>
                   <Button
                     disabled={!hasStepName}
                     color="primary"
@@ -242,6 +247,20 @@ export const CellMetadataEditor: React.FC<IProps> = props => {
                     style={{ width: '5%' }}
                   >
                     CACHE
+                  </Button>
+                </div>
+
+                <div style={{ padding: 0 }}>
+                  <Button
+                    disabled={!hasStepName}
+                    color="primary"
+                    variant="contained"
+                    size="small"
+                    title="HTML Report"
+                    onClick={() => setHtmlReportDialogOpen(true)}
+                    style={{ width: '5%' }}
+                  >
+                    REPORT
                   </Button>
                 </div>
               </>
@@ -295,6 +314,13 @@ export const CellMetadataEditor: React.FC<IProps> = props => {
         onClose={() => setCacheDialogOpen(false)}
         enableCaching={enableCaching}
         onUpdateCaching={updateCellTags.updateCaching}
+      />
+
+      <HtmlReportDialog
+        open={htmlReportDialogOpen}
+        onClose={() => setHtmlReportDialogOpen(false)}
+        generateHtmlReport={generateHtmlReport}
+        onUpdateHtmlReport={updateCellTags.updateHtmlReport}
       />
     </>
   );

--- a/labextension/src/widgets/cell-metadata/InlineCellsMetadata.tsx
+++ b/labextension/src/widgets/cell-metadata/InlineCellsMetadata.tsx
@@ -125,6 +125,7 @@ export const InlineCellsMetadata: React.FC<IProps> = ({
         limits: activeEditorData.limits || {},
         baseImage: activeEditorData.baseImage,
         enableCaching: activeEditorData.enableCaching,
+        generateHtmlReport: activeEditorData.generateHtmlReport,
       }
     : {
         notebook: notebook,
@@ -133,6 +134,7 @@ export const InlineCellsMetadata: React.FC<IProps> = ({
         limits: {},
         baseImage: undefined,
         enableCaching: undefined,
+        generateHtmlReport: undefined,
       };
 
   const cellMetadataEditor = createPortal(
@@ -143,6 +145,7 @@ export const InlineCellsMetadata: React.FC<IProps> = ({
       limits={editorProps.limits}
       baseImage={editorProps.baseImage}
       enableCaching={editorProps.enableCaching}
+      generateHtmlReport={editorProps.generateHtmlReport}
       resolvedDefaultBaseImage={resolvedDefaultBaseImage}
     />,
     document.body,

--- a/labextension/src/widgets/cell-metadata/InlineMetadata.tsx
+++ b/labextension/src/widgets/cell-metadata/InlineMetadata.tsx
@@ -30,6 +30,7 @@ interface IProps {
   limits: { [id: string]: string };
   baseImage?: string;
   enableCaching?: boolean;
+  generateHtmlReport?: boolean;
   cellElement: any;
   cellIndex: number;
   resolvedDefaultBaseImage: string;
@@ -59,6 +60,7 @@ export const InlineMetadata: React.FC<IProps> = ({
   limits,
   baseImage,
   enableCaching,
+  generateHtmlReport,
   cellElement,
   cellIndex,
   resolvedDefaultBaseImage,
@@ -153,6 +155,13 @@ export const InlineMetadata: React.FC<IProps> = ({
       </p>
     ) : null;
 
+  const reportText =
+    generateHtmlReport === false ? (
+      <p style={{ fontStyle: 'italic', marginLeft: '10px' }}>
+        HTML Report: disabled
+      </p>
+    ) : null;
+
   const details = isReserved ? null : (
     <>
       {dependencies.length > 0 ? (
@@ -162,6 +171,7 @@ export const InlineMetadata: React.FC<IProps> = ({
       {limitsText}
       {baseImageText}
       {cacheText}
+      {reportText}
     </>
   );
 

--- a/labextension/src/widgets/cell-metadata/constants.ts
+++ b/labextension/src/widgets/cell-metadata/constants.ts
@@ -34,6 +34,7 @@ export const KALE_TAG_PREFIXES = [
   'limit:',
   'image:',
   'cache:',
+  'report:',
   'skip',
   'imports',
   'functions',

--- a/labextension/src/widgets/cell-metadata/dialogs/HtmlReportDialog.tsx
+++ b/labextension/src/widgets/cell-metadata/dialogs/HtmlReportDialog.tsx
@@ -1,0 +1,89 @@
+// Copyright 2026 The Kubeflow Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as React from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  FormControl,
+  FormControlLabel,
+  Radio,
+  RadioGroup,
+} from '@mui/material';
+
+type HtmlReportValue = 'default' | 'disabled';
+
+interface IHtmlReportDialogProps {
+  open: boolean;
+  onClose: () => void;
+  generateHtmlReport?: boolean;
+  onUpdateHtmlReport: (value: boolean | undefined) => void;
+}
+
+export const HtmlReportDialog: React.FC<IHtmlReportDialogProps> = ({
+  open,
+  onClose,
+  generateHtmlReport,
+  onUpdateHtmlReport,
+}) => {
+  const [reportValue, setReportValue] =
+    React.useState<HtmlReportValue>('default');
+
+  React.useEffect(() => {
+    if (open) {
+      setReportValue(generateHtmlReport === false ? 'disabled' : 'default');
+    }
+  }, [open, generateHtmlReport]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value as HtmlReportValue;
+    setReportValue(val);
+    onUpdateHtmlReport(val === 'disabled' ? false : undefined);
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>HTML Report Generation</DialogTitle>
+      <DialogContent>
+        <p style={{ margin: '8px 0 16px 0' }}>
+          Control whether this step generates an HTML report artifact. The HTML
+          report contains the rendered output of the notebook cells executed in
+          this step.
+        </p>
+        <FormControl component="fieldset">
+          <RadioGroup value={reportValue} onChange={handleChange}>
+            <FormControlLabel
+              value="default"
+              control={<Radio />}
+              label="Generate HTML Report (Default)"
+            />
+            <FormControlLabel
+              value="disabled"
+              control={<Radio />}
+              label="Disable HTML Report"
+            />
+          </RadioGroup>
+        </FormControl>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="primary">
+          Ok
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/labextension/src/widgets/cell-metadata/hooks/useCellTags.ts
+++ b/labextension/src/widgets/cell-metadata/hooks/useCellTags.ts
@@ -25,6 +25,7 @@ interface IUseCellTagsParams {
   limits?: { [id: string]: string };
   baseImage?: string;
   enableCaching?: boolean;
+  generateHtmlReport?: boolean;
 }
 
 /**
@@ -39,6 +40,7 @@ export function useUpdateCellTags({
   limits,
   baseImage,
   enableCaching,
+  generateHtmlReport,
 }: IUseCellTagsParams) {
   const { activeCellIndex } = useContext(CellMetadataContext);
 
@@ -51,6 +53,7 @@ export function useUpdateCellTags({
         limits: limits || {},
         baseImage,
         enableCaching,
+        generateHtmlReport,
         stepName: value,
       });
     },
@@ -62,6 +65,7 @@ export function useUpdateCellTags({
       limits,
       baseImage,
       enableCaching,
+      generateHtmlReport,
     ],
   );
 
@@ -83,10 +87,19 @@ export function useUpdateCellTags({
         limits: limits || {},
         baseImage,
         enableCaching,
+        generateHtmlReport,
         prevStepNames: previousSteps,
       });
     },
-    [notebook, activeCellIndex, stepName, limits, baseImage, enableCaching],
+    [
+      notebook,
+      activeCellIndex,
+      stepName,
+      limits,
+      baseImage,
+      enableCaching,
+      generateHtmlReport,
+    ],
   );
 
   const updateLimits = useCallback(
@@ -116,6 +129,74 @@ export function useUpdateCellTags({
         limits: newLimits,
         baseImage,
         enableCaching,
+        generateHtmlReport,
+      });
+    },
+    [
+      notebook,
+      activeCellIndex,
+      stepName,
+      stepDependencies,
+      limits,
+      baseImage,
+      enableCaching,
+      generateHtmlReport,
+    ],
+  );
+
+  const updateBaseImage = useCallback(
+    (value: string) => {
+      TagsUtils.setKaleCellTags(notebook, activeCellIndex, {
+        stepName: stepName || '',
+        prevStepNames: stepDependencies,
+        limits: limits || {},
+        baseImage: value || undefined,
+        enableCaching,
+        generateHtmlReport,
+      });
+    },
+    [
+      notebook,
+      activeCellIndex,
+      stepName,
+      stepDependencies,
+      limits,
+      enableCaching,
+      generateHtmlReport,
+    ],
+  );
+
+  const updateCaching = useCallback(
+    (value: boolean | undefined) => {
+      TagsUtils.setKaleCellTags(notebook, activeCellIndex, {
+        stepName: stepName || '',
+        prevStepNames: stepDependencies,
+        limits: limits || {},
+        baseImage,
+        enableCaching: value,
+        generateHtmlReport,
+      });
+    },
+    [
+      notebook,
+      activeCellIndex,
+      stepName,
+      stepDependencies,
+      limits,
+      baseImage,
+      generateHtmlReport,
+    ],
+  );
+
+  const updateHtmlReport = useCallback(
+    (value: boolean | undefined) => {
+      TagsUtils.setKaleCellTags(notebook, activeCellIndex, {
+        stepName: stepName || '',
+        prevStepNames: stepDependencies,
+        limits: limits || {},
+        baseImage,
+        enableCaching,
+        generateHtmlReport: value,
       });
     },
     [
@@ -128,39 +209,6 @@ export function useUpdateCellTags({
       enableCaching,
     ],
   );
-
-  const updateBaseImage = useCallback(
-    (value: string) => {
-      TagsUtils.setKaleCellTags(notebook, activeCellIndex, {
-        stepName: stepName || '',
-        prevStepNames: stepDependencies,
-        limits: limits || {},
-        baseImage: value || undefined,
-        enableCaching,
-      });
-    },
-    [
-      notebook,
-      activeCellIndex,
-      stepName,
-      stepDependencies,
-      limits,
-      enableCaching,
-    ],
-  );
-
-  const updateCaching = useCallback(
-    (value: boolean | undefined) => {
-      TagsUtils.setKaleCellTags(notebook, activeCellIndex, {
-        stepName: stepName || '',
-        prevStepNames: stepDependencies,
-        limits: limits || {},
-        baseImage,
-        enableCaching: value,
-      });
-    },
-    [notebook, activeCellIndex, stepName, stepDependencies, limits, baseImage],
-  );
   const clearCellMetadata = useCallback(() => {
     TagsUtils.removeAllKaleTags(notebook, activeCellIndex);
   }, [notebook, activeCellIndex]);
@@ -172,6 +220,7 @@ export function useUpdateCellTags({
     updateLimits,
     updateBaseImage,
     updateCaching,
+    updateHtmlReport,
     clearCellMetadata,
   };
 }

--- a/labextension/src/widgets/cell-metadata/hooks/useInlineMetadata.tsx
+++ b/labextension/src/widgets/cell-metadata/hooks/useInlineMetadata.tsx
@@ -119,6 +119,7 @@ export function useInlineMetadata(
         limits: tags.limits || {},
         baseImage: tags.baseImage,
         enableCaching: tags.enableCaching,
+        generateHtmlReport: tags.generateHtmlReport,
       };
 
       const cellElement = nb.content.widgets[index].node as HTMLElement;
@@ -150,6 +151,7 @@ export function useInlineMetadata(
             limits={tags.limits || {}}
             baseImage={tags.baseImage}
             enableCaching={tags.enableCaching}
+            generateHtmlReport={tags.generateHtmlReport}
             previousStepName={previousStepName}
             cellIndex={index}
             resolvedDefaultBaseImage={


### PR DESCRIPTION
## Allow Users to Hide the HTML Report
This branch adds a new feature that allows users to disable HTML report generation on a per-step basis in Kale pipelines.

## Changes

### Backend (Python):

* Added generate_html_report field to StepConfig in step.py
* Added report:enabled|disabled tag parsing in nbprocessor.py
* Modified compiler.py to conditionally include the HTML report output parameter
* Updated Jinja2 template nb_function_template.jinja2 to skip HTML artifact generation when disabled

### Frontend (TypeScript/React):

* Added new HtmlReportDialog component in dialogs/HtmlReportDialog.tsx
* Added "REPORT" button to CellMetadataEditor to open the dialog
* Extended TagsUtils to parse and serialize report: tags
* Updated useCellTags hook with updateHtmlReport function
* Added report: to known tag prefixes in constants

### Usage

Users can now add a report:disabled tag to step cells to skip HTML report generation, reducing pipeline artifact overhead when the rendered notebook output isn't needed.


Example, the following notebook:
<img width="516" height="361" alt="image" src="https://github.com/user-attachments/assets/becaf450-2512-4e06-84a7-633e34288aa8" />



Would generate an HTML report for both the first cell and the second, but the first HTML report would be generated but without any content:

<img width="1131" height="570" alt="image" src="https://github.com/user-attachments/assets/3b511d78-f769-4920-8585-1bc4425ed749" />


Disabling the HTML output now generates a different pipeline with no HTML output for the first cell
<img width="1102" height="577" alt="image" src="https://github.com/user-attachments/assets/0c69428c-c208-4008-be66-0fe150349aaf" />



<img width="639" height="662" alt="image" src="https://github.com/user-attachments/assets/8195244d-3fd2-4036-80f4-9038d04c75ef" />

