### PR TITLE
build(deps): bump js-yaml from 3.14.2 to 3.15.0 in /labextension

### DIFF
--- a/labextension/yarn.lock
+++ b/labextension/yarn.lock
@@ -8443,14 +8443,14 @@ __metadata:
   linkType: hard
 
 "js-yaml@npm:^3.13.1":
-  version: 3.14.2
-  resolution: "js-yaml@npm:3.14.2"
+  version: 3.15.0
+  resolution: "js-yaml@npm:3.15.0"
   dependencies:
     argparse: ^1.0.7
     esprima: ^4.0.0
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 626fc207734a3452d6ba84e1c8c226240e6d431426ed94d0ab043c50926d97c509629c08b1d636f5d27815833b7cfd225865631da9fb33cb957374490bf3e90b
+  checksum: 0209830c3ce51cec4c2cefee4b2b68c547b56b36920004efbf7c6a91ae7eee784bf64341738ef1acffa975d16e7882e9b69234b9a4411f455b72b33d4d74771e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bumps [js-yaml](https://github.com/nodeca/js-yaml) from 3.14.2 to 3.15.0 (indirect dependency in `labextension/yarn.lock`)
- Security update: backports `maxTotalMergeKeys` option to limit total keys processed by YAML merge across `load()`/`loadAll()` calls
- Manual recreation of #863 — the Dependabot PR failed CI because it included a mismatched typescript compat-patch hash (`5786d5` vs `85af82`) that caused `YN0028` (immutable lockfile violation). This PR regenerates the lockfile using `jlpm` (Yarn 3.5.0) to produce correct checksums.

## Test plan
- [x] `CI=true jlpm install` passes (no YN0028 immutable lockfile error)
- [x] TypeScript compilation (`tsc --noEmit`) passes
- [x] Jest tests pass
- [x] ESLint passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)