### PR TITLE
fix(release): scope git-cliff to the X.Y line and tag the new section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,13 +292,30 @@ release: ## Set release version (usage: make release VERSION=X.Y.Z)
 	@NPM_VERSION=$$(echo "$(VERSION)" | sed -E 's/([0-9]+\.[0-9]+\.[0-9]+)(a)([0-9]+)/\1-alpha.\3/; s/([0-9]+\.[0-9]+\.[0-9]+)(b)([0-9]+)/\1-beta.\3/; s/([0-9]+\.[0-9]+\.[0-9]+)(rc)([0-9]+)/\1-rc.\3/'); \
 	cd labextension && npm version "$$NPM_VERSION" --no-git-tag-version --allow-same-version; \
 	printf "$(GREEN)Version set to $(VERSION) (npm: $$NPM_VERSION)\n$(NC)"
-	@# Generate changelog if git-cliff is available
-	@command -v git-cliff >/dev/null 2>&1 && { \
+	@# Generate changelog if git-cliff is available.
+	@# Scope it to the X.Y line this version belongs to: start from the newest
+	@# reachable tag outside that line, so CHANGELOG-X.Y.md accumulates every
+	@# X.Y release and nothing older. --merged HEAD keeps tags cut on other
+	@# release branches out of the range. Without a range git-cliff emits the
+	@# whole project history, and without --tag the new entries land under an
+	@# "[unreleased]" heading - both end up verbatim in the GitHub release body
+	@# (see the github-release job in .github/workflows/release.yml).
+	@if ! command -v git-cliff >/dev/null 2>&1; then \
+		printf "$(YELLOW)git-cliff not found, skipping changelog generation\n$(NC)"; \
+	else \
 		MAJOR=$$(echo "$(VERSION)" | cut -d. -f1); \
 		MINOR=$$(echo "$(VERSION)" | cut -d. -f2); \
-		git-cliff --output CHANGELOG/CHANGELOG-$$MAJOR.$$MINOR.md; \
-		printf "$(GREEN)Changelog generated: CHANGELOG/CHANGELOG-$$MAJOR.$$MINOR.md\n$(NC)"; \
-	} || printf "$(YELLOW)git-cliff not found, skipping changelog generation\n$(NC)"
+		OUT=CHANGELOG/CHANGELOG-$$MAJOR.$$MINOR.md; \
+		BASE=$$(git tag --list 'v[0-9]*' --merged HEAD --sort=-v:refname \
+			| grep -v "^v$$MAJOR\.$$MINOR\." | head -1); \
+		if [ -n "$$BASE" ]; then \
+			git-cliff "$$BASE..HEAD" --tag v$(VERSION) --output $$OUT; \
+			printf "$(GREEN)Changelog generated: $$OUT ($$BASE..HEAD, tagged v$(VERSION))\n$(NC)"; \
+		else \
+			git-cliff --tag v$(VERSION) --output $$OUT; \
+			printf "$(GREEN)Changelog generated: $$OUT (full history, tagged v$(VERSION))\n$(NC)"; \
+		fi; \
+	fi
 
 ##@ Docker
 


### PR DESCRIPTION
## Problem

`make release VERSION=X.Y.Z` ran git-cliff with no revision range and no `--tag`:

```make
git-cliff --output CHANGELOG/CHANGELOG-$MAJOR.$MINOR.md
```

Both omissions matter, because [`github-release`](https://github.com/kubeflow/kale/blob/main/.github/workflows/release.yml#L230-L246) cats that file **straight into the GitHub release body**:

- **No range** → git-cliff emits the project's entire history. Preparing 2.2.0 produced **2622 lines / 83 KB** covering every tag back to `v2.0.0a1`, in a file named for a single minor version.
- **No `--tag`** → the new entries land under an `## [unreleased]` heading, since the version's tag doesn't exist yet at bump time.

So the v2.2.0 release notes would have been 83 KB of full project history titled "unreleased". Found while preparing #919, where the changelog had to be hand-generated to work around it.

Nobody hit this before because `CHANGELOG/` holds only `.gitkeep` — v2.1.0 and v2.1.1 both shipped with git-cliff absent, silently falling back to `generate_release_notes`.

## Fix

Scope the range to the X.Y line the version belongs to, starting from the newest reachable tag *outside* that line:

```make
BASE=$(git tag --list 'v[0-9]*' --merged HEAD --sort=-v:refname \
        | grep -v "^v$MAJOR\.$MINOR\." | head -1)
git-cliff "$BASE..HEAD" --tag v$(VERSION) --output $OUT
```

Two details worth calling out:

- **Excluding the current X.Y line**, rather than just taking the previous tag, is what makes `CHANGELOG-X.Y.md` accumulate. Cutting 2.2.1 after 2.2.0 resolves `BASE` to `v2.1.0`, so the file keeps both sections. A `git describe --abbrev=0` would resolve to `v2.2.0` and silently drop 2.2.0's entries from its own changelog on every patch release.
- **`--merged HEAD`** keeps tags cut on other release branches out of the range. `v2.1.1` exists but was tagged on `release-2.1`, so preparing 2.2.0 from `main` correctly bases on `v2.1.0`.

Falls back to full history with `--tag` when no base tag is reachable, for the first release on a fresh history.

Also replaces the `command -v git-cliff && { ... } || printf` construct with an explicit `if`/`else`. In the old form *any* failure inside the braces — now including a bad range — printed `git-cliff not found, skipping`, which would have been actively misleading.

## Testing

On `main`:

```
$ make release VERSION=2.2.0
Changelog generated: CHANGELOG/CHANGELOG-2.2.md (v2.1.0..HEAD, tagged v2.2.0)
```

91 lines under a `## [2.2.0] - 2026-08-05` heading — byte-identical to the changelog hand-generated for #919 (modulo the trailing newline `end-of-file-fixer` adds on commit).

Simulated a `v2.2.0` tag and confirmed 2.2.1 still resolves `BASE` to `v2.1.0`, so the 2.2 line accumulates rather than overwriting.

Version-file changes from the test run were reverted — this PR is the Makefile only.

## Relationship to #919

Independent, no conflict. #919 carries the already-correct changelog for 2.2.0, so this can merge before or after it. Merging this first would mean anyone regenerating 2.2.0's changelog gets the same file #919 already has.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
