### PR TITLE
fix(backend): avoid duplicate PyPI index url in compute_pip_index_urls

### DIFF
--- a/kale/common/utils.py
+++ b/kale/common/utils.py
@@ -250,11 +250,9 @@ def compute_pip_index_urls() -> list[str]:
                 )
             )
 
-    # important to keep the prod url at the end to preserve package
-    # resolution order.
-    urls.append(pypi_prod_url)
-
-    # remove duplicates while keeping order
+    # Keep the prod url at the end to preserve package resolution order, but
+    # only add it when the user hasn't already included it, so it is not
+    # duplicated in the resulting list.
     if pypi_prod_url not in urls:
         urls.append(pypi_prod_url)
     return urls

--- a/kale/tests/unit_tests/test_utils.py
+++ b/kale/tests/unit_tests/test_utils.py
@@ -128,6 +128,21 @@ def test_compute_pip_index_urls_override_beats_dev_mode(monkeypatch):
     ]
 
 
+def test_compute_pip_index_urls_override_includes_pypi(monkeypatch):
+    """PyPI is not duplicated when the user's override already contains it."""
+    _clear_env(monkeypatch)
+    monkeypatch.setenv(
+        "KALE_PIP_INDEX_URLS",
+        "https://pypi.org/simple, https://mirror.one/simple",
+    )
+
+    # PyPI keeps the user-specified position and appears exactly once.
+    assert utils.compute_pip_index_urls() == [
+        "https://pypi.org/simple",
+        "https://mirror.one/simple",
+    ]
+
+
 def _clear_security_context_env(monkeypatch):
     """Ensure security context env vars are unset for predictable tests."""
     for key in (


### PR DESCRIPTION
## What this does

Fixes `compute_pip_index_urls` so the production PyPI index (`https://pypi.org/simple`) is added exactly once.

## Why

The tail of the function was:

```python
urls.append(pypi_prod_url)              # unconditional append

# remove duplicates while keeping order
if pypi_prod_url not in urls:           # always False here — dead code
    urls.append(pypi_prod_url)
return urls
```

Because `pypi_prod_url` was appended unconditionally just above, the `if pypi_prod_url not in urls` guard was always false and never deduplicated anything. When a user's `KALE_PIP_INDEX_URLS` already included `https://pypi.org/simple`, it ended up in the list twice:

```python
KALE_PIP_INDEX_URLS="https://pypi.org/simple,http://myindex/simple"
# before: ['https://pypi.org/simple', 'http://myindex/simple', 'https://pypi.org/simple']
# after:  ['https://pypi.org/simple', 'http://myindex/simple']
```

The fix drops the unconditional append and keeps only the guarded one, so PyPI is appended only when the user hasn't already listed it, preserving their chosen position.

## Testing

Added `test_compute_pip_index_urls_override_includes_pypi` covering the override-includes-PyPI case. It fails on `main` and passes with this change; the existing `compute_pip_index_urls` tests continue to pass.

Found while reading `kale/common/utils.py`. Happy to open a tracking issue if maintainers prefer.
