### PR TITLE
chore(release): v2.2.0

### DIFF
--- a/CHANGELOG/CHANGELOG-2.2.md
+++ b/CHANGELOG/CHANGELOG-2.2.md
@@ -1,0 +1,90 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [2.2.0] - 2026-08-05
+
+### Build
+
+- *(deps)* Bump dompurify from 3.4.2 to 3.4.10 in /labextension/ui-tests (#832)
+- *(deps)* Bump tornado from 6.5.5 to 6.5.7 (#833)
+- *(deps)* Bump bleach from 6.3.0 to 6.4.0 (#834)
+- *(deps)* Bump cryptography from 46.0.7 to 48.0.1 (#835)
+- *(deps)* Bump jupyter-server from 2.18.0 to 2.20.0 (#841)
+- *(deps)* Bump transitive JS dependencies (#844)
+- *(deps)* Bump tar from 7.5.12 to 7.5.17 in /labextension/ui-tests (#845)
+- *(deps)* Bump form-data from 4.0.5 to 4.0.6 in /labextension/ui-tests (#846)
+- *(deps)* Bump soupsieve from 2.8.3 to 2.8.4 (#876)
+- *(deps)* Bump mistune from 3.2.1 to 3.3.0 (#877)
+- *(deps)* Bump ws from 8.19.0 to 8.21.0 in /labextension/ui-tests (#878)
+- *(deps)* Bump systeminformation from 5.31.6 to 5.31.17 in /labextension/ui-tests (#880)
+- *(deps)* Bump brace-expansion from 5.0.6 to 5.0.7 in /labextension/ui-tests (#890)
+- *(deps)* Bump setuptools from 82.0.0 to 83.0.0 (#897)
+- *(deps)* Bump pyasn1 from 0.6.3 to 0.6.4 (#896)
+- *(deps)* Bump fast-uri from 3.1.2 to 3.1.4 in /labextension/ui-tests (#902)
+- *(deps)* Bump dompurify from 3.4.10 to 3.4.12 in /labextension/ui-tests (#903)
+- *(deps)* Bump js-yaml from 3.14.2 to 3.15.0 in /labextension (#895)
+- *(deps)* Bump brace-expansion from 5.0.7 to 5.0.9 in /labextension/ui-tests (#910)
+- *(deps)* Bump ip-address from 10.2.0 to 10.4.0 in /labextension/ui-tests (#911)
+- *(deps)* Bump 7 transitive deps, regenerating locks with jlpm/uv (#918)
+
+### Documentation
+
+- Add project ROADMAP.md (#858)
+- Add v2.1 release news and good first issues link (#859)
+- Add KEP-0607 for built-in example notebooks catalog (#850)
+- Add KEP-0812 Composable Kale Notebooks proposal (#847)
+- Add roadmap item to hide HTML Report (#886)
+- Add KEP-843 for mounting PVCs (#888)
+
+### Features
+
+- *(dev)* Add lightweight KFP local dev cluster via k3d (#753)
+- *(frontend)* Add clear metadata button to cell metadata editor (#811)
+- *(backend)* Support KALE_PYPI_PROD_URL for configurable production PyPI index (#866)
+- *(backend)* Auto-promote trailing cell variable to output artifact (#874)
+- Allow users to hide the HTML Report (#889)
+- Consolidate per-step config buttons into a single Configure dialog (#908)
+
+### Miscellaneous
+
+- Add CODE_OF_CONDUCT.md in kubeflow/kale (#830)
+- Add ADOPTERS.md for Kale (#860)
+- Add PR title check workflow with conventional commits (#861)
+- Add stale issues and PRs workflow (#862)
+- *(frontend)* Remove DeploysProgress wrapper and simplify to single DeployProgress (#842)
+
+### Other
+
+- Removing Default Security Context (#823)
+
+Signed-off-by: William Siqueira <william.fatecsjc@gmail.com>
+- Add SECURITY.md (#849)
+
+Define security processes including vulnerability reporting channels,
+disclosure process, and prevention mechanisms per Kubeflow incubating
+maturity requirements.
+
+Signed-off-by: Eder Ignatowicz <ignatowicz@gmail.com>
+Co-authored-by: Claude <noreply@anthropic.com>
+- Add env vars for customization of run and upload links (#821)
+
+* add 2 new env variables to explicitly overwrite the run and upload links
+
+Signed-off-by: Adam Maly <amaly@redhat.com>
+
+* edit docs
+
+Signed-off-by: Adam Maly <amaly@redhat.com>
+
+* fixes from review - renaming, promiseAll, using only 1 type
+
+Signed-off-by: Adam Maly <amaly@redhat.com>
+
+* fixes from review - add basic validation and log only on Kale start
+
+Signed-off-by: Adam Maly <amaly@redhat.com>
+
+---------
+
+Signed-off-by: Adam Maly <amaly@redhat.com>

--- a/kale/__init__.py
+++ b/kale/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 from typing import Any, NamedTuple
 

--- a/labextension/package.json
+++ b/labextension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jupyterlab-kubeflow-kale",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Convert Notebooks to Kubeflow pipelines with Kale",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
## What

Version bump for the **2.2.0** release, per [RELEASE.md](https://github.com/kubeflow/kale/blob/main/RELEASE.md).

| File | From | To |
|---|---|---|
| `kale/__init__.py` | 2.1.0 | 2.2.0 |
| `labextension/package.json` | 2.1.0 | 2.2.0 |
| `CHANGELOG/CHANGELOG-2.2.md` | — | new (91 lines) |

**This must merge before the release workflow can run.** The workflow has no version input — [release.yml:32-37](https://github.com/kubeflow/kale/blob/main/.github/workflows/release.yml#L32-L37) reads `__version__` off whatever branch you select, so running it against `main` today would just re-release 2.1.0.

## Why main was still on 2.1.0

`main` hadn't moved since "Bump dev version to 2.1.0" (#769) in April. `v2.1.1` was cut from the `release-2.1` branch, and its dev-version bumps (#819, #827) landed there rather than on `main`.

Nothing is stranded on `release-2.1` — its only functional commit, `e8e90cc`, is the backport of #823, already on `main` as `60e256e`. So this release covers the **41 commits on `main` since `v2.1.0`**, including the Configure-dialog consolidation (#908), the HTML-report toggle (#889), auto-promoted output artifacts (#874), and the dependency sweep in #918.

## A note on the changelog

The changelog here was generated scoped:

```bash
git-cliff v2.1.0..HEAD --tag v2.2.0 -o CHANGELOG/CHANGELOG-2.2.md
```

not with the bare `git-cliff --output CHANGELOG/CHANGELOG-$MAJOR.$MINOR.md` that [`make release`](https://github.com/kubeflow/kale/blob/main/Makefile#L296-L301) runs. With no range argument, git-cliff emits the project's **entire history** — 2622 lines, 83 KB, every tag back to `2.0.0a1` — into a file named for one minor version, with the 2.2.0 entries under an `## [unreleased]` heading because the tag doesn't exist yet.

That matters because [`github-release`](https://github.com/kubeflow/kale/blob/main/.github/workflows/release.yml#L230-L246) cats the file straight into the release body, so the v2.2.0 notes would have been 83 KB of full project history titled "unreleased". Scoped output is 91 lines under a proper `## [2.2.0] - 2026-08-05`.

The `make release` target should probably pass the range itself. Left alone here to keep this PR to the version bump — happy to send that as a follow-up.

## Testing

Ran the release workflow's own build steps locally:

- `make check-versions` → `2.2.0 (Python) == 2.2.0 (npm)`
- `SKIP_JUPYTER_BUILDER=1 uv sync --all-extras --frozen` clean, and `CI=true jlpm install --immutable` still clean after the bump (both are what the release `build` job does)
- `make verify`: ruff check, ruff format --check (58 files), stylelint, prettier, eslint, **270 backend tests**, labextension jest suite
- `jlpm build:prod` → `make build` produces `kubeflow_kale-2.2.0-py3-none-any.whl` + `.tar.gz`; `twine check` **PASSED** on both
- fresh-venv install of the wheel, mirroring the `test-wheels` job: `__version__ == "2.2.0"` asserts, `kale --help` exits 0

## After this merges

Actions → Release → Run workflow, branch `main`:

1. `target = dry-run` — full build + wheel smoke tests, no tag, no publish
2. `target = testpypi` — **also** pushes the `v2.2.0` tag, creates the GitHub release, and opens the 2.2.1a1 bump PR ([create-tag](https://github.com/kubeflow/kale/blob/main/.github/workflows/release.yml#L158), [github-release](https://github.com/kubeflow/kale/blob/main/.github/workflows/release.yml#L217) and [bump-dev-version](https://github.com/kubeflow/kale/blob/main/.github/workflows/release.yml#L260) all gate on `target != 'dry-run'`, not on PyPI). Validate with:
   ```
   pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ kubeflow-kale==2.2.0
   ```
3. `target = testpypi+pypi` — production PyPI, gated on the `production` environment's required reviewers

Then `git checkout -b release-2.2 main && git push origin release-2.2`, matching `release-2.0` / `release-2.1`.

Worth merging the auto-generated 2.2.1a1 bump PR promptly — its 2.1.x equivalent (#827) going to `release-2.1` instead of `main` is exactly why `main` sat at 2.1.0 for four months.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
